### PR TITLE
feat: Java methods returning java.lang primitive

### DIFF
--- a/test-app/app/src/main/assets/app/tests/testMetadata.js
+++ b/test-app/app/src/main/assets/app/tests/testMetadata.js
@@ -35,4 +35,52 @@ describe("Tests metadata", function () {
 		var expected = 5;
 		expect(keywordClass.getValue5()).toBe(expected);
 	});
+
+	it("java method returning java.lang.Int should return JS number", function () {
+		var keywordClass = new $in.tns.tests.JavascriptKeywordClass();
+		var result = keywordClass.getIntValue5();
+		var expected = 5;
+		expect(result).toBe(expected);
+		expect(typeof result).toBe("number");
+	});
+
+	it("java method returning java.lang.Long should return JS number", function () {
+		var keywordClass = new $in.tns.tests.JavascriptKeywordClass();
+		var result = keywordClass.getLongValue5();
+		var expected = 5;
+		expect(result).toBe(expected);
+		expect(typeof result).toBe("number");
+	});
+
+	it("java method returning java.lang.Short should return JS number", function () {
+		var keywordClass = new $in.tns.tests.JavascriptKeywordClass();
+		var result = keywordClass.getShortValue5();
+		var expected = 5;
+		expect(result).toBe(expected);
+		expect(typeof result).toBe("number");
+	});
+
+	it("java method returning java.lang.Float should return JS number", function () {
+		var keywordClass = new $in.tns.tests.JavascriptKeywordClass();
+		var result = keywordClass.getFloatValue5();
+		var expected = 5;
+		expect(result).toBe(expected);
+		expect(typeof result).toBe("number");
+	});
+
+	it("java method returning java.lang.Double should return JS number", function () {
+		var keywordClass = new $in.tns.tests.JavascriptKeywordClass();
+		var result = keywordClass.getDoubleValue5();
+		var expected = 5;
+		expect(result).toBe(expected);
+		expect(typeof result).toBe("number");
+	});
+
+	it("java method returning java.lang.Boolean should return JS boolean", function () {
+		var keywordClass = new $in.tns.tests.JavascriptKeywordClass();
+		var result = keywordClass.getBooleanValueTrue();
+		var expected = true;
+		expect(result).toBe(expected);
+		expect(typeof result).toBe("boolean");
+	});
 });

--- a/test-app/app/src/main/java/in/tns/tests/JavascriptKeywordClass.java
+++ b/test-app/app/src/main/java/in/tns/tests/JavascriptKeywordClass.java
@@ -5,4 +5,10 @@ public class JavascriptKeywordClass {
     {
         return 5;
     }
+    public Int getIntValue5() {return Int.valueOf(5); }
+    public Long getLongValue5() {return Long.valueOf(5); }
+    public Float getFloatValue5() {return Float.valueOf(5); }
+    public Short getShortValue5() {return Short.valueOf(5); }
+    public Double getDoubleValue5() {return Double.valueOf(5); }
+    public Boolean getBooleanValueTrue() {return true; }
 }

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -508,10 +508,21 @@ void CallbackHandlers::CallJavaMethod(const Local<Object>& caller, const string&
 
         if (result != nullptr) {
             auto isString = env.IsInstanceOf(result, JAVA_LANG_STRING);
-
             Local<Value> objectResult;
             if (isString) {
                 objectResult = ArgConverter::jstringToV8String(isolate, (jstring) result);
+            } else if(*returnType == JAVA_LANG_INT) {
+                objectResult = Number::New(isolate, JType::IntValue(env, result));
+            } else if(*returnType == JAVA_LANG_SHORT) {
+                objectResult = Number::New(isolate, JType::ShortValue(env, result));
+            } else if(*returnType == JAVA_LANG_DOUBLE) {
+                objectResult = Number::New(isolate, JType::DoubleValue(env, result));
+            } else if(*returnType == JAVA_LANG_FLOAT) {
+                objectResult = Number::New(isolate, JType::FloatValue(env, result));
+            } else if(*returnType == JAVA_LANG_LONG) {
+                objectResult = Number::New(isolate, JType::LongValue(env, result));
+            } else if(*returnType == JAVA_LANG_BOOLEAN) {
+                objectResult = Boolean::New(isolate, JType::BooleanValue(env, result));
             } else {
                 jint javaObjectID = objectManager->GetOrCreateObjectId(result);
                 objectResult = objectManager->GetJsObjectByJavaObject(javaObjectID);
@@ -1517,7 +1528,12 @@ jmethodID CallbackHandlers::GET_TYPE_METADATA = nullptr;
 jmethodID CallbackHandlers::ENABLE_VERBOSE_LOGGING_METHOD_ID = nullptr;
 jmethodID CallbackHandlers::DISABLE_VERBOSE_LOGGING_METHOD_ID = nullptr;
 jmethodID CallbackHandlers::INIT_WORKER_METHOD_ID = nullptr;
-
+std::string CallbackHandlers::JAVA_LANG_INT = "Ljava/lang/Int;";
+std::string CallbackHandlers::JAVA_LANG_SHORT = "Ljava/lang/Short;";
+std::string CallbackHandlers::JAVA_LANG_LONG = "Ljava/lang/Long;";
+std::string CallbackHandlers::JAVA_LANG_FLOAT = "Ljava/lang/Float;";
+std::string CallbackHandlers::JAVA_LANG_DOUBLE = "Ljava/lang/Double;";
+std::string CallbackHandlers::JAVA_LANG_BOOLEAN = "Ljava/lang/Boolean;";
 
 
 NumericCasts CallbackHandlers::castFunctions;

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -226,6 +226,18 @@ namespace tns {
 
         static FieldAccessor fieldAccessor;
 
+        static std::string JAVA_LANG_LONG;
+
+        static std::string JAVA_LANG_INT;
+
+        static std::string JAVA_LANG_FLOAT;
+
+        static std::string JAVA_LANG_DOUBLE;
+
+        static std::string JAVA_LANG_SHORT;
+
+        static std::string JAVA_LANG_BOOLEAN;
+
         struct JavaObjectIdScope {
             JavaObjectIdScope(JEnv &env, jfieldID fieldId, jobject runtime, int javaObjectId)
                     : _env(env), _fieldID(fieldId), _runtime(runtime) {


### PR DESCRIPTION
converted to JS corresponding type. This is an issue which always bugged me on difference between Float/Integer/Double/Long  and basic float/int/long... handling

This is kind of a breaking change since JS codes doing `floatValue()` before wont work anymore and will crash.
We have a few in N core for which i ll create a PR