### PR TITLE
fix: minor memory leaks

### DIFF
--- a/test-app/runtime/src/main/cpp/DesugaredInterfaceCompanionClassNameResolver.cpp
+++ b/test-app/runtime/src/main/cpp/DesugaredInterfaceCompanionClassNameResolver.cpp
@@ -1,11 +1,11 @@
 #include "DesugaredInterfaceCompanionClassNameResolver.h"
 
 std::string DesugaredInterfaceCompanionClassNameResolver::resolveD8InterfaceCompanionClassName(
-        std::string interfaceName) {
+        const std::string& interfaceName) {
     return interfaceName + D8_COMPANION_CLASS_SUFFIX;
 }
 
 std::string DesugaredInterfaceCompanionClassNameResolver::resolveBazelInterfaceCompanionClassName(
-        std::string interfaceName) {
+        const std::string& interfaceName) {
     return interfaceName + BAZEL_COMPANION_CLASS_SUFFIX;
 }

--- a/test-app/runtime/src/main/cpp/DesugaredInterfaceCompanionClassNameResolver.h
+++ b/test-app/runtime/src/main/cpp/DesugaredInterfaceCompanionClassNameResolver.h
@@ -7,9 +7,9 @@
 class DesugaredInterfaceCompanionClassNameResolver {
 
 public:
-    std::string resolveD8InterfaceCompanionClassName(std::string interfaceName);
+    std::string resolveD8InterfaceCompanionClassName(const std::string& interfaceName);
 
-    std::string resolveBazelInterfaceCompanionClassName(std::string interfaceName);
+    std::string resolveBazelInterfaceCompanionClassName(const std::string& interfaceName);
 
 private:
     const std::string BAZEL_COMPANION_CLASS_SUFFIX = "$$CC";

--- a/test-app/runtime/src/main/cpp/JEnv.cpp
+++ b/test-app/runtime/src/main/cpp/JEnv.cpp
@@ -865,11 +865,11 @@ JEnv::GetInterfaceStaticMethodIDAndJClass(const std::string &interfaceName,
                                           const std::string &methodName,
                                           const std::string &sig) {
 
-    auto companionClassNameResolver = new DesugaredInterfaceCompanionClassNameResolver();
+    DesugaredInterfaceCompanionClassNameResolver companionClassNameResolver;
     std::string possibleCalleeNames[] = {interfaceName,
-                                         companionClassNameResolver->resolveBazelInterfaceCompanionClassName(
+                                         companionClassNameResolver.resolveBazelInterfaceCompanionClassName(
                                                  interfaceName),
-                                         companionClassNameResolver->resolveD8InterfaceCompanionClassName(
+                                         companionClassNameResolver.resolveD8InterfaceCompanionClassName(
                                                  interfaceName)};
 
     for (std::string calleeName: possibleCalleeNames) {

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -507,6 +507,7 @@ void ModuleInternal::SaveScriptCache(const Local<Script> script, const std::stri
     int length = cachedData->length;
     auto cachePath = path + ".cache";
     File::WriteBinary(cachePath, cachedData->data, length);
+    delete cachedData;
 }
 
 ModuleInternal::ModulePathKind ModuleInternal::GetModulePathKind(const std::string& path) {


### PR DESCRIPTION
### Description

Fixes 2 minor memory leaks:

1. when creating code cache, delete the CachedData (it's created with BufferNotOwned by default, so we're just deleting the structure we won't use anymore)

2. When using DesugaredInterfaceCompanionClassNameResolver, instantiate it statically, so we don't need to delete anything. We could even make this class static. Also changed it to `const std::string&` to avoid string copying. Overall, this was leaking 24 bytes per invocation.
