### PR TITLE
Restore DOM and Network callback handlers

### DIFF
--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -71,7 +71,9 @@ if (NOT OPTIMIZED_BUILD OR OPTIMIZED_WITH_INSPECTOR_BUILD)
         INSPECTOR_SOURCES
 
         src/main/cpp/com_tns_AndroidJsV8Inspector.cpp
+        src/main/cpp/DOMDomainCallbackHandlers.cpp
         src/main/cpp/JsV8InspectorClient.cpp
+        src/main/cpp/NetworkDomainCallbackHandlers.cpp
     )
 else ()
     # When building in Release mode we do not include the V8 inspector sources

--- a/test-app/runtime/src/main/cpp/DOMDomainCallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/DOMDomainCallbackHandlers.cpp
@@ -2,184 +2,184 @@
 // Created by pkanev on 5/10/2017.
 //
 
-#include <sstream>
-#include <ArgConverter.h>
-#include <NativeScriptAssert.h>
+// #include <sstream>
+// #include <ArgConverter.h>
+// #include <NativeScriptAssert.h>
 
-#include <v8_inspector/src/inspector/protocol/Protocol.h>
-#include <v8_inspector/src/inspector/string-util.h>
-#include <v8_inspector/third_party/inspector_protocol/crdtp/error_support.h>
-#include <v8_inspector/third_party/inspector_protocol/crdtp/json.h>
+// #include <v8_inspector/src/inspector/protocol/Protocol.h>
+// #include <v8_inspector/src/inspector/string-util.h>
+// #include <v8_inspector/third_party/inspector_protocol/crdtp/error_support.h>
+// #include <v8_inspector/third_party/inspector_protocol/crdtp/json.h>
 
 #include "DOMDomainCallbackHandlers.h"
 
 using namespace tns;
 
 void DOMDomainCallbackHandlers::DocumentUpdatedCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    auto domAgentInstance = DOMAgentImpl::Instance;
+    // auto domAgentInstance = DOMAgentImpl::Instance;
 
-    if (!domAgentInstance) {
-        return;
-    }
+    // if (!domAgentInstance) {
+    //     return;
+    // }
 
-    domAgentInstance->m_frontend.documentUpdated();
+    // domAgentInstance->m_frontend.documentUpdated();
 }
 
 void DOMDomainCallbackHandlers::ChildNodeInsertedCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto domAgentInstance = DOMAgentImpl::Instance;
+    // try {
+    //     auto domAgentInstance = DOMAgentImpl::Instance;
 
-        if (!domAgentInstance) {
-            return;
-        }
+    //     if (!domAgentInstance) {
+    //         return;
+    //     }
 
-        auto isolate = args.GetIsolate();
+    //     auto isolate = args.GetIsolate();
 
-        v8::HandleScope scope(isolate);
+    //     v8::HandleScope scope(isolate);
 
-        if (args.Length() != 3 || !(args[0]->IsNumber() && args[1]->IsNumber() && args[2]->IsString())) {
-            throw NativeScriptException("Calling ChildNodeInserted with invalid arguments. Required params: parentId: number, lastId: number, node: JSON String");
-        }
+    //     if (args.Length() != 3 || !(args[0]->IsNumber() && args[1]->IsNumber() && args[2]->IsString())) {
+    //         throw NativeScriptException("Calling ChildNodeInserted with invalid arguments. Required params: parentId: number, lastId: number, node: JSON String");
+    //     }
 
-        auto context = isolate->GetCurrentContext();
-        auto parentId = args[0]->ToNumber(context).ToLocalChecked();
-        auto lastId = args[1]->ToNumber(context).ToLocalChecked();
-        auto node = args[2]->ToString(context).ToLocalChecked();
+    //     auto context = isolate->GetCurrentContext();
+    //     auto parentId = args[0]->ToNumber(context).ToLocalChecked();
+    //     auto lastId = args[1]->ToNumber(context).ToLocalChecked();
+    //     auto node = args[2]->ToString(context).ToLocalChecked();
 
-        auto resultString = DOMAgentImpl::AddBackendNodeIdProperty(isolate, node);
-        auto nodeUtf16Data = resultString.data();
-        const v8_inspector::String16& nodeString16 = v8_inspector::String16((const uint16_t*) nodeUtf16Data);
-        std::vector<uint8_t> cbor;
-        v8_crdtp::json::ConvertJSONToCBOR(v8_crdtp::span<uint16_t>(nodeString16.characters16(), nodeString16.length()), &cbor);
-        std::unique_ptr<protocol::Value> protocolNodeJson = protocol::Value::parseBinary(cbor.data(), cbor.size());
+    //     auto resultString = DOMAgentImpl::AddBackendNodeIdProperty(isolate, node);
+    //     auto nodeUtf16Data = resultString.data();
+    //     const v8_inspector::String16& nodeString16 = v8_inspector::String16((const uint16_t*) nodeUtf16Data);
+    //     std::vector<uint8_t> cbor;
+    //     v8_crdtp::json::ConvertJSONToCBOR(v8_crdtp::span<uint16_t>(nodeString16.characters16(), nodeString16.length()), &cbor);
+    //     std::unique_ptr<protocol::Value> protocolNodeJson = protocol::Value::parseBinary(cbor.data(), cbor.size());
 
-        v8_crdtp::ErrorSupport errorSupport;
-        auto domNode = protocol::DOM::Node::fromValue(protocolNodeJson.get(), &errorSupport);
+    //     v8_crdtp::ErrorSupport errorSupport;
+    //     auto domNode = protocol::DOM::Node::fromValue(protocolNodeJson.get(), &errorSupport);
 
-        std::vector<uint8_t> json;
-        v8_crdtp::json::ConvertCBORToJSON(errorSupport.Errors(), &json);
-        auto errorSupportString = String16(reinterpret_cast<const char*>(json.data()), json.size()).utf8();
-        if (!errorSupportString.empty()) {
-            auto errorMessage = "Error while parsing debug `DOM Node` object. ";
-            DEBUG_WRITE_FORCE("%s Error: %s", errorMessage, errorSupportString.c_str());
-            return;
-        }
+    //     std::vector<uint8_t> json;
+    //     v8_crdtp::json::ConvertCBORToJSON(errorSupport.Errors(), &json);
+    //     auto errorSupportString = String16(reinterpret_cast<const char*>(json.data()), json.size()).utf8();
+    //     if (!errorSupportString.empty()) {
+    //         auto errorMessage = "Error while parsing debug `DOM Node` object. ";
+    //         DEBUG_WRITE_FORCE("%s Error: %s", errorMessage, errorSupportString.c_str());
+    //         return;
+    //     }
 
-        domAgentInstance->m_frontend.childNodeInserted(parentId->Int32Value(context).ToChecked(), lastId->Int32Value(context).ToChecked(), std::move(domNode));
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        std::stringstream ss;
-        ss << "Error: c exception: " << e.what() << std::endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c exception!"));
-        nsEx.ReThrowToV8();
-    }
+    //     domAgentInstance->m_frontend.childNodeInserted(parentId->Int32Value(context).ToChecked(), lastId->Int32Value(context).ToChecked(), std::move(domNode));
+    // } catch (NativeScriptException& e) {
+    //     e.ReThrowToV8();
+    // } catch (std::exception e) {
+    //     std::stringstream ss;
+    //     ss << "Error: c exception: " << e.what() << std::endl;
+    //     NativeScriptException nsEx(ss.str());
+    //     nsEx.ReThrowToV8();
+    // } catch (...) {
+    //     NativeScriptException nsEx(std::string("Error: c exception!"));
+    //     nsEx.ReThrowToV8();
+    // }
 }
 
 void DOMDomainCallbackHandlers::ChildNodeRemovedCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto domAgentInstance = DOMAgentImpl::Instance;
+    // try {
+    //     auto domAgentInstance = DOMAgentImpl::Instance;
 
-        if (!domAgentInstance) {
-            return;
-        }
+    //     if (!domAgentInstance) {
+    //         return;
+    //     }
 
-        auto isolate = args.GetIsolate();
+    //     auto isolate = args.GetIsolate();
 
-        v8::HandleScope scope(isolate);
+    //     v8::HandleScope scope(isolate);
 
-        if (args.Length() != 2 || !(args[0]->IsNumber() && args[1]->IsNumber())) {
-            throw NativeScriptException("Calling ChildNodeRemoved with invalid arguments. Required params: parentId: number, nodeId: number");
-        }
+    //     if (args.Length() != 2 || !(args[0]->IsNumber() && args[1]->IsNumber())) {
+    //         throw NativeScriptException("Calling ChildNodeRemoved with invalid arguments. Required params: parentId: number, nodeId: number");
+    //     }
 
-        auto context = isolate->GetCurrentContext();
-        auto parentId = args[0]->ToNumber(context).ToLocalChecked();
-        auto nodeId = args[1]->ToNumber(context).ToLocalChecked();
+    //     auto context = isolate->GetCurrentContext();
+    //     auto parentId = args[0]->ToNumber(context).ToLocalChecked();
+    //     auto nodeId = args[1]->ToNumber(context).ToLocalChecked();
 
-        domAgentInstance->m_frontend.childNodeRemoved(parentId->Int32Value(context).ToChecked(), nodeId->Int32Value(context).ToChecked());
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        std::stringstream ss;
-        ss << "Error: c exception: " << e.what() << std::endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c exception!"));
-        nsEx.ReThrowToV8();
-    }
+    //     domAgentInstance->m_frontend.childNodeRemoved(parentId->Int32Value(context).ToChecked(), nodeId->Int32Value(context).ToChecked());
+    // } catch (NativeScriptException& e) {
+    //     e.ReThrowToV8();
+    // } catch (std::exception e) {
+    //     std::stringstream ss;
+    //     ss << "Error: c exception: " << e.what() << std::endl;
+    //     NativeScriptException nsEx(ss.str());
+    //     nsEx.ReThrowToV8();
+    // } catch (...) {
+    //     NativeScriptException nsEx(std::string("Error: c exception!"));
+    //     nsEx.ReThrowToV8();
+    // }
 }
 
 void DOMDomainCallbackHandlers::AttributeModifiedCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto domAgentInstance = DOMAgentImpl::Instance;
+    // try {
+    //     auto domAgentInstance = DOMAgentImpl::Instance;
 
-        if (!domAgentInstance) {
-            return;
-        }
+    //     if (!domAgentInstance) {
+    //         return;
+    //     }
 
-        auto isolate = args.GetIsolate();
+    //     auto isolate = args.GetIsolate();
 
-        v8::HandleScope scope(isolate);
+    //     v8::HandleScope scope(isolate);
 
-        if (args.Length() != 3 || !(args[0]->IsNumber() && args[1]->IsString() && args[2]->IsString())) {
-            throw NativeScriptException("Calling AttributeModified with invalid arguments. Required params: nodeId: number, name: string, value: string");
-        }
+    //     if (args.Length() != 3 || !(args[0]->IsNumber() && args[1]->IsString() && args[2]->IsString())) {
+    //         throw NativeScriptException("Calling AttributeModified with invalid arguments. Required params: nodeId: number, name: string, value: string");
+    //     }
 
-        auto context = isolate->GetCurrentContext();
-        auto nodeId = args[0]->ToNumber(context).ToLocalChecked();
-        auto attributeName = args[1]->ToString(context).ToLocalChecked();
-        auto attributeValue = args[2]->ToString(context).ToLocalChecked();
+    //     auto context = isolate->GetCurrentContext();
+    //     auto nodeId = args[0]->ToNumber(context).ToLocalChecked();
+    //     auto attributeName = args[1]->ToString(context).ToLocalChecked();
+    //     auto attributeValue = args[2]->ToString(context).ToLocalChecked();
 
-        domAgentInstance->m_frontend.attributeModified(nodeId->Int32Value(context).ToChecked(),
-                v8_inspector::toProtocolString(isolate, attributeName),
-                v8_inspector::toProtocolString(isolate, attributeValue));
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        std::stringstream ss;
-        ss << "Error: c exception: " << e.what() << std::endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c exception!"));
-        nsEx.ReThrowToV8();
-    }
+    //     domAgentInstance->m_frontend.attributeModified(nodeId->Int32Value(context).ToChecked(),
+    //             v8_inspector::toProtocolString(isolate, attributeName),
+    //             v8_inspector::toProtocolString(isolate, attributeValue));
+    // } catch (NativeScriptException& e) {
+    //     e.ReThrowToV8();
+    // } catch (std::exception e) {
+    //     std::stringstream ss;
+    //     ss << "Error: c exception: " << e.what() << std::endl;
+    //     NativeScriptException nsEx(ss.str());
+    //     nsEx.ReThrowToV8();
+    // } catch (...) {
+    //     NativeScriptException nsEx(std::string("Error: c exception!"));
+    //     nsEx.ReThrowToV8();
+    // }
 }
 
 void DOMDomainCallbackHandlers::AttributeRemovedCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto domAgentInstance = DOMAgentImpl::Instance;
+    // try {
+    //     auto domAgentInstance = DOMAgentImpl::Instance;
 
-        if (!domAgentInstance) {
-            return;
-        }
-        auto isolate = args.GetIsolate();
+    //     if (!domAgentInstance) {
+    //         return;
+    //     }
+    //     auto isolate = args.GetIsolate();
 
-        v8::HandleScope scope(isolate);
+    //     v8::HandleScope scope(isolate);
 
-        if (args.Length() != 2 || !(args[0]->IsNumber() && args[1]->IsString())) {
-            throw NativeScriptException("Calling AttributeRemoved with invalid arguments. Required params: nodeId: number, name: string");
-        }
+    //     if (args.Length() != 2 || !(args[0]->IsNumber() && args[1]->IsString())) {
+    //         throw NativeScriptException("Calling AttributeRemoved with invalid arguments. Required params: nodeId: number, name: string");
+    //     }
 
-        auto context = isolate->GetCurrentContext();
-        auto nodeId = args[0]->ToNumber(context).ToLocalChecked();
-        auto attributeName = args[1]->ToString(context).ToLocalChecked();
+    //     auto context = isolate->GetCurrentContext();
+    //     auto nodeId = args[0]->ToNumber(context).ToLocalChecked();
+    //     auto attributeName = args[1]->ToString(context).ToLocalChecked();
 
-        domAgentInstance->m_frontend.attributeRemoved(nodeId->Int32Value(context).ToChecked(),
-                v8_inspector::toProtocolString(isolate, attributeName));
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        std::stringstream ss;
-        ss << "Error: c exception: " << e.what() << std::endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c exception!"));
-        nsEx.ReThrowToV8();
-    }
+    //     domAgentInstance->m_frontend.attributeRemoved(nodeId->Int32Value(context).ToChecked(),
+    //             v8_inspector::toProtocolString(isolate, attributeName));
+    // } catch (NativeScriptException& e) {
+    //     e.ReThrowToV8();
+    // } catch (std::exception e) {
+    //     std::stringstream ss;
+    //     ss << "Error: c exception: " << e.what() << std::endl;
+    //     NativeScriptException nsEx(ss.str());
+    //     nsEx.ReThrowToV8();
+    // } catch (...) {
+    //     NativeScriptException nsEx(std::string("Error: c exception!"));
+    //     nsEx.ReThrowToV8();
+    // }
 }

--- a/test-app/runtime/src/main/cpp/DOMDomainCallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/DOMDomainCallbackHandlers.h
@@ -6,9 +6,9 @@
 #define DOMDOMAINCALLBACKHANDLERS_H
 
 #include <include/v8.h>
-#include "DOMAgentImpl.h"
-#include "JsV8InspectorClient.h"
-#include "NativeScriptException.h"
+// #include "DOMAgentImpl.h"
+// #include "JsV8InspectorClient.h"
+// #include "NativeScriptException.h"
 
 namespace tns {
 class DOMDomainCallbackHandlers {

--- a/test-app/runtime/src/main/cpp/JsV8InspectorClient.cpp
+++ b/test-app/runtime/src/main/cpp/JsV8InspectorClient.cpp
@@ -11,8 +11,8 @@
 #include "NativeScriptException.h"
 
 #include "ArgConverter.h"
-// #include "DOMDomainCallbackHandlers.h"
-// #include "NetworkDomainCallbackHandlers.h"
+#include "DOMDomainCallbackHandlers.h"
+#include "NetworkDomainCallbackHandlers.h"
 
 using namespace std;
 using namespace tns;
@@ -265,17 +265,17 @@ void JsV8InspectorClient::attachInspectorCallbacks(Isolate* isolate,
 
     auto inspectorJSObject = ObjectTemplate::New(isolate);
 
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "responseReceived"), FunctionTemplate::New(isolate, NetworkDomainCallbackHandlers::ResponseReceivedCallback));
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "requestWillBeSent"), FunctionTemplate::New(isolate, NetworkDomainCallbackHandlers::RequestWillBeSentCallback));
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "dataForRequestId"), FunctionTemplate::New(isolate, NetworkDomainCallbackHandlers::DataForRequestIdCallback));
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "loadingFinished"), FunctionTemplate::New(isolate, NetworkDomainCallbackHandlers::LoadingFinishedCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "responseReceived"), FunctionTemplate::New(isolate, NetworkDomainCallbackHandlers::ResponseReceivedCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "requestWillBeSent"), FunctionTemplate::New(isolate, NetworkDomainCallbackHandlers::RequestWillBeSentCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "dataForRequestId"), FunctionTemplate::New(isolate, NetworkDomainCallbackHandlers::DataForRequestIdCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "loadingFinished"), FunctionTemplate::New(isolate, NetworkDomainCallbackHandlers::LoadingFinishedCallback));
     inspectorJSObject->SetAccessor(ArgConverter::ConvertToV8String(isolate, "isConnected"), JsV8InspectorClient::InspectorIsConnectedGetterCallback);
 
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "documentUpdated"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::DocumentUpdatedCallback));
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "childNodeInserted"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::ChildNodeInsertedCallback));
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "childNodeRemoved"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::ChildNodeRemovedCallback));
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "attributeModified"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::AttributeModifiedCallback));
-    // inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "attributeRemoved"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::AttributeRemovedCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "documentUpdated"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::DocumentUpdatedCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "childNodeInserted"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::ChildNodeInsertedCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "childNodeRemoved"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::ChildNodeRemovedCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "attributeModified"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::AttributeModifiedCallback));
+    inspectorJSObject->Set(ArgConverter::ConvertToV8String(isolate, "attributeRemoved"), FunctionTemplate::New(isolate, DOMDomainCallbackHandlers::AttributeRemovedCallback));
 
     globalObjectTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__inspector"), inspectorJSObject);
 }

--- a/test-app/runtime/src/main/cpp/NetworkDomainCallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/NetworkDomainCallbackHandlers.cpp
@@ -2,331 +2,331 @@
 // Created by pkanev on 3/8/2017.
 //
 
-#include <sstream>
+// #include <sstream>
 
-#include <v8_inspector/src/inspector/protocol/Protocol.h>
-#include <v8_inspector/src/inspector/string-util.h>
-#include <v8_inspector/third_party/inspector_protocol/crdtp/error_support.h>
-#include <v8_inspector/third_party/inspector_protocol/crdtp/json.h>
+// #include <v8_inspector/src/inspector/protocol/Protocol.h>
+// #include <v8_inspector/src/inspector/string-util.h>
+// #include <v8_inspector/third_party/inspector_protocol/crdtp/error_support.h>
+// #include <v8_inspector/third_party/inspector_protocol/crdtp/json.h>
 #include "NetworkDomainCallbackHandlers.h"
-#include "NativeScriptAssert.h"
-#include "utils/NetworkRequestData.h"
+// #include "NativeScriptAssert.h"
+// #include "utils/NetworkRequestData.h"
 
 using namespace tns;
 
 void NetworkDomainCallbackHandlers::ResponseReceivedCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto networkAgentInstance = NetworkAgentImpl::Instance;
-        const std::string wrongParametersError = "Not all parameters are present in the object argument in the call to ResponseReceived! Required params: 'requestId', `timestamp`, `type`, `response`";
+    // try {
+    //     auto networkAgentInstance = NetworkAgentImpl::Instance;
+    //     const std::string wrongParametersError = "Not all parameters are present in the object argument in the call to ResponseReceived! Required params: 'requestId', `timestamp`, `type`, `response`";
 
-        if (!networkAgentInstance) {
-            return;
-        }
+    //     if (!networkAgentInstance) {
+    //         return;
+    //     }
 
-        if (args.Length() == 0 || !args[0]->IsObject()) {
-            throw NativeScriptException(wrongParametersError);
-        }
+    //     if (args.Length() == 0 || !args[0]->IsObject()) {
+    //         throw NativeScriptException(wrongParametersError);
+    //     }
 
-        auto isolate = args.GetIsolate();
+    //     auto isolate = args.GetIsolate();
 
-        v8::HandleScope scope(isolate);
+    //     v8::HandleScope scope(isolate);
 
-        auto context = isolate->GetCurrentContext();
+    //     auto context = isolate->GetCurrentContext();
 
-        v8::Local<v8::Object> argsObj = args[0]->ToObject(context).ToLocalChecked();
+    //     v8::Local<v8::Object> argsObj = args[0]->ToObject(context).ToLocalChecked();
 
-        if ((!argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "requestId")).FromMaybe(false) ||
-                !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).FromMaybe(false) ||
-                !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "type")).FromMaybe(false)) ||
-                !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "response")).FromMaybe(false)) {
-            throw NativeScriptException(wrongParametersError);
-        }
+    //     if ((!argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "requestId")).FromMaybe(false) ||
+    //             !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).FromMaybe(false) ||
+    //             !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "type")).FromMaybe(false)) ||
+    //             !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "response")).FromMaybe(false)) {
+    //         throw NativeScriptException(wrongParametersError);
+    //     }
 
-        auto requestId = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "requestId")).ToLocalChecked()->ToString(context).ToLocalChecked();
-        auto type = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "type")).ToLocalChecked()->ToString(context).ToLocalChecked();
-        auto response = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "response")).ToLocalChecked();
-        auto timeStamp = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
+    //     auto requestId = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "requestId")).ToLocalChecked()->ToString(context).ToLocalChecked();
+    //     auto type = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "type")).ToLocalChecked()->ToString(context).ToLocalChecked();
+    //     auto response = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "response")).ToLocalChecked();
+    //     auto timeStamp = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
 
-        auto responseAsObj = response->ToObject(context).ToLocalChecked();
-        auto connectionReusedProp = ArgConverter::ConvertToV8String(isolate, "connectionReused");
-        if (!responseAsObj->Has(context, connectionReusedProp).FromMaybe(false)) {
-            responseAsObj->Set(context, connectionReusedProp, v8::Boolean::New(isolate, true));
-        }
-        auto connectionIdProp = ArgConverter::ConvertToV8String(isolate, "connectionId");
-        if (!responseAsObj->Has(context, connectionIdProp).FromMaybe(false)) {
-            responseAsObj->Set(context, connectionIdProp, v8::Number::New(isolate, 0));
-        }
-        auto encodedDataLengthProp = ArgConverter::ConvertToV8String(isolate, "encodedDataLength");
-        if (!responseAsObj->Has(context, encodedDataLengthProp).FromMaybe(false)) {
-            responseAsObj->Set(context, encodedDataLengthProp, v8::Number::New(isolate, 0));
-        }
-        auto securityStateProp = ArgConverter::ConvertToV8String(isolate, "securityState");
-        if (!responseAsObj->Has(context, securityStateProp).FromMaybe(false)) {
-            responseAsObj->Set(context, securityStateProp, ArgConverter::ConvertToV8String(isolate, "info"));
-        }
-        v8::Local<v8::String> responseJson;
-        auto maybeResponseJson = v8::JSON::Stringify(context, responseAsObj);
+    //     auto responseAsObj = response->ToObject(context).ToLocalChecked();
+    //     auto connectionReusedProp = ArgConverter::ConvertToV8String(isolate, "connectionReused");
+    //     if (!responseAsObj->Has(context, connectionReusedProp).FromMaybe(false)) {
+    //         responseAsObj->Set(context, connectionReusedProp, v8::Boolean::New(isolate, true));
+    //     }
+    //     auto connectionIdProp = ArgConverter::ConvertToV8String(isolate, "connectionId");
+    //     if (!responseAsObj->Has(context, connectionIdProp).FromMaybe(false)) {
+    //         responseAsObj->Set(context, connectionIdProp, v8::Number::New(isolate, 0));
+    //     }
+    //     auto encodedDataLengthProp = ArgConverter::ConvertToV8String(isolate, "encodedDataLength");
+    //     if (!responseAsObj->Has(context, encodedDataLengthProp).FromMaybe(false)) {
+    //         responseAsObj->Set(context, encodedDataLengthProp, v8::Number::New(isolate, 0));
+    //     }
+    //     auto securityStateProp = ArgConverter::ConvertToV8String(isolate, "securityState");
+    //     if (!responseAsObj->Has(context, securityStateProp).FromMaybe(false)) {
+    //         responseAsObj->Set(context, securityStateProp, ArgConverter::ConvertToV8String(isolate, "info"));
+    //     }
+    //     v8::Local<v8::String> responseJson;
+    //     auto maybeResponseJson = v8::JSON::Stringify(context, responseAsObj);
 
-        if (!maybeResponseJson.ToLocal(&responseJson)) {
-            throw NativeScriptException("`response` parameter not in the correct format.");
-        }
+    //     if (!maybeResponseJson.ToLocal(&responseJson)) {
+    //         throw NativeScriptException("`response` parameter not in the correct format.");
+    //     }
 
-        const v8_inspector::String16 responseJsonString = v8_inspector::toProtocolString(isolate, responseJson);
-        std::vector<uint8_t> cbor;
-        v8_crdtp::json::ConvertJSONToCBOR(v8_crdtp::span<uint16_t>(responseJsonString.characters16(), responseJsonString.length()), &cbor);
-        std::unique_ptr<protocol::Value> protocolResponseJson = protocol::Value::parseBinary(cbor.data(), cbor.size());
+    //     const v8_inspector::String16 responseJsonString = v8_inspector::toProtocolString(isolate, responseJson);
+    //     std::vector<uint8_t> cbor;
+    //     v8_crdtp::json::ConvertJSONToCBOR(v8_crdtp::span<uint16_t>(responseJsonString.characters16(), responseJsonString.length()), &cbor);
+    //     std::unique_ptr<protocol::Value> protocolResponseJson = protocol::Value::parseBinary(cbor.data(), cbor.size());
 
-        v8_crdtp::ErrorSupport errorSupport;
-        auto protocolResponseObj = protocol::Network::Response::fromValue(protocolResponseJson.get(), &errorSupport);
+    //     v8_crdtp::ErrorSupport errorSupport;
+    //     auto protocolResponseObj = protocol::Network::Response::fromValue(protocolResponseJson.get(), &errorSupport);
 
-        std::vector<uint8_t> json;
-        v8_crdtp::json::ConvertCBORToJSON(errorSupport.Errors(), &json);
-        auto errorString = String16(reinterpret_cast<const char*>(json.data()), json.size()).utf8();
+    //     std::vector<uint8_t> json;
+    //     v8_crdtp::json::ConvertCBORToJSON(errorSupport.Errors(), &json);
+    //     auto errorString = String16(reinterpret_cast<const char*>(json.data()), json.size()).utf8();
 
-        if (!errorString.empty()) {
-            auto errorMessage = "Error while parsing debug `response` object. ";
-            DEBUG_WRITE_FORCE("%s Error: %s", errorMessage, errorString.c_str());
+    //     if (!errorString.empty()) {
+    //         auto errorMessage = "Error while parsing debug `response` object. ";
+    //         DEBUG_WRITE_FORCE("%s Error: %s", errorMessage, errorString.c_str());
 
-            throw NativeScriptException(errorMessage + errorString);
-        }
+    //         throw NativeScriptException(errorMessage + errorString);
+    //     }
 
-        auto requestIdString = ArgConverter::ConvertToString(requestId);
-        auto networkRequestData = new utils::NetworkRequestData();
-        networkAgentInstance->m_responses.insert(std::make_pair(requestIdString, networkRequestData));
+    //     auto requestIdString = ArgConverter::ConvertToString(requestId);
+    //     auto networkRequestData = new utils::NetworkRequestData();
+    //     networkAgentInstance->m_responses.insert(std::make_pair(requestIdString, networkRequestData));
 
-        auto id = ArgConverter::ConvertToV8String(isolate, FrameId);
-        protocol::Maybe<String16> frameId(ArgConverter::ConvertToString(id).c_str());
+    //     auto id = ArgConverter::ConvertToV8String(isolate, FrameId);
+    //     protocol::Maybe<String16> frameId(ArgConverter::ConvertToString(id).c_str());
 
-        networkAgentInstance->m_frontend.responseReceived(
-            requestIdString.c_str(),
-            LoaderId,
-            timeStamp,
-            ArgConverter::ConvertToString(type).c_str(),
-            std::move(protocolResponseObj),
-            std::move(frameId));
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        std::stringstream ss;
-        ss << "Error: c exception: " << e.what() << std::endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c exception!"));
-        nsEx.ReThrowToV8();
-    }
+    //     networkAgentInstance->m_frontend.responseReceived(
+    //         requestIdString.c_str(),
+    //         LoaderId,
+    //         timeStamp,
+    //         ArgConverter::ConvertToString(type).c_str(),
+    //         std::move(protocolResponseObj),
+    //         std::move(frameId));
+    // } catch (NativeScriptException& e) {
+    //     e.ReThrowToV8();
+    // } catch (std::exception e) {
+    //     std::stringstream ss;
+    //     ss << "Error: c exception: " << e.what() << std::endl;
+    //     NativeScriptException nsEx(ss.str());
+    //     nsEx.ReThrowToV8();
+    // } catch (...) {
+    //     NativeScriptException nsEx(std::string("Error: c exception!"));
+    //     nsEx.ReThrowToV8();
+    // }
 }
 
 void NetworkDomainCallbackHandlers::RequestWillBeSentCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto networkAgentInstance = NetworkAgentImpl::Instance;
-        const std::string wrongParametersError = "Not all parameters are present in the object argument in the call to RequestWillBeSent! Required params: 'requestId', `url`, `timestamp`, `type`, `request`, `timestamps`";
+    // try {
+    //     auto networkAgentInstance = NetworkAgentImpl::Instance;
+    //     const std::string wrongParametersError = "Not all parameters are present in the object argument in the call to RequestWillBeSent! Required params: 'requestId', `url`, `timestamp`, `type`, `request`, `timestamps`";
 
-        if (!networkAgentInstance) {
-            return;
-        }
+    //     if (!networkAgentInstance) {
+    //         return;
+    //     }
 
-        if (args.Length() == 0 || !args[0]->IsObject()) {
-            throw NativeScriptException(wrongParametersError);
-        }
+    //     if (args.Length() == 0 || !args[0]->IsObject()) {
+    //         throw NativeScriptException(wrongParametersError);
+    //     }
 
-        auto isolate = args.GetIsolate();
+    //     auto isolate = args.GetIsolate();
 
-        v8::HandleScope scope(isolate);
+    //     v8::HandleScope scope(isolate);
 
-        auto context = isolate->GetCurrentContext();
+    //     auto context = isolate->GetCurrentContext();
 
-        v8::Local<v8::Object> argsObj = args[0]->ToObject(context).ToLocalChecked();
+    //     v8::Local<v8::Object> argsObj = args[0]->ToObject(context).ToLocalChecked();
 
-        if ((!(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "requestId")).FromMaybe(false)) ||
-                !(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "url")).FromMaybe(false)) ||
-                !(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "request")).FromMaybe(false)) ||
-                !(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).FromMaybe(false)) ||
-                !(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "type")).FromMaybe(false)))) {
-            throw NativeScriptException(wrongParametersError);
-        }
+    //     if ((!(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "requestId")).FromMaybe(false)) ||
+    //             !(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "url")).FromMaybe(false)) ||
+    //             !(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "request")).FromMaybe(false)) ||
+    //             !(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).FromMaybe(false)) ||
+    //             !(argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "type")).FromMaybe(false)))) {
+    //         throw NativeScriptException(wrongParametersError);
+    //     }
 
-        auto requestId = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "requestId")).ToLocalChecked()->ToString(context).ToLocalChecked();
-        auto url = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "url")).ToLocalChecked()->ToString(context).ToLocalChecked();
-        auto request = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "request")).ToLocalChecked();
-        auto timeStamp = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
-        auto typeArg = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "type")).ToLocalChecked()->ToString(context).ToLocalChecked();
-        long long int wallTime = 0;
-        if (argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "wallTime")).FromMaybe(true)) {
-            wallTime = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "wallTime")).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
-        }
+    //     auto requestId = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "requestId")).ToLocalChecked()->ToString(context).ToLocalChecked();
+    //     auto url = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "url")).ToLocalChecked()->ToString(context).ToLocalChecked();
+    //     auto request = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "request")).ToLocalChecked();
+    //     auto timeStamp = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
+    //     auto typeArg = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "type")).ToLocalChecked()->ToString(context).ToLocalChecked();
+    //     long long int wallTime = 0;
+    //     if (argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "wallTime")).FromMaybe(true)) {
+    //         wallTime = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "wallTime")).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
+    //     }
 
-        auto requestAsObj = request->ToObject(context).ToLocalChecked();
-        auto initialPriorityProp = ArgConverter::ConvertToV8String(isolate, "initialPriority");
-        auto referrerPolicyProp = ArgConverter::ConvertToV8String(isolate, "referrerPolicy");
-        if (!argsObj->Has(context, initialPriorityProp).FromMaybe(false)) {
-            requestAsObj->Set(context, initialPriorityProp, ArgConverter::ConvertToV8String(isolate, "Medium"));
-        }
-        if (!argsObj->Has(context, referrerPolicyProp).FromMaybe(false)) {
-            requestAsObj->Set(context, referrerPolicyProp, ArgConverter::ConvertToV8String(isolate, "no-referrer-when-downgrade"));
-        }
+    //     auto requestAsObj = request->ToObject(context).ToLocalChecked();
+    //     auto initialPriorityProp = ArgConverter::ConvertToV8String(isolate, "initialPriority");
+    //     auto referrerPolicyProp = ArgConverter::ConvertToV8String(isolate, "referrerPolicy");
+    //     if (!argsObj->Has(context, initialPriorityProp).FromMaybe(false)) {
+    //         requestAsObj->Set(context, initialPriorityProp, ArgConverter::ConvertToV8String(isolate, "Medium"));
+    //     }
+    //     if (!argsObj->Has(context, referrerPolicyProp).FromMaybe(false)) {
+    //         requestAsObj->Set(context, referrerPolicyProp, ArgConverter::ConvertToV8String(isolate, "no-referrer-when-downgrade"));
+    //     }
 
-        v8::Local<v8::String> requestJson;
-        auto maybeRequestJson = v8::JSON::Stringify(context, requestAsObj);
+    //     v8::Local<v8::String> requestJson;
+    //     auto maybeRequestJson = v8::JSON::Stringify(context, requestAsObj);
 
-        if (!maybeRequestJson.ToLocal(&requestJson)) {
-            throw NativeScriptException("`request` parameter not in the correct format.");
-        }
+    //     if (!maybeRequestJson.ToLocal(&requestJson)) {
+    //         throw NativeScriptException("`request` parameter not in the correct format.");
+    //     }
 
-        const String16& requestJsonString16 = toProtocolString(isolate, requestJson);
-        std::vector<uint8_t> cbor;
-        v8_crdtp::json::ConvertJSONToCBOR(v8_crdtp::span<uint16_t>(requestJsonString16.characters16(), requestJsonString16.length()), &cbor);
-        std::unique_ptr<protocol::Value> protocolRequestJson = protocol::Value::parseBinary(cbor.data(), cbor.size());
+    //     const String16& requestJsonString16 = toProtocolString(isolate, requestJson);
+    //     std::vector<uint8_t> cbor;
+    //     v8_crdtp::json::ConvertJSONToCBOR(v8_crdtp::span<uint16_t>(requestJsonString16.characters16(), requestJsonString16.length()), &cbor);
+    //     std::unique_ptr<protocol::Value> protocolRequestJson = protocol::Value::parseBinary(cbor.data(), cbor.size());
 
-        protocol::ErrorSupport errorSupport;
-        auto protocolRequestObj = protocol::Network::Request::fromValue(protocolRequestJson.get(), &errorSupport);
-        auto initiator = protocol::Network::Initiator::create().setType(protocol::Network::Initiator::TypeEnum::Script).build();
+    //     protocol::ErrorSupport errorSupport;
+    //     auto protocolRequestObj = protocol::Network::Request::fromValue(protocolRequestJson.get(), &errorSupport);
+    //     auto initiator = protocol::Network::Initiator::create().setType(protocol::Network::Initiator::TypeEnum::Script).build();
 
-        std::vector<uint8_t> json;
-        v8_crdtp::json::ConvertCBORToJSON(errorSupport.Errors(), &json);
-        auto errorString = String16(reinterpret_cast<const char*>(json.data()), json.size()).utf8();
+    //     std::vector<uint8_t> json;
+    //     v8_crdtp::json::ConvertCBORToJSON(errorSupport.Errors(), &json);
+    //     auto errorString = String16(reinterpret_cast<const char*>(json.data()), json.size()).utf8();
 
-        if (!errorString.empty()) {
-            auto errorMessage = "Error while parsing debug `request` object. ";
-            DEBUG_WRITE_FORCE("%s Error: %s", errorMessage, errorString.c_str());
+    //     if (!errorString.empty()) {
+    //         auto errorMessage = "Error while parsing debug `request` object. ";
+    //         DEBUG_WRITE_FORCE("%s Error: %s", errorMessage, errorString.c_str());
 
-            throw NativeScriptException(errorMessage + errorString);
-        }
+    //         throw NativeScriptException(errorMessage + errorString);
+    //     }
 
-        protocol::Maybe<String16> frameId(ArgConverter::ConvertToString(ArgConverter::ConvertToV8String(isolate, FrameId)).c_str());
-        protocol::Maybe<String16> type(ArgConverter::ConvertToString(typeArg).c_str());
-        protocol::Maybe<protocol::Network::Response> emptyRedirect;
-        networkAgentInstance->m_frontend.requestWillBeSent(
-            ArgConverter::ConvertToString(requestId).c_str(),
-            LoaderId,
-            ArgConverter::ConvertToString(url).c_str(),
-            std::move(protocolRequestObj),
-            timeStamp,
-            wallTime,
-            std::move(initiator),
-            std::move(emptyRedirect),
-            std::move(type),
-            std::move(frameId));
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        std::stringstream ss;
-        ss << "Error: c exception: " << e.what() << std::endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c exception!"));
-        nsEx.ReThrowToV8();
-    }
+    //     protocol::Maybe<String16> frameId(ArgConverter::ConvertToString(ArgConverter::ConvertToV8String(isolate, FrameId)).c_str());
+    //     protocol::Maybe<String16> type(ArgConverter::ConvertToString(typeArg).c_str());
+    //     protocol::Maybe<protocol::Network::Response> emptyRedirect;
+    //     networkAgentInstance->m_frontend.requestWillBeSent(
+    //         ArgConverter::ConvertToString(requestId).c_str(),
+    //         LoaderId,
+    //         ArgConverter::ConvertToString(url).c_str(),
+    //         std::move(protocolRequestObj),
+    //         timeStamp,
+    //         wallTime,
+    //         std::move(initiator),
+    //         std::move(emptyRedirect),
+    //         std::move(type),
+    //         std::move(frameId));
+    // } catch (NativeScriptException& e) {
+    //     e.ReThrowToV8();
+    // } catch (std::exception e) {
+    //     std::stringstream ss;
+    //     ss << "Error: c exception: " << e.what() << std::endl;
+    //     NativeScriptException nsEx(ss.str());
+    //     nsEx.ReThrowToV8();
+    // } catch (...) {
+    //     NativeScriptException nsEx(std::string("Error: c exception!"));
+    //     nsEx.ReThrowToV8();
+    // }
 }
 
 void NetworkDomainCallbackHandlers::DataForRequestIdCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto networkAgentInstance = NetworkAgentImpl::Instance;
-        const std::string wrongParametersError = "Not all parameters are present in the object argument in the call to DataForRequestId! Required params: 'requestId', `data`, `hasTextContent`";
+    // try {
+    //     auto networkAgentInstance = NetworkAgentImpl::Instance;
+    //     const std::string wrongParametersError = "Not all parameters are present in the object argument in the call to DataForRequestId! Required params: 'requestId', `data`, `hasTextContent`";
 
-        if (!networkAgentInstance) {
-            return;
-        }
+    //     if (!networkAgentInstance) {
+    //         return;
+    //     }
 
-        if (args.Length() == 0 || !args[0]->IsObject()) {
-            throw NativeScriptException(wrongParametersError);
-        }
+    //     if (args.Length() == 0 || !args[0]->IsObject()) {
+    //         throw NativeScriptException(wrongParametersError);
+    //     }
 
-        auto isolate = args.GetIsolate();
+    //     auto isolate = args.GetIsolate();
 
-        v8::HandleScope scope(isolate);
+    //     v8::HandleScope scope(isolate);
 
-        auto context = isolate->GetCurrentContext();
+    //     auto context = isolate->GetCurrentContext();
 
-        v8::Local<v8::Object> argsObj = args[0]->ToObject(context).ToLocalChecked();
+    //     v8::Local<v8::Object> argsObj = args[0]->ToObject(context).ToLocalChecked();
 
-        if (!argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "requestId")).FromMaybe(false) ||
-                !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "data")).FromMaybe(false) ||
-                !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "hasTextContent")).FromMaybe(false)) {
-            throw NativeScriptException(wrongParametersError);
-        }
+    //     if (!argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "requestId")).FromMaybe(false) ||
+    //             !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "data")).FromMaybe(false) ||
+    //             !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "hasTextContent")).FromMaybe(false)) {
+    //         throw NativeScriptException(wrongParametersError);
+    //     }
 
-        auto requestId = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "requestId")).ToLocalChecked()->ToString(context).ToLocalChecked();
-        auto data = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "data")).ToLocalChecked()->ToString(context).ToLocalChecked();
-        auto hasTextContent = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "hasTextContent")).ToLocalChecked()->ToBoolean(isolate);
+    //     auto requestId = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "requestId")).ToLocalChecked()->ToString(context).ToLocalChecked();
+    //     auto data = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "data")).ToLocalChecked()->ToString(context).ToLocalChecked();
+    //     auto hasTextContent = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "hasTextContent")).ToLocalChecked()->ToBoolean(isolate);
 
-        auto requestIdString = ArgConverter::ConvertToString(requestId);
-        auto dataString = ArgConverter::ConvertToUtf16String(data);
-        auto hasTextContentBool = hasTextContent->BooleanValue(isolate);
+    //     auto requestIdString = ArgConverter::ConvertToString(requestId);
+    //     auto dataString = ArgConverter::ConvertToUtf16String(data);
+    //     auto hasTextContentBool = hasTextContent->BooleanValue(isolate);
 
-        auto responses = networkAgentInstance->m_responses;
-        auto it = responses.find(requestIdString);
+    //     auto responses = networkAgentInstance->m_responses;
+    //     auto it = responses.find(requestIdString);
 
-        if (it == responses.end()) {
-            throw NativeScriptException("Response not found for requestId = " + requestIdString);
-        } else {
-            utils::NetworkRequestData* response = it->second;
+    //     if (it == responses.end()) {
+    //         throw NativeScriptException("Response not found for requestId = " + requestIdString);
+    //     } else {
+    //         utils::NetworkRequestData* response = it->second;
 
-            response->setData(dataString);
+    //         response->setData(dataString);
 
-            response->setHasTextContent(hasTextContentBool);
-        }
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        std::stringstream ss;
-        ss << "Error: c exception: " << e.what() << std::endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c exception!"));
-        nsEx.ReThrowToV8();
-    }
+    //         response->setHasTextContent(hasTextContentBool);
+    //     }
+    // } catch (NativeScriptException& e) {
+    //     e.ReThrowToV8();
+    // } catch (std::exception e) {
+    //     std::stringstream ss;
+    //     ss << "Error: c exception: " << e.what() << std::endl;
+    //     NativeScriptException nsEx(ss.str());
+    //     nsEx.ReThrowToV8();
+    // } catch (...) {
+    //     NativeScriptException nsEx(std::string("Error: c exception!"));
+    //     nsEx.ReThrowToV8();
+    // }
 }
 
 void NetworkDomainCallbackHandlers::LoadingFinishedCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto networkAgentInstance = NetworkAgentImpl::Instance;
-        const std::string wrongParametersError = "Not all parameters are present in the object argument in the call to LoadingFinished! Required params: 'requestId', `timeStamp`";
+    // try {
+    //     auto networkAgentInstance = NetworkAgentImpl::Instance;
+    //     const std::string wrongParametersError = "Not all parameters are present in the object argument in the call to LoadingFinished! Required params: 'requestId', `timeStamp`";
 
-        if (!networkAgentInstance) {
-            return;
-        }
+    //     if (!networkAgentInstance) {
+    //         return;
+    //     }
 
-        if (args.Length() == 0 || !args[0]->IsObject()) {
-            throw NativeScriptException(wrongParametersError);
-        }
+    //     if (args.Length() == 0 || !args[0]->IsObject()) {
+    //         throw NativeScriptException(wrongParametersError);
+    //     }
 
-        auto isolate = args.GetIsolate();
+    //     auto isolate = args.GetIsolate();
 
-        v8::HandleScope scope(isolate);
+    //     v8::HandleScope scope(isolate);
 
-        auto context = isolate->GetCurrentContext();
+    //     auto context = isolate->GetCurrentContext();
 
-        v8::Local<v8::Object> argsObj = args[0]->ToObject(context).ToLocalChecked();
+    //     v8::Local<v8::Object> argsObj = args[0]->ToObject(context).ToLocalChecked();
 
-        if (!argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "requestId")).FromMaybe(false) ||
-                !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).FromMaybe(false)) {
-            throw NativeScriptException(wrongParametersError);
-        }
+    //     if (!argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "requestId")).FromMaybe(false) ||
+    //             !argsObj->Has(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).FromMaybe(false)) {
+    //         throw NativeScriptException(wrongParametersError);
+    //     }
 
-        auto requestId = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "requestId")).ToLocalChecked()->ToString(context).ToLocalChecked();
-        auto timeStamp = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
-        long long int encodedDataLength = 0;
-        auto encodedDataLengthProp = ArgConverter::ConvertToV8String(isolate, "encodedDataLength");
-        if (argsObj->Has(context, encodedDataLengthProp).FromMaybe(true)) {
-            encodedDataLength = argsObj->Get(context, encodedDataLengthProp).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
-        }
+    //     auto requestId = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "requestId")).ToLocalChecked()->ToString(context).ToLocalChecked();
+    //     auto timeStamp = argsObj->Get(context, ArgConverter::ConvertToV8String(isolate, "timestamp")).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
+    //     long long int encodedDataLength = 0;
+    //     auto encodedDataLengthProp = ArgConverter::ConvertToV8String(isolate, "encodedDataLength");
+    //     if (argsObj->Has(context, encodedDataLengthProp).FromMaybe(true)) {
+    //         encodedDataLength = argsObj->Get(context, encodedDataLengthProp).ToLocalChecked()->ToNumber(context).ToLocalChecked()->IntegerValue(context).ToChecked();
+    //     }
 
-        networkAgentInstance->m_frontend.loadingFinished(ArgConverter::ConvertToString(requestId).c_str(), timeStamp, encodedDataLength);
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        std::stringstream ss;
-        ss << "Error: c exception: " << e.what() << std::endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c exception!"));
-        nsEx.ReThrowToV8();
-    }
+    //     networkAgentInstance->m_frontend.loadingFinished(ArgConverter::ConvertToString(requestId).c_str(), timeStamp, encodedDataLength);
+    // } catch (NativeScriptException& e) {
+    //     e.ReThrowToV8();
+    // } catch (std::exception e) {
+    //     std::stringstream ss;
+    //     ss << "Error: c exception: " << e.what() << std::endl;
+    //     NativeScriptException nsEx(ss.str());
+    //     nsEx.ReThrowToV8();
+    // } catch (...) {
+    //     NativeScriptException nsEx(std::string("Error: c exception!"));
+    //     nsEx.ReThrowToV8();
+    // }
 }
 
-const char* NetworkDomainCallbackHandlers::FrameId = "";
-const char* NetworkDomainCallbackHandlers::LoaderId = "NSLoaderIdentifier";
+// const char* NetworkDomainCallbackHandlers::FrameId = "";
+// const char* NetworkDomainCallbackHandlers::LoaderId = "NSLoaderIdentifier";

--- a/test-app/runtime/src/main/cpp/NetworkDomainCallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/NetworkDomainCallbackHandlers.h
@@ -7,19 +7,19 @@
 
 
 #include <include/v8.h>
-#ifdef APPLICATION_IN_DEBUG
-#include "JsV8InspectorClient.h"
-#include "NetworkAgentImpl.h"
-#endif
-#include "ArgConverter.h"
-#include "NativeScriptException.h"
+// #ifdef APPLICATION_IN_DEBUG
+// #include "JsV8InspectorClient.h"
+// #include "NetworkAgentImpl.h"
+// #endif
+// #include "ArgConverter.h"
+// #include "NativeScriptException.h"
 
 namespace tns {
 class NetworkDomainCallbackHandlers {
 
     public:
-        static const char* FrameId;
-        static const char* LoaderId;
+        // static const char* FrameId;
+        // static const char* LoaderId;
 
         /*
          * Fired when device is about to send HTTP request.


### PR DESCRIPTION
### Description

This restores the JS functions that were used to implement the DOM and Network inspector domains. The functions do nothing, but they are present so that using the corresponding UI features in the inspector doesn't crash.

### Related Pull Requests
- #1751 

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
No tests included; there's currently no framework for automated tests of the devtools inspector. Test this by attaching the inspector and using functionality in the DOM and Network tabs.

