### PR TITLE
Remove weak callback from __postFrameCallback cache

### DIFF
--- a/test-app/runtime/src/main/cpp/ArrayBufferHelper.cpp
+++ b/test-app/runtime/src/main/cpp/ArrayBufferHelper.cpp
@@ -89,13 +89,13 @@ void ArrayBufferHelper::CreateFromCallbackImpl(const FunctionCallbackInfo<Value>
         auto data = env.GetDirectBufferAddress(obj);
         auto size = env.GetDirectBufferCapacity(obj);
 
-        std::shared_ptr<v8::BackingStore> store = ArrayBuffer::NewBackingStore(
+        std::unique_ptr<v8::BackingStore> store = ArrayBuffer::NewBackingStore(
                 data,
                 size,
-                [](void* data, size_t length, void* deleter_data) {},
-                data);
+                BackingStore::EmptyDeleter,
+                nullptr);
 
-        arrayBuffer = ArrayBuffer::New(isolate, store);
+        arrayBuffer = ArrayBuffer::New(isolate, std::move(store));
     } else {
         if (m_remainingMethodID == nullptr) {
             m_remainingMethodID = env.GetMethodID(m_ByteBufferClass, "remaining", "()I");
@@ -117,7 +117,7 @@ void ArrayBufferHelper::CreateFromCallbackImpl(const FunctionCallbackInfo<Value>
         jbyte* data = new jbyte[bufferRemainingSize];
         memcpy(data, byteArrayElements, bufferRemainingSize);
 
-        std::shared_ptr<v8::BackingStore> store = ArrayBuffer::NewBackingStore(
+        std::unique_ptr<v8::BackingStore> store = ArrayBuffer::NewBackingStore(
                 data,
                 bufferRemainingSize,
                 [](void *data, size_t length, void *deleter_data) {
@@ -125,7 +125,7 @@ void ArrayBufferHelper::CreateFromCallbackImpl(const FunctionCallbackInfo<Value>
                 },
                 nullptr);
 
-        arrayBuffer = ArrayBuffer::New(isolate, store);
+        arrayBuffer = ArrayBuffer::New(isolate, std::move(store));
         env.ReleaseByteArrayElements(byteArray, byteArrayElements, 0);
     }
 

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -826,10 +826,10 @@ void CallbackHandlers::EnableVerboseLoggingMethodCallback(
         const v8::FunctionCallbackInfo<v8::Value> &args) {
     try {
         auto isolate = args.GetIsolate();
-        auto runtume = Runtime::GetRuntime(isolate);
+        auto runtime = Runtime::GetRuntime(isolate);
         tns::LogEnabled = true;
         JEnv env;
-        env.CallVoidMethod(runtume->GetJavaRuntime(), ENABLE_VERBOSE_LOGGING_METHOD_ID);
+        env.CallVoidMethod(runtime->GetJavaRuntime(), ENABLE_VERBOSE_LOGGING_METHOD_ID);
     } catch (NativeScriptException &e) {
         e.ReThrowToV8();
     } catch (std::exception e) {
@@ -847,10 +847,10 @@ void CallbackHandlers::DisableVerboseLoggingMethodCallback(
         const v8::FunctionCallbackInfo<v8::Value> &args) {
     try {
         auto isolate = args.GetIsolate();
-        auto runtume = Runtime::GetRuntime(isolate);
+        auto runtime = Runtime::GetRuntime(isolate);
         tns::LogEnabled = false;
         JEnv env;
-        env.CallVoidMethod(runtume->GetJavaRuntime(), DISABLE_VERBOSE_LOGGING_METHOD_ID);
+        env.CallVoidMethod(runtime->GetJavaRuntime(), DISABLE_VERBOSE_LOGGING_METHOD_ID);
     } catch (NativeScriptException &e) {
         e.ReThrowToV8();
     } catch (std::exception e) {

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -1671,20 +1671,6 @@ void CallbackHandlers::PostFrameCallback(const FunctionCallbackInfo<v8::Value> &
         FrameCallbackCacheEntry entry (isolate, callback, context);
         entry.id = key;
 
-        auto finalCallback = [](const v8::WeakCallbackInfo<FrameCallbackCacheEntry> &data) {
-            auto value = data.GetParameter();
-            for (auto &item: frameCallbackCache_) {
-                if (item.second.id == value->id) {
-                    item.second.context_.Reset();
-                    item.second.callback_.Reset();
-                    frameCallbackCache_.erase(item.first);
-                    break;
-                }
-            }
-        };
-
-        entry.callback_.SetWeak(&entry, finalCallback, v8::WeakCallbackType::kFinalizer);
-
         frameCallbackCache_.emplace(key, std::move(entry));
 
         auto val = frameCallbackCache_.find(key);

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -700,11 +700,10 @@ int CallbackHandlers::RunOnMainThreadFdCallback(int fd, int events, void *data) 
     auto context = it->second.context_.Get(isolate);
     Context::Scope context_scope(context);
     Local<v8::Function> cb = it->second.callback_.Get(isolate);
-    Local<Value> result;
 
     v8::TryCatch tc(isolate);
 
-    if (!cb->Call(context, context->Global(), 0, nullptr).ToLocal(&result)) {}
+    cb->Call(context, context->Global(), 0, nullptr);  // ignore JS return value
 
     cache_.erase(it);
 

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -1667,10 +1667,8 @@ void CallbackHandlers::PostFrameCallback(const FunctionCallbackInfo<v8::Value> &
 
         robin_hood::unordered_map<uint64_t, FrameCallbackCacheEntry>::iterator val;
         bool inserted;
-        std::tie(val, inserted) = frameCallbackCache_.try_emplace(key, isolate, callback, context);
+        std::tie(val, inserted) = frameCallbackCache_.try_emplace(key, isolate, callback, context, key);
         assert(inserted && "Frame callback ID should not be duplicated");
-
-        val->second.id = key;
 
         PostCallback(args, &val->second, context);
     }

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -284,8 +284,6 @@ namespace tns {
             jobject _runtime;
         };
 
-        static void RemoveKey(const uint64_t key);
-
         static std::atomic_int64_t count_;
 
 

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -341,6 +341,9 @@ namespace tns {
                 if (data != nullptr) {
                     auto entry = static_cast<FrameCallbackCacheEntry *>(data);
                     if (entry->removed) {
+                        entry->context_.Reset();
+                        entry->callback_.Reset();
+                        frameCallbackCache_.erase(entry->id);  // invalidates *entry
                         return;
                     }
                     v8::Isolate *isolate = entry->isolate_;
@@ -361,6 +364,10 @@ namespace tns {
                     if (!cb->Call(context, context->Global(), 1, args).ToLocal(&result)) {
                         // TODO
                     }
+
+                    entry->context_.Reset();
+                    entry->callback_.Reset();
+                    frameCallbackCache_.erase(entry->id);  // invalidates *entry
 
                     if(tc.HasCaught()){
                         throw NativeScriptException(tc);

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -305,6 +305,11 @@ namespace tns {
                       context_(isolate, context){
             }
 
+            ~CacheEntry() {
+                context_.Reset();
+                callback_.Reset();
+            }
+
             v8::Isolate* isolate_;
             v8::Global<v8::Function> callback_;
             v8::Global<v8::Context> context_;
@@ -321,6 +326,11 @@ namespace tns {
                       callback_(isolate,callback),
                       context_(isolate, context)
                       {
+            }
+
+            ~FrameCallbackCacheEntry() {
+                context_.Reset();
+                callback_.Reset();
             }
 
             v8::Isolate *isolate_;
@@ -341,8 +351,6 @@ namespace tns {
                 if (data != nullptr) {
                     auto entry = static_cast<FrameCallbackCacheEntry *>(data);
                     if (entry->removed) {
-                        entry->context_.Reset();
-                        entry->callback_.Reset();
                         frameCallbackCache_.erase(entry->id);  // invalidates *entry
                         return;
                     }
@@ -365,8 +373,6 @@ namespace tns {
                         // TODO
                     }
 
-                    entry->context_.Reset();
-                    entry->callback_.Reset();
                     frameCallbackCache_.erase(entry->id);  // invalidates *entry
 
                     if(tc.HasCaught()){

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -326,7 +326,7 @@ namespace tns {
             v8::Isolate *isolate_;
             v8::Global<v8::Function> callback_;
             v8::Global<v8::Context> context_;
-            bool removed;
+            bool removed = false;
             uint64_t id;
 
             AChoreographer_frameCallback frameCallback_ = [](long ts, void *data) {

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -321,11 +321,12 @@ namespace tns {
         static std::atomic_uint64_t frameCallbackCount_;
 
         struct FrameCallbackCacheEntry {
-            FrameCallbackCacheEntry(v8::Isolate *isolate, v8::Local<v8::Function> callback, v8::Local<v8::Context> context)
-                    : isolate_(isolate),
-                      callback_(isolate,callback),
-                      context_(isolate, context)
-                      {
+            FrameCallbackCacheEntry(v8::Isolate *isolate, v8::Local<v8::Function> callback,
+                                    v8::Local<v8::Context> context, uint64_t aId)
+                : isolate_(isolate),
+                  callback_(isolate, callback),
+                  context_(isolate, context),
+                  id(aId) {
             }
 
             ~FrameCallbackCacheEntry() {

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -362,15 +362,11 @@ namespace tns {
                     v8::Context::Scope context_scope(context);
 
                     v8::Local<v8::Function> cb = entry->callback_.Get(isolate);
-                    v8::Local<v8::Value> result;
-
                     v8::Local<v8::Value> args[1] = {v8::Number::New(isolate, ts)};
 
                     v8::TryCatch tc(isolate);
 
-                    if (!cb->Call(context, context->Global(), 1, args).ToLocal(&result)) {
-                        // TODO
-                    }
+                    cb->Call(context, context->Global(), 1, args);  // ignore JS return value
 
                     frameCallbackCache_.erase(entry->id);  // invalidates *entry
 

--- a/test-app/runtime/src/main/cpp/MessageLoopTimer.cpp
+++ b/test-app/runtime/src/main/cpp/MessageLoopTimer.cpp
@@ -129,7 +129,6 @@ int MessageLoopTimer::PumpMessageLoopCallback(int fd, int events, void* data) {
     v8::HandleScope handleScope(isolate);
 
     while (v8::platform::PumpMessageLoop(Runtime::platform, isolate)) {
-//        isolate->RunMicrotasks();
         isolate->PerformMicrotaskCheckpoint();
     }
 

--- a/test-app/runtime/src/main/cpp/Profiler.cpp
+++ b/test-app/runtime/src/main/cpp/Profiler.cpp
@@ -18,8 +18,6 @@ void Profiler::Init(Isolate* isolate, const Local<Object>& globalObj, const stri
     globalObj->Set(context, ArgConverter::ConvertToV8String(isolate, "__startCPUProfiler"), FunctionTemplate::New(isolate, Profiler::StartCPUProfilerCallback, extData)->GetFunction(context).ToLocalChecked());
     globalObj->Set(context, ArgConverter::ConvertToV8String(isolate, "__stopCPUProfiler"), FunctionTemplate::New(isolate, Profiler::StopCPUProfilerCallback, extData)->GetFunction(context).ToLocalChecked());
     globalObj->Set(context, ArgConverter::ConvertToV8String(isolate, "__heapSnapshot"), FunctionTemplate::New(isolate, Profiler::HeapSnapshotMethodCallback, extData)->GetFunction(context).ToLocalChecked());
-    globalObj->Set(context, ArgConverter::ConvertToV8String(isolate, "__startNDKProfiler"), FunctionTemplate::New(isolate, Profiler::StartNDKProfilerCallback, extData)->GetFunction(context).ToLocalChecked());
-    globalObj->Set(context, ArgConverter::ConvertToV8String(isolate, "__stopNDKProfiler"), FunctionTemplate::New(isolate, Profiler::StopNDKProfilerCallback, extData)->GetFunction(context).ToLocalChecked());
 }
 
 void Profiler::StartCPUProfilerCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -193,56 +191,6 @@ bool Profiler::Write(CpuProfile* cpuProfile) {
     fclose(fp);
 
     return true;
-}
-
-void Profiler::StartNDKProfilerCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto isolate = args.GetIsolate();
-        auto extData = args.Data().As<External>();
-        auto thiz = static_cast<Profiler*>(extData->Value());
-        thiz->StartNDKProfiler();
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        stringstream ss;
-        ss << "Error: c++ exception: " << e.what() << endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c++ exception!"));
-        nsEx.ReThrowToV8();
-    }
-}
-
-void Profiler::StopNDKProfilerCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    try {
-        auto isolate = args.GetIsolate();
-        auto extData = args.Data().As<External>();
-        auto thiz = static_cast<Profiler*>(extData->Value());
-        thiz->StopNDKProfiler();
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception e) {
-        stringstream ss;
-        ss << "Error: c++ exception: " << e.what() << endl;
-        NativeScriptException nsEx(ss.str());
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c++ exception!"));
-        nsEx.ReThrowToV8();
-    }
-}
-
-void Profiler::StartNDKProfiler() {
-#ifdef NDK_PROFILER_ENABLED
-    monstartup("libNativeScript.so");
-#endif
-}
-
-void Profiler::StopNDKProfiler() {
-#ifdef NDK_PROFILER_ENABLED
-    moncleanup();
-#endif
 }
 
 class FileOutputStream: public OutputStream {

--- a/test-app/runtime/src/main/cpp/Profiler.h
+++ b/test-app/runtime/src/main/cpp/Profiler.h
@@ -17,10 +17,6 @@ class Profiler {
 
         static void StopCPUProfilerCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-        static void StartNDKProfilerCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
-
-        static void StopNDKProfilerCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
-
         static void HeapSnapshotMethodCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
 
         void StartCPUProfilerCallbackImpl(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -32,10 +28,6 @@ class Profiler {
         void StartCPUProfiler(v8::Isolate* isolate, const v8::Local<v8::String>& name);
 
         bool StopCPUProfiler(v8::Isolate* isolate, const v8::Local<v8::String>& name);
-
-        void StartNDKProfiler();
-
-        void StopNDKProfiler();
 
         bool Write(v8::CpuProfile* cpuProfile);
 


### PR DESCRIPTION
### Description

In preparation for upgrading V8 to 11.x, we need to remove uses of `kFinalizer` weak callbacks because V8 no longer supports them. One was used to clean up the cache entries for `__postFrameCallback()` callbacks, but that isn't necessary; we can just do the cleanup after the callback runs.

Also fixes a bug where sometimes a frame callback never got called.

Includes various cleanups in CallbackHanders.cpp and CallbackHanders.h, as well as a few misc commits left over from some of the upgrade work I did in February (the first 3 commits in the stack).

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?

`__postFrameCallback()` doesn't have a unit test. (If one is needed, let me know and I can write one.)

I tested this by adding the following snippet to the test-app:
```diff
--- a/test-app/app/src/main/assets/app/MyActivity.js
+++ b/test-app/app/src/main/assets/app/MyActivity.js
@@ -56,6 +56,13 @@ var MyActivity = (function (_super) {
                        onClick: function () {
                                button.setBackgroundColor(colors[taps % colors.length]);
                                taps++;
+                               textView.setText('Waiting for frame callback...');
+                               __postFrameCallback(() => {
+                                   textView.setText(`Message after one second: ${new Date()}`);
+                               }, 1000 /* ms */);
+                               __runOnMainThread(() => {
+                                   button.setText(`Hit me ${5 - taps} more times`);
+                               });
                        },
                })
         );
```

