### PR TITLE
Don't store V8 context in callback info

### DIFF
--- a/test-app/runtime/src/main/cpp/Timers.h
+++ b/test-app/runtime/src/main/cpp/Timers.h
@@ -40,7 +40,6 @@ namespace tns {
             args_.reset();
             isolate_ = nullptr;
             queued_ = false;
-            disposed = true;
         }
 
         int nestingLevel_ = 0;
@@ -59,7 +58,6 @@ namespace tns {
         double dueTime_ = -1;
         double startTime_ = -1;
         int id_;
-        bool disposed = false;
     };
 
     struct TimerReference {
@@ -109,11 +107,6 @@ namespace tns {
         void removeTask(const std::shared_ptr<TimerTask> &task);
 
         void removeTask(const int &taskId);
-
-        inline bool IsScheduled(const int &id) {
-            auto it = timerMap_.find(id);
-            return it != timerMap_.end();
-        }
 
         v8::Isolate *isolate_ = nullptr;
         ALooper *looper_;

--- a/test-app/runtime/src/main/cpp/Timers.h
+++ b/test-app/runtime/src/main/cpp/Timers.h
@@ -20,7 +20,7 @@ namespace tns {
                          bool repeats,
                          const std::shared_ptr<std::vector<std::shared_ptr<v8::Persistent<v8::Value>>>> &args,
                          int id, double startTime)
-                : isolate_(isolate), context_(isolate, context), callback_(isolate, callback),
+                : isolate_(isolate), callback_(isolate, callback),
                   frequency_(frequency), repeats_(repeats), args_(args), id_(id),
                   startTime_(startTime) {
 
@@ -36,7 +36,6 @@ namespace tns {
         }
 
         inline void Unschedule() {
-            context_.Reset();
             callback_.Reset();
             args_.reset();
             isolate_ = nullptr;
@@ -46,7 +45,6 @@ namespace tns {
 
         int nestingLevel_ = 0;
         v8::Isolate *isolate_;
-        v8::Persistent<v8::Context> context_;
         v8::Persistent<v8::Function> callback_;
         std::shared_ptr<std::vector<std::shared_ptr<v8::Persistent<v8::Value>>>> args_;
         bool repeats_ = false;


### PR DESCRIPTION
### Description

This change is from an idea by @edusperoni, that it might not be necessary to store a `Persistent<Context>` in frame and main thread callback info. That seems to be the case indeed, if we use `GetCreationContextChecked()` to get the context that the callback JS function belongs to and use that instead. `GetCreationContextChecked()` can potentially be more expensive in terms of performance than storing the context in a persistent, but I estimate it shouldn't be too bad since it's called only once for each execution of a callback.

### Related Pull Requests
None.

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?

I believe this is covered by the unit tests at least partly.
I also added the following snippet to `MyActivity.js` in the test app to test manually that the callbacks continue to work:
```js
--- a/test-app/app/src/main/assets/app/MyActivity.js
+++ b/test-app/app/src/main/assets/app/MyActivity.js
@@ -56,6 +56,13 @@ var MyActivity = (function (_super) {
                        onClick: function () {
                                button.setBackgroundColor(colors[taps % colors.length]);
                                taps++;
+                              textView.setText('Waiting for frame callback...');
+                              __postFrameCallback(() => {
+                                  textView.setText(`Message after one second: ${new Date()}`);
+                              }, 1000 /* ms */);
+                              __runOnMainThread(() => {
+                                  button.setText(`Hit me ${5 - taps} more times`);
+                              });
                        },
                })
         );
```
