### PR TITLE
feat: add support for kotlin 1.8

### DIFF
--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/parsing/kotlin/classes/KotlinClassDescriptor.kt
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/parsing/kotlin/classes/KotlinClassDescriptor.kt
@@ -18,8 +18,8 @@ import com.telerik.metadata.security.classes.SecuredClassRepository
 import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClass
 import kotlinx.metadata.KmProperty
-import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.Metadata
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.setterSignature
 import org.apache.bcel.classfile.JavaClass
@@ -253,7 +253,7 @@ class KotlinClassDescriptor(nativeClass: JavaClass, private val metadataAnnotati
 
     private val metadataParser = BytecodeClassMetadataParser()
     internal val kotlinMetadata: KotlinClassMetadata? by lazy {
-        val kotlinClassHeader = KotlinClassHeader(
+        val metadata = Metadata(
                 metadataAnnotation.kind,
                 metadataAnnotation.metadataVersion,
                 metadataAnnotation.data1,
@@ -262,7 +262,7 @@ class KotlinClassDescriptor(nativeClass: JavaClass, private val metadataAnnotati
                 metadataAnnotation.packageName,
                 metadataAnnotation.extraInt)
 
-        KotlinClassMetadata.read(kotlinClassHeader)
+        KotlinClassMetadata.read(metadata)
     }
 
 

--- a/test-app/gradle.properties
+++ b/test-app/gradle.properties
@@ -41,6 +41,6 @@ ns_default_gson_version = 2.9.0
 ns_default_json_version = 20180813
 ns_default_junit_version = 4.13.2
 ns_default_kotlin_version = 1.7.10
-ns_default_kotlinx_metadata_jvm_version = 0.4.2
+ns_default_kotlinx_metadata_jvm_version = 0.6.2
 ns_default_mockito_core_version = 3.0.0
 ns_default_spotbugs_version = 3.1.12


### PR DESCRIPTION
### Description

When using Kotlin 1.8, the runtime has trouble generating the correct metadata, resulting in empty enums, among other issues. This is fixed by updating the kotlinx-metadata-jvm package.

To validate this fix, you can change `ns_default_kotlin_version` to 1.8.10 and all tests will pass (they'd fail on previous version)

