### PR TITLE
fix: pull js stack trace from wrapped NativeScriptExceptions

### DIFF
--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -285,6 +285,8 @@ public class Runtime {
     public static String getJSStackTrace(Throwable ex) {
         if (ex instanceof NativeScriptException) {
             return ((NativeScriptException) ex).getIncomingStackTrace();
+        } else if(ex.getCause() instanceof NativeScriptException) {
+            return ((NativeScriptException) ex.getCause()).getIncomingStackTrace();
         } else {
             return null;
         }


### PR DESCRIPTION
Unwrap and print stack traces from RuntimeException that are caused by a NativeScriptException.
This now properly shows the JS stack trace in the exception for easier debugging.

Before:
![image](https://github.com/NativeScript/android/assets/879060/9e1b151d-9572-4930-9f5c-8fd3ab53237a)

After:
![image](https://github.com/NativeScript/android/assets/879060/30584609-815d-49b7-a0bf-31dff0adfbb2)



