### PR TITLE
Preparations for V8 11.x

### DIFF
--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -566,7 +566,7 @@ CallbackHandlers::GetImplementedInterfaces(JEnv &env, const Local<Object> &imple
 
     vector<jstring> interfacesToImplement;
     auto isolate = implementationObject->GetIsolate();
-    auto context = implementationObject->CreationContext();
+    Local<Context> context = implementationObject->GetCreationContextChecked();
     Local<String> interfacesName = String::NewFromUtf8Literal(isolate, "interfaces");
     Local<Value> prop;
     if (implementationObject->Get(context, interfacesName).ToLocal(&prop) && !prop.IsEmpty() && prop->IsArray()) {
@@ -612,7 +612,7 @@ CallbackHandlers::GetMethodOverrides(JEnv &env, const Local<Object> &implementat
 
     vector<jstring> methodNames;
     auto isolate = implementationObject->GetIsolate();
-    auto context = implementationObject->CreationContext();
+    Local<Context> context = implementationObject->GetCreationContextChecked();
     auto propNames = implementationObject->GetOwnPropertyNames(context).ToLocalChecked();
     for (int i = 0; i < propNames->Length(); i++) {
         auto name = propNames->Get(context, i).ToLocalChecked().As<String>();

--- a/test-app/runtime/src/main/cpp/Constants.cpp
+++ b/test-app/runtime/src/main/cpp/Constants.cpp
@@ -9,4 +9,3 @@
 
 std::string Constants::APP_ROOT_FOLDER_PATH = "";
 bool Constants::V8_CACHE_COMPILED_CODE = false;
-std::string Constants::V8_STARTUP_FLAGS = "";

--- a/test-app/runtime/src/main/cpp/Constants.h
+++ b/test-app/runtime/src/main/cpp/Constants.h
@@ -8,7 +8,6 @@ class Constants {
         const static char CLASS_NAME_LOCATION_SEPARATOR = '_';
 
         static std::string APP_ROOT_FOLDER_PATH;
-        static std::string V8_STARTUP_FLAGS;
         static bool V8_CACHE_COMPILED_CODE;
 
     private:

--- a/test-app/runtime/src/main/cpp/JsV8InspectorClient.cpp
+++ b/test-app/runtime/src/main/cpp/JsV8InspectorClient.cpp
@@ -1,6 +1,7 @@
 #include "JsV8InspectorClient.h"
 #include <assert.h>
-#include <include/libplatform/libplatform.h>
+
+#include <cppgc/default-platform.h>
 #include <src/inspector/v8-console-message.h>
 #include <src/inspector/v8-inspector-impl.h>
 #include <src/inspector/v8-inspector-session-impl.h>
@@ -134,7 +135,7 @@ void JsV8InspectorClient::runMessageLoopOnPause(int context_group_id) {
             doDispatchMessage(inspectorMessage);
         }
 
-        while (v8::platform::PumpMessageLoop(Runtime::platform, isolate_)) {
+        while (v8::platform::PumpMessageLoop(Runtime::platform->GetV8Platform(), isolate_)) {
         }
     }
     terminated_ = false;

--- a/test-app/runtime/src/main/cpp/MessageLoopTimer.cpp
+++ b/test-app/runtime/src/main/cpp/MessageLoopTimer.cpp
@@ -3,7 +3,9 @@
 #include <unistd.h>
 #include <cerrno>
 #include <thread>
-#include "include/libplatform/libplatform.h"
+
+#include <cppgc/default-platform.h>
+
 #include "NativeScriptAssert.h"
 #include "ArgConverter.h"
 #include "Runtime.h"
@@ -128,7 +130,7 @@ int MessageLoopTimer::PumpMessageLoopCallback(int fd, int events, void* data) {
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
 
-    while (v8::platform::PumpMessageLoop(Runtime::platform, isolate)) {
+    while (v8::platform::PumpMessageLoop(Runtime::platform->GetV8Platform(), isolate)) {
         isolate->PerformMicrotaskCheckpoint();
     }
 

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1398,7 +1398,7 @@ Local<Object> MetadataNode::GetImplementationObject(Isolate* isolate, const Loca
         return implementationObject;
     }
 
-    auto context = object->CreationContext();
+    Local<Context> context = object->GetCreationContextChecked();
     if (object->HasOwnProperty(context, V8StringConstants::GetIsPrototypeImplementationObject(isolate)).ToChecked()) {
         auto v8Prototype = V8StringConstants::GetPrototype(isolate);
         auto maybeHasOwnProperty = object->HasOwnProperty(context, v8Prototype);

--- a/test-app/runtime/src/main/cpp/NumericCasts.cpp
+++ b/test-app/runtime/src/main/cpp/NumericCasts.cpp
@@ -37,7 +37,7 @@ CastType NumericCasts::GetCastType(Isolate* isolate, const Local<Object>& object
 
 Local<Value> NumericCasts::GetCastValue(const Local<Object>& object) {
     auto isolate = object->GetIsolate();
-    auto context = object->CreationContext();
+    Local<Context> context = object->GetCreationContextChecked();
     Local<Value> value;
     object->Get(context, V8StringConstants::GetValue(isolate)).ToLocal(&value);
     return value;
@@ -364,7 +364,7 @@ void NumericCasts::MarkJsObject(Isolate* isolate, const Local<Object>& object, C
     auto key = ArgConverter::ConvertToV8String(isolate, s_castMarker);
     auto type = Integer::New(isolate, static_cast<int>(castType));
     V8SetPrivateValue(isolate, object, key, type);
-    auto context = object->CreationContext();
+    Local<Context> context = object->GetCreationContextChecked();
     object->Set(context, V8StringConstants::GetValue(isolate), value);
 
     DEBUG_WRITE("MarkJsObject: Marking js object: %d with cast type: %d", object->GetIdentityHash(), castType);

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -187,7 +187,8 @@ void Runtime::Init(JNIEnv* env, jstring filesPath, jstring nativeLibDir, bool ve
     // read config options passed from Java
     // Indices correspond to positions in the com.tns.AppConfig.KnownKeys enum
     JniLocalRef v8Flags(env->GetObjectArrayElement(args, 0));
-    Constants::V8_STARTUP_FLAGS = ArgConverter::jstringToString(v8Flags);
+    std::string v8FlagsString = ArgConverter::jstringToString(v8Flags);
+    V8::SetFlagsFromString(v8FlagsString.c_str(), v8FlagsString.size());
     JniLocalRef cacheCode(env->GetObjectArrayElement(args, 1));
     Constants::V8_CACHE_COMPILED_CODE = (bool) cacheCode;
     JniLocalRef profilerOutputDir(env->GetObjectArrayElement(args, 2));
@@ -477,7 +478,6 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, const string& native
     isolate->SetData((uint32_t)Runtime::IsolateData::RUNTIME, this);
     isolate->SetData((uint32_t)Runtime::IsolateData::CONSTANTS, consts);
 
-    V8::SetFlagsFromString(Constants::V8_STARTUP_FLAGS.c_str(), Constants::V8_STARTUP_FLAGS.size());
     isolate->SetCaptureStackTraceForUncaughtExceptions(true, 100, StackTrace::kOverview);
 
     isolate->AddMessageListener(NativeScriptException::OnUncaughtError);

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -28,7 +28,12 @@
 #include "ManualInstrumentation.h"
 #include "IsolateDisposer.h"
 #include <unistd.h>
+
+#include <memory>
 #include <thread>
+
+#include <cppgc/default-platform.h>
+
 #include "File.h"
 
 #ifdef APPLICATION_IN_DEBUG
@@ -444,8 +449,8 @@ void Runtime::PassUncaughtExceptionFromWorkerToMainHandler(Local<v8::String> mes
 }
 
 static void InitializeV8() {
-    Runtime::platform = v8::platform::NewDefaultPlatform().release();
-    V8::InitializePlatform(Runtime::platform);
+    Runtime::platform = std::make_shared<cppgc::DefaultPlatform>();
+    V8::InitializePlatform(Runtime::platform->GetV8Platform());
     V8::Initialize();
 }
 
@@ -680,7 +685,7 @@ jmethodID Runtime::GET_USED_MEMORY_METHOD_ID = nullptr;
 map<int, Runtime*> Runtime::s_id2RuntimeCache;
 unordered_map<Isolate*, Runtime*> Runtime::s_isolate2RuntimesCache;
 bool Runtime::s_mainThreadInitialized = false;
-v8::Platform* Runtime::platform = nullptr;
+std::shared_ptr<cppgc::DefaultPlatform> Runtime::platform;
 int Runtime::m_androidVersion = Runtime::GetAndroidVersion();
 ALooper* Runtime::m_mainLooper = nullptr;
 int Runtime::m_mainLooper_fd[2];

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -1,6 +1,8 @@
 #ifndef RUNTIME_H_
 #define RUNTIME_H_
 
+#include <memory>
+
 #include "v8.h"
 #include "JniLocalRef.h"
 #include "ObjectManager.h"
@@ -15,6 +17,10 @@
 #include <mutex>
 #include <android/looper.h>
 #include <fcntl.h>
+
+namespace cppgc {
+class DefaultPlatform;
+}
 
 namespace tns {
 class Runtime {
@@ -69,7 +75,7 @@ class Runtime {
 
         v8::Local<v8::Context> GetContext();
 
-        static v8::Platform* platform;
+        static std::shared_ptr<cppgc::DefaultPlatform> platform;
 
         std::string ReadFileText(const std::string& filePath);
 

--- a/test-app/runtime/src/main/cpp/V8GlobalHelpers.cpp
+++ b/test-app/runtime/src/main/cpp/V8GlobalHelpers.cpp
@@ -107,7 +107,7 @@ std::string tns::JsonStringifyObject(Isolate* isolate, v8::Local<v8::Object> val
 bool tns::V8GetPrivateValue(Isolate* isolate, const Local<Object>& obj, const Local<String>& propName, Local<Value>& out) {
     auto privateKey = Private::ForApi(isolate, propName);
 
-    auto context = obj->CreationContext();
+    Local<Context> context = obj->GetCreationContextChecked();
     auto hasPrivate = obj->HasPrivate(context, privateKey);
 
     if (hasPrivate.IsNothing()) {
@@ -133,7 +133,7 @@ bool tns::V8GetPrivateValue(Isolate* isolate, const Local<Object>& obj, const Lo
 
 bool tns::V8SetPrivateValue(Isolate* isolate, const Local<Object>& obj, const Local<String>& propName, const Local<Value>& value) {
     auto privateKey = Private::ForApi(isolate, propName);
-    auto context = obj->CreationContext();
+    Local<Context> context = obj->GetCreationContextChecked();
     auto res = obj->SetPrivate(context, privateKey, value);
 
     if (res.IsNothing()) {


### PR DESCRIPTION
### Description

This PR contains a few updates that will be required for V8 11.x but should be harmless to apply before the migration. (It should not be very risky to apply them to `main`, as well.)

- Switch from `CreationContext` to `GetCreationContextChecked`: the `CreationContext` API goes away in 11.x, but the replacement already exists in 10.x, so we can go ahead and use it.
- Set V8 flags before initializing V8: setting the flags after initialization will crash in 11.x. In 10.x the flags can be set either before or after.
- Use CPPGC-compatible platform: we'll be migrating ObjectManager to use CPPGC, which requires changing the V8 Platform to use the CPPGC default platform. This already works fine in 10.x and should be harmless.

More details in the individual commit messages.

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?

No tests. The PR doesn't introduce any new functionality so the existing tests should all continue passing.
