### PR TITLE
Don't copy generator .jar files to build-tools/

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,11 +261,11 @@ task copyFilesToProjectTemeplate {
             into "$DIST_FRAMEWORK_PATH/app/src/main/java/com/tns/internal"
         }
         copy {
-            from "$BUILD_TOOLS_PATH/static-binding-generator.jar"
+            from "$BUILD_TOOLS_PATH/static-binding-generator/build/libs/static-binding-generator.jar"
             into "$DIST_FRAMEWORK_PATH/build-tools"
         }
         copy {
-            from "$BUILD_TOOLS_PATH/dts-generator.jar"
+            from "$BUILD_TOOLS_PATH/android-dts-generator/build/libs/dts-generator.jar"
             into "$DIST_FRAMEWORK_PATH/build-tools"
         }
         copy {
@@ -273,7 +273,7 @@ task copyFilesToProjectTemeplate {
             into "$DIST_FRAMEWORK_PATH/build-tools/jsparser"
         }
         copy {
-            from "$BUILD_TOOLS_PATH/android-metadata-generator.jar"
+            from "$BUILD_TOOLS_PATH/android-metadata-generator/build/libs/android-metadata-generator.jar"
             into "$DIST_FRAMEWORK_PATH/build-tools"
         }
         copy {

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -504,7 +504,7 @@ task runSbg(type: BuildToolTask) {
     mainClass = "-jar"
 
     def paramz = new ArrayList<String>()
-    paramz.add("static-binding-generator.jar")
+    paramz.add("static-binding-generator/build/libs/static-binding-generator.jar")
 
     if (failOnCompilationWarningsEnabled()) {
         paramz.add("-show-deprecation-warnings")
@@ -841,7 +841,7 @@ task buildMetadata(type: BuildToolTask) {
         setOutputs outLogger
 
         def paramz = new ArrayList<String>()
-        paramz.add("android-metadata-generator.jar")
+        paramz.add("android-metadata-generator/build/libs/android-metadata-generator.jar")
 
         if(enableAnalytics){
             paramz.add("analyticsFilePath=$analyticsFilePath")

--- a/test-app/build-tools/.gitignore
+++ b/test-app/build-tools/.gitignore
@@ -1,13 +1,10 @@
-static-binding-generator.jar
 sbg-bindings.txt
 sbg-interface-names.txt
 sbg-js-parsed-files.txt
 sbg-input-file.txt
 sbg-output-file.txt
 sbg-java-dependencies.txt
-android-metadata-generator.jar
 mdg-output-dir.txt
 mdg-java-dependencies.txt
-dts-generator.jar
 sbg-input-output-dirs.txt
 mdg-java-out.txt

--- a/test-app/build-tools/android-metadata-generator/build.gradle
+++ b/test-app/build-tools/android-metadata-generator/build.gradle
@@ -93,13 +93,3 @@ jar {
 
     duplicatesStrategy = 'include'
 }
-
-task copyJarToBuildTools (type: Copy) {
-	from "$projectDir/build/libs/android-metadata-generator.jar"
-	into "$projectDir/../"
-}
-
-jar.finalizedBy(copyJarToBuildTools)
-
-
-

--- a/test-app/build-tools/static-binding-generator/build.gradle
+++ b/test-app/build-tools/static-binding-generator/build.gradle
@@ -33,16 +33,7 @@ dependencies {
 }
 
 compileJava {
-    if (!findProject(':dts-generator').is(null)) {
-        dependsOn ':dts-generator:copyJarToBuildTools'
-    }
     options.compilerArgs << "-Xlint:all" << "-Xlint:-options" << "-Werror"
-}
-
-task copyJarToBuildTools (type: Copy) {
-    inputs.file("$projectDir/build/libs/static-binding-generator.jar")
-    from "$projectDir/build/libs/static-binding-generator.jar"
-    into "$projectDir/../"
 }
 
 jar {
@@ -72,5 +63,3 @@ jar {
 
     duplicatesStrategy = 'include'
 }
-
-jar.finalizedBy(copyJarToBuildTools)

--- a/test-app/build-tools/static-binding-generator/runtests.gradle
+++ b/test-app/build-tools/static-binding-generator/runtests.gradle
@@ -58,16 +58,7 @@ jar {
     duplicatesStrategy = 'include'
 }
 
-task copyJar(dependsOn: 'jar') {
-    doFirst {
-        def source = file("$projectDir/build/libs/static-binding-generator.jar").toPath()
-        print source.toFile().exists()
-        def dest = file("$projectDir/../static-binding-generator.jar").toPath()
-        Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING)
-    }
-}
-
-task prepareInputFiles(dependsOn: 'copyJar') {
+task prepareInputFiles {
     doFirst {
         inputFile.write(appRoot)
         outputFile.write(generatedJavaClassesRoot.toString())
@@ -77,7 +68,7 @@ task prepareInputFiles(dependsOn: 'copyJar') {
 }
 
 task runSbg(type: JavaExec, dependsOn: 'prepareInputFiles') {
-    classpath = files('../static-binding-generator.jar', '../')
+    classpath = files('build/libs/static-binding-generator.jar', '../')
     workingDir = "../"
     main = "org.nativescript.staticbindinggenerator.Main"
 }


### PR DESCRIPTION
Gradle complains that when multiple tasks have the same output path, it cannot decide accurately whether they need to run or not. The copyJarToBuildTools task of all three generators (android-dts-generator, android-metadata-generator, and static-binding-generator) shared the same output path, so they were always getting run.

Instead, we can leave the .jar files in the location where they are built, and reference them from there in tasks that subsequently require them.

This fix was submitted separately to android-dts-generator, which is a git submodule, in https://github.com/NativeScript/android-dts-generator/pull/77 This commit pulls in a newer version of android-dts-generator which includes that fix.

<!--Dear friend, we, the rest of the NativeScript community thank you for your
contribution! Because we want to present a really nice, readable changelog with each
release, please provide the following information: -->

### Related Pull Requests

https://github.com/NativeScript/android-dts-generator/pull/77

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?

Should not need any new tests as this is just a Gradle build speedup. All existing tests should continue to pass.

