### PR TITLE
fix: make jar files readonly prior to loading

### DIFF
--- a/test-app/runtime/src/main/java/com/tns/DexFactory.java
+++ b/test-app/runtime/src/main/java/com/tns/DexFactory.java
@@ -155,6 +155,7 @@ public class DexFactory {
             out.closeEntry();
             out.close();
         }
+        jarFile.setReadOnly();
 
         Class<?> result;
         DexClassLoader dexClassLoader = new DexClassLoader(jarFilePath, this.odexDir.getAbsolutePath(), null, classLoader);


### PR DESCRIPTION
Fixes targetSdk 34 https://developer.android.com/about/versions/14/behavior-changes-14#safer-dynamic-code-loading