### PR TITLE
feat: migrate to faster maps and use runtime context

### DIFF
--- a/test-app/runtime/src/main/cpp/ArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/ArgConverter.cpp
@@ -200,7 +200,7 @@ ArgConverter::TypeLongOperationsCache* ArgConverter::GetTypeLongCache(v8::Isolat
     auto itFound = s_type_long_operations_cache.find(isolate);
     if (itFound == s_type_long_operations_cache.end()) {
         cache = new TypeLongOperationsCache;
-        s_type_long_operations_cache.insert(make_pair(isolate, cache));
+        s_type_long_operations_cache.emplace(isolate, cache);
     } else {
         cache = itFound->second;
     }
@@ -230,4 +230,4 @@ void ArgConverter::onDisposeIsolate(Isolate* isolate) {
     }
 }
 
-std::map<Isolate*, ArgConverter::TypeLongOperationsCache*> ArgConverter::s_type_long_operations_cache;
+robin_hood::unordered_map<Isolate*, ArgConverter::TypeLongOperationsCache*> ArgConverter::s_type_long_operations_cache;

--- a/test-app/runtime/src/main/cpp/ArgConverter.h
+++ b/test-app/runtime/src/main/cpp/ArgConverter.h
@@ -124,7 +124,7 @@ class ArgConverter {
          * "s_type_long_operations_cache" used to keep function
          * dealing with operations concerning java long -> javascript number.
          */
-        static std::map<v8::Isolate*, TypeLongOperationsCache*> s_type_long_operations_cache;
+        static robin_hood::unordered_map<v8::Isolate*, TypeLongOperationsCache*> s_type_long_operations_cache;
 };
 }
 

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -685,7 +685,8 @@ int CallbackHandlers::RunOnMainThreadFdCallback(int fd, int events, void *data) 
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
     Local<v8::Function> cb = it->second.callback_.Get(isolate);
-    v8::Local<v8::Context> context = cb->GetCreationContextChecked();
+    Runtime* runtime = Runtime::GetRuntime(isolate);
+    v8::Local<v8::Context> context = runtime->GetContext();
     Context::Scope context_scope(context);
     // erase the it here as we're already done with its values and the callback might invalidate the iterator
     cache_.erase(it);
@@ -1025,7 +1026,7 @@ void CallbackHandlers::NewThreadCallback(const v8::FunctionCallbackInfo<v8::Valu
 
         auto persistentWorker = new Persistent<Object>(isolate, thiz);
 
-        id2WorkerMap.insert(make_pair(workerId, persistentWorker));
+        id2WorkerMap.emplace(workerId, persistentWorker);
 
         DEBUG_WRITE("Called Worker constructor id=%d", workerId);
 
@@ -1740,7 +1741,7 @@ std::atomic_uint64_t CallbackHandlers::frameCallbackCount_ = {0};
 
 
 int CallbackHandlers::nextWorkerId = 0;
-std::map<int, Persistent<Object> *> CallbackHandlers::id2WorkerMap;
+robin_hood::unordered_map<int, Persistent<Object> *> CallbackHandlers::id2WorkerMap;
 
 short CallbackHandlers::MAX_JAVA_STRING_ARRAY_LENGTH = 100;
 jclass CallbackHandlers::RUNTIME_CLASS = nullptr;

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include "NativeScriptAssert.h"
 #include "NativeScriptException.h"
+#include "Runtime.h"
 
 namespace tns {
     class CallbackHandlers {
@@ -27,7 +28,7 @@ namespace tns {
          * Stores persistent handles of all 'Worker' objects initialized on the main thread
          * Note: No isolates different than that of the main thread should access this map
          */
-        static std::map<int, v8::Persistent<v8::Object> *> id2WorkerMap;
+        static robin_hood::unordered_map<int, v8::Persistent<v8::Object> *> id2WorkerMap;
 
         static int nextWorkerId;
 
@@ -364,7 +365,8 @@ namespace tns {
                     v8::Isolate::Scope isolate_scope(isolate);
                     v8::HandleScope handle_scope(isolate);
                     v8::Local<v8::Function> cb = entry->callback_.Get(isolate);
-                    v8::Local<v8::Context> context = cb->GetCreationContextChecked();
+                    Runtime* runtime = Runtime::GetRuntime(isolate);
+                    v8::Local<v8::Context> context = runtime->GetContext();
                     v8::Context::Scope context_scope(context);
                     // we're running the callback now, so it's not scheduled anymore
                     entry->markUnscheduled();

--- a/test-app/runtime/src/main/cpp/JEnv.cpp
+++ b/test-app/runtime/src/main/cpp/JEnv.cpp
@@ -769,7 +769,7 @@ jclass JEnv::CheckForClassInCache(const string &className) {
 
 jclass JEnv::InsertClassIntoCache(const string &className, jclass &tmp) {
     auto global_class = reinterpret_cast<jclass>(m_env->NewGlobalRef(tmp));
-    s_classCache.insert(make_pair(className, global_class));
+    s_classCache.emplace(className, global_class);
     m_env->DeleteLocalRef(tmp);
 
     return global_class;
@@ -788,7 +788,7 @@ jthrowable JEnv::CheckForClassMissingCache(const string &className) {
 
 jthrowable JEnv::InsertClassIntoMissingCache(const string &className,const jthrowable &tmp) {
     auto throwable = reinterpret_cast<jthrowable>(m_env->NewGlobalRef(tmp));
-    s_missingClasses.insert(make_pair(className, throwable));
+    s_missingClasses.emplace(className, throwable);
     m_env->DeleteLocalRef(tmp);
 
     return throwable;
@@ -855,8 +855,8 @@ void JEnv::CheckForJavaException() {
 }
 
 JavaVM *JEnv::s_jvm = nullptr;
-map<string, jclass> JEnv::s_classCache;
-map<string, jthrowable> JEnv::s_missingClasses;
+robin_hood::unordered_map<string, jclass> JEnv::s_classCache;
+robin_hood::unordered_map<string, jthrowable> JEnv::s_missingClasses;
 jclass JEnv::RUNTIME_CLASS = nullptr;
 jmethodID JEnv::GET_CACHED_CLASS_METHOD_ID = nullptr;
 

--- a/test-app/runtime/src/main/cpp/JEnv.h
+++ b/test-app/runtime/src/main/cpp/JEnv.h
@@ -2,7 +2,7 @@
 #define JENV_H_
 
 #include "jni.h"
-#include <map>
+#include "robin_hood.h"
 #include <string>
 
 namespace tns {
@@ -342,8 +342,8 @@ class JEnv {
 
         static jmethodID GET_CACHED_CLASS_METHOD_ID;
 
-        static std::map<std::string, jclass> s_classCache;
-        static std::map<std::string, jthrowable> s_missingClasses;
+        static robin_hood::unordered_map<std::string, jclass> s_classCache;
+        static robin_hood::unordered_map<std::string, jthrowable> s_missingClasses;
 };
 }
 

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -97,7 +97,7 @@ MetadataNode* MetadataNode::GetOrCreate(const string& className) {
 
         node = GetOrCreateInternal(treeNode);
 
-        s_name2NodeCache.insert(make_pair(className, node));
+        s_name2NodeCache.emplace(className, node);
     } else {
         node = it->second;
     }
@@ -115,7 +115,7 @@ MetadataNode* MetadataNode::GetOrCreateInternal(MetadataTreeNode* treeNode) {
     } else {
         result = new MetadataNode(treeNode);
 
-        s_treeNode2NodeCache.insert(make_pair(treeNode, result));
+        s_treeNode2NodeCache.emplace(treeNode, result);
     }
 
     return result;
@@ -131,7 +131,7 @@ MetadataTreeNode* MetadataNode::GetOrCreateTreeNodeByName(const string& classNam
     } else {
         result = s_metadataReader.GetOrCreateTreeNodeByName(className);
 
-        s_name2TreeNodeCache.insert(make_pair(className, result));
+        s_name2TreeNodeCache.emplace(className, result);
     }
 
     return result;
@@ -993,7 +993,7 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
         ctorFuncTemplate.Clear();
         auto pft = new Persistent<FunctionTemplate>(isolate, ctorFuncTemplate);
         CtorCacheData ctorCacheItem(pft, instanceMethodsCallbackData);
-        cache->CtorFuncCache.insert(make_pair(treeNode, ctorCacheItem));
+        cache->CtorFuncCache.emplace(treeNode, ctorCacheItem);
         return ctorFuncTemplate;
     }
 
@@ -1060,7 +1060,7 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
    //cache "ctorFuncTemplate"
    auto pft = new Persistent<FunctionTemplate>(isolate, ctorFuncTemplate);
    CtorCacheData ctorCacheItem(pft, instanceMethodsCallbackData);
-   cache->CtorFuncCache.insert(make_pair(treeNode, ctorCacheItem));
+   cache->CtorFuncCache.emplace(treeNode, ctorCacheItem);
 
     SetInnerTypes(isolate, wrappedCtorFunc, treeNode);
 
@@ -1735,11 +1735,11 @@ void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value
         SetTypeMetadata(isolate, extendFunc, new TypeMetadata(fullExtendedName));
         info.GetReturnValue().Set(extendFunc);
 
-        s_name2NodeCache.insert(make_pair(fullExtendedName, node));
+        s_name2NodeCache.emplace(fullExtendedName, node);
 
         ExtendedClassCacheData cacheData(extendFunc, fullExtendedName, node);
         auto cache = GetMetadataNodeCache(isolate);
-        cache->ExtendedCtorFuncCache.insert(make_pair(fullExtendedName, cacheData));
+        cache->ExtendedCtorFuncCache.emplace(fullExtendedName, cacheData);
 
         if (frame.check()) {
             frame.log("Extending: " + node->m_name);
@@ -2027,7 +2027,7 @@ MetadataNode::MetadataNodeCache* MetadataNode::GetMetadataNodeCache(Isolate* iso
     auto itFound = s_metadata_node_cache.find(isolate);
     if (itFound == s_metadata_node_cache.end()) {
         cache = new MetadataNodeCache;
-        s_metadata_node_cache.insert(make_pair(isolate, cache));
+        s_metadata_node_cache.emplace(isolate, cache);
     } else {
         cache = itFound->second;
     }
@@ -2293,10 +2293,10 @@ void MetadataNode::onDisposeIsolate(Isolate* isolate) {
 
 string MetadataNode::TNS_PREFIX = "com/tns/gen/";
 MetadataReader MetadataNode::s_metadataReader;
-std::map<std::string, MetadataNode*> MetadataNode::s_name2NodeCache;
-std::map<std::string, MetadataTreeNode*> MetadataNode::s_name2TreeNodeCache;
-std::map<MetadataTreeNode*, MetadataNode*> MetadataNode::s_treeNode2NodeCache;
-map<Isolate*, MetadataNode::MetadataNodeCache*> MetadataNode::s_metadata_node_cache;
+robin_hood::unordered_map<std::string, MetadataNode*> MetadataNode::s_name2NodeCache;
+robin_hood::unordered_map<std::string, MetadataTreeNode*> MetadataNode::s_name2TreeNodeCache;
+robin_hood::unordered_map<MetadataTreeNode*, MetadataNode*> MetadataNode::s_treeNode2NodeCache;
+robin_hood::unordered_map<Isolate*, MetadataNode::MetadataNodeCache*> MetadataNode::s_metadata_node_cache;
 bool MetadataNode::s_profilerEnabled = false;
-std::map<Isolate*, Persistent<ObjectTemplate>*> MetadataNode::s_arrayObjectTemplates;
+robin_hood::unordered_map<Isolate*, Persistent<ObjectTemplate>*> MetadataNode::s_arrayObjectTemplates;
 

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -170,18 +170,18 @@ class MetadataNode {
                                    PrototypeTemplateFiller& protoFiller);
 
         MetadataTreeNode* m_treeNode;
-        std::map<v8::Isolate*, v8::Persistent<v8::Function>*> m_poCtorCachePerIsolate;
+        robin_hood::unordered_map<v8::Isolate*, v8::Persistent<v8::Function>*> m_poCtorCachePerIsolate;
         std::string m_name;
         std::string m_implType;
         bool m_isArray;
 
         static std::string TNS_PREFIX;
         static MetadataReader s_metadataReader;
-        static std::map<std::string, MetadataNode*> s_name2NodeCache;
-        static std::map<std::string, MetadataTreeNode*> s_name2TreeNodeCache;
-        static std::map<MetadataTreeNode*, MetadataNode*> s_treeNode2NodeCache;
-        static std::map<v8::Isolate*, MetadataNodeCache*> s_metadata_node_cache;
-        static std::map<v8::Isolate*, v8::Persistent<v8::ObjectTemplate>*> s_arrayObjectTemplates;
+        static robin_hood::unordered_map<std::string, MetadataNode*> s_name2NodeCache;
+        static robin_hood::unordered_map<std::string, MetadataTreeNode*> s_name2TreeNodeCache;
+        static robin_hood::unordered_map<MetadataTreeNode*, MetadataNode*> s_treeNode2NodeCache;
+        static robin_hood::unordered_map<v8::Isolate*, MetadataNodeCache*> s_metadata_node_cache;
+        static robin_hood::unordered_map<v8::Isolate*, v8::Persistent<v8::ObjectTemplate>*> s_arrayObjectTemplates;
         static bool s_profilerEnabled;
 
         struct MethodCallbackData {
@@ -263,9 +263,9 @@ class MetadataNode {
         struct MetadataNodeCache {
             v8::Persistent<v8::String>* MetadataKey;
 
-            std::map<MetadataTreeNode*, CtorCacheData> CtorFuncCache;
+            robin_hood::unordered_map<MetadataTreeNode*, CtorCacheData> CtorFuncCache;
 
-            std::map<std::string, MetadataNode::ExtendedClassCacheData> ExtendedCtorFuncCache;
+            robin_hood::unordered_map<std::string, MetadataNode::ExtendedClassCacheData> ExtendedCtorFuncCache;
         };
 };
 }

--- a/test-app/runtime/src/main/cpp/MetadataReader.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataReader.cpp
@@ -178,7 +178,7 @@ string MetadataReader::ReadTypeName(MetadataTreeNode* treeNode) {
     } else {
         name = ReadTypeNameInternal(treeNode);
 
-        m_typeNameCache.insert(make_pair(treeNode, name));
+        m_typeNameCache.emplace(treeNode, name);
     }
 
     return name;

--- a/test-app/runtime/src/main/cpp/MetadataReader.h
+++ b/test-app/runtime/src/main/cpp/MetadataReader.h
@@ -186,7 +186,7 @@ class MetadataReader {
         std::vector<MetadataTreeNode*> m_v;
         GetTypeMetadataCallback m_getTypeMetadataCallback;
 
-        std::map<MetadataTreeNode*, std::string> m_typeNameCache;
+        robin_hood::unordered_map<MetadataTreeNode*, std::string> m_typeNameCache;
 };
 }
 

--- a/test-app/runtime/src/main/cpp/MethodCache.cpp
+++ b/test-app/runtime/src/main/cpp/MethodCache.cpp
@@ -54,7 +54,7 @@ MethodCache::CacheMethodInfo MethodCache::ResolveMethodSignature(const string& c
                               :
                               env.GetMethodID(clazz, methodName, signature);
 
-            s_mthod_ctor_signature_cache.insert(make_pair(encoded_method_signature, method_info));
+            s_mthod_ctor_signature_cache.emplace(encoded_method_signature, method_info);
         }
     } else {
         method_info = (*it).second;
@@ -81,7 +81,7 @@ MethodCache::CacheMethodInfo MethodCache::ResolveConstructorSignature(const Args
             constructor_info.signature = signature;
             constructor_info.mid = env.GetMethodID(javaClass, "<init>", signature);
 
-            s_mthod_ctor_signature_cache.insert(make_pair(encoded_ctor_signature, constructor_info));
+            s_mthod_ctor_signature_cache.emplace(encoded_ctor_signature, constructor_info);
         }
     } else {
         constructor_info = (*it).second;
@@ -261,7 +261,7 @@ string MethodCache::ResolveConstructor(const FunctionCallbackInfo<Value>& args, 
     return resolvedSignature;
 }
 
-map<string, MethodCache::CacheMethodInfo> MethodCache::s_mthod_ctor_signature_cache;
+robin_hood::unordered_map<string, MethodCache::CacheMethodInfo> MethodCache::s_mthod_ctor_signature_cache;
 jclass MethodCache::RUNTIME_CLASS = nullptr;
 jmethodID MethodCache::RESOLVE_METHOD_OVERLOAD_METHOD_ID = nullptr;
 jmethodID MethodCache::RESOLVE_CONSTRUCTOR_SIGNATURE_ID = nullptr;

--- a/test-app/runtime/src/main/cpp/MethodCache.h
+++ b/test-app/runtime/src/main/cpp/MethodCache.h
@@ -59,7 +59,7 @@ class MethodCache {
          *  Used for caching the resolved constructor or method signature.
          * The encoded signature has template: <className>.S/I.<methodName>.<argsCount>.<arg1class>.<...>
          */
-        static std::map<std::string, CacheMethodInfo> s_mthod_ctor_signature_cache;
+        static robin_hood::unordered_map<std::string, CacheMethodInfo> s_mthod_ctor_signature_cache;
 };
 }
 

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -132,7 +132,7 @@ Local<Function> ModuleInternal::GetRequireFunction(Isolate* isolate, const strin
 
         auto poFunc = new Persistent<Function>(isolate, requireFunc);
 
-        m_requireCache.insert(make_pair(dirName, poFunc));
+        m_requireCache.emplace(dirName, poFunc);
     }
 
     return requireFunc;
@@ -446,7 +446,7 @@ Local<Object> ModuleInternal::LoadData(Isolate* isolate, const string& path) {
 
     auto poObj = new Persistent<Object>(isolate, json);
 
-    m_loadedModules.insert(make_pair(path, ModuleCacheEntry(poObj, true /* isData */)));
+    m_loadedModules.emplace(path, ModuleCacheEntry(poObj, true /* isData */));
 
     return json;
 }

--- a/test-app/runtime/src/main/cpp/NetworkAgentImpl.h
+++ b/test-app/runtime/src/main/cpp/NetworkAgentImpl.h
@@ -60,7 +60,7 @@ class NetworkAgentImpl : public protocol::Network::Backend {
 
         static NetworkAgentImpl* Instance;
         protocol::Network::Frontend m_frontend;
-        std::map<std::string, utils::NetworkRequestData*> m_responses;
+        robin_hood::unordered_map<std::string, utils::NetworkRequestData*> m_responses;
 
     private:
         V8InspectorSessionImpl* m_session;

--- a/test-app/runtime/src/main/cpp/ObjectManager.cpp
+++ b/test-app/runtime/src/main/cpp/ObjectManager.cpp
@@ -263,7 +263,7 @@ void ObjectManager::Link(const Local<Object> &object, uint32_t javaObjectID, jcl
     //link
     object->SetInternalField(jsInfoIdx, jsInfo);
 
-    m_idToObject.insert(make_pair(javaObjectID, objectHandle));
+    m_idToObject.emplace(javaObjectID, objectHandle);
 }
 
 bool ObjectManager::CloneLink(const Local<Object> &src, const Local<Object> &dest) {
@@ -384,7 +384,7 @@ void ObjectManager::JSObjectWeakCallback(Isolate *isolate, ObjectWeakCallbackSta
                 if (jsInstanceInfo->IsJavaObjectWeak) {
                     m_implObjWeak.emplace_back(po, javaObjectID);
                 } else {
-                    m_implObjStrong.insert(make_pair(javaObjectID, po));
+                    m_implObjStrong.emplace(javaObjectID, po);
                     jsInstanceInfo->IsJavaObjectWeak = true;
                 }
             } else {

--- a/test-app/runtime/src/main/cpp/PageAgentImpl.cpp
+++ b/test-app/runtime/src/main/cpp/PageAgentImpl.cpp
@@ -105,7 +105,7 @@ void PageAgentImpl::getResourceContent(const String& in_frameId, const String& i
         return;
     }
 
-    std::map<std::string, utils::PageResource> cachedPageResources = utils::PageResource::s_cachedPageResources;
+    robin_hood::unordered_map<std::string, utils::PageResource> cachedPageResources = utils::PageResource::s_cachedPageResources;
     if (utils::PageResource::s_cachedPageResources.size() == 0) {
         cachedPageResources = utils::PageResource::getPageResources();
     }
@@ -136,7 +136,7 @@ void PageAgentImpl::searchInResource(const String& in_frameId, const String& in_
     bool isRegex = in_isRegex.fromMaybe(false);
     bool isCaseSensitive = in_caseSensitive.fromMaybe(false);
 
-    std::map<std::string, utils::PageResource> cachedPageResources = utils::PageResource::s_cachedPageResources;
+    robin_hood::unordered_map<std::string, utils::PageResource> cachedPageResources = utils::PageResource::s_cachedPageResources;
     if (utils::PageResource::s_cachedPageResources.size() == 0) {
         cachedPageResources = utils::PageResource::getPageResources();
     }

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -98,7 +98,7 @@ Runtime::Runtime(JNIEnv* env, jobject runtime, int id)
     m_runtime = env->NewGlobalRef(runtime);
     m_objectManager = new ObjectManager(m_runtime);
     m_loopTimer = new MessageLoopTimer();
-    s_id2RuntimeCache.insert(make_pair(id, this));
+    s_id2RuntimeCache.emplace(id, this);
 
     if (GET_USED_MEMORY_METHOD_ID == nullptr) {
         auto RUNTIME_CLASS = env->FindClass("com/tns/Runtime");
@@ -692,8 +692,8 @@ int Runtime::GetReader(){
 
 JavaVM* Runtime::s_jvm = nullptr;
 jmethodID Runtime::GET_USED_MEMORY_METHOD_ID = nullptr;
-map<int, Runtime*> Runtime::s_id2RuntimeCache;
-unordered_map<Isolate*, Runtime*> Runtime::s_isolate2RuntimesCache;
+robin_hood::unordered_map<int, Runtime*> Runtime::s_id2RuntimeCache;
+robin_hood::unordered_map<Isolate*, Runtime*> Runtime::s_isolate2RuntimesCache;
 bool Runtime::s_mainThreadInitialized = false;
 v8::Platform* Runtime::platform = nullptr;
 int Runtime::m_androidVersion = Runtime::GetAndroidVersion();

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -114,9 +114,9 @@ class Runtime {
         static int GetAndroidVersion();
         static int m_androidVersion;
 
-        static std::map<int, Runtime*> s_id2RuntimeCache;
+        static robin_hood::unordered_map<int, Runtime*> s_id2RuntimeCache;
 
-        static std::unordered_map<v8::Isolate*, Runtime*> s_isolate2RuntimesCache;
+        static robin_hood::unordered_map<v8::Isolate*, Runtime*> s_isolate2RuntimesCache;
 
         static JavaVM* s_jvm;
 

--- a/test-app/runtime/src/main/cpp/Timers.cpp
+++ b/test-app/runtime/src/main/cpp/Timers.cpp
@@ -294,7 +294,8 @@ int Timers::PumpTimerLoopCallback(int fd, int events, void *data) {
             thiz->addTask(task);
         }
         v8::Local<v8::Function> cb = task->callback_.Get(isolate);
-        v8::Local<v8::Context> context = cb->GetCreationContextChecked();
+        Runtime* runtime = Runtime::GetRuntime(isolate);
+        v8::Local<v8::Context> context = runtime->GetContext();
         Context::Scope context_scope(context);
         TryCatch tc(isolate);
         auto argc = task->args_.get() == nullptr ? 0 : task->args_->size();

--- a/test-app/runtime/src/main/cpp/Timers.h
+++ b/test-app/runtime/src/main/cpp/Timers.h
@@ -6,6 +6,7 @@
 #include "ObjectManager.h"
 #include "condition_variable"
 #include "thread"
+#include "robin_hood.h"
 
 namespace tns {
     /**
@@ -113,7 +114,7 @@ namespace tns {
         int currentTimerId = 0;
         int nesting = 0;
         // stores the map of timer tasks
-        std::map<int, std::shared_ptr<TimerTask>> timerMap_;
+        robin_hood::unordered_map<int, std::shared_ptr<TimerTask>> timerMap_;
         std::vector<std::shared_ptr<TimerReference>> sortedTimers_;
         // sets are faster than vector iteration
         // so we use this to avoid redundant isolate locks and we don't care about the

--- a/test-app/runtime/src/main/cpp/V8GlobalHelpers.cpp
+++ b/test-app/runtime/src/main/cpp/V8GlobalHelpers.cpp
@@ -5,11 +5,12 @@
 #include "JEnv.h"
 #include "NativeScriptException.h"
 #include <sstream>
+#include "robin_hood.h"
 
 using namespace v8;
 using namespace std;
 
-static std::map<v8::Isolate*, v8::Persistent<v8::Function>*> isolateToPersistentSmartJSONStringify = std::map<v8::Isolate*, v8::Persistent<v8::Function>*>();
+static robin_hood::unordered_map<v8::Isolate*, v8::Persistent<v8::Function>*> isolateToPersistentSmartJSONStringify = robin_hood::unordered_map<v8::Isolate*, v8::Persistent<v8::Function>*>();
 
 Local<Function> GetSmartJSONStringifyFunction(Isolate* isolate) {
     auto it = isolateToPersistentSmartJSONStringify.find(isolate);
@@ -61,7 +62,7 @@ Local<Function> GetSmartJSONStringifyFunction(Isolate* isolate) {
 
     auto smartStringifyPersistentFunction = new Persistent<Function>(isolate, smartStringifyFunction);
 
-    isolateToPersistentSmartJSONStringify.insert(std::make_pair(isolate, smartStringifyPersistentFunction));
+    isolateToPersistentSmartJSONStringify.emplace(isolate, smartStringifyPersistentFunction);
 
     return smartStringifyPersistentFunction->Get(isolate);
 }


### PR DESCRIPTION
switch most maps to robin hood for better performance. We also remove the getCreationContext calls because they can hard crash under some circumstances