### PR TITLE
[jsparser]: report webpack failure

### DIFF
--- a/test-app/build-tools/jsparser/js_parser.js
+++ b/test-app/build-tools/jsparser/js_parser.js
@@ -194,6 +194,9 @@ function traverseAndAnalyseFilesDir(inputDir, err) {
 }
 
 function traverseFiles(filesToTraverse) {
+  if (filesToTraverse.length === 0) {
+    throw "no file was found in " + inputDir + ". Something must be wrong with the webpack build";
+  }
   for (let i = 0; i < filesToTraverse.length; i += 1) {
     const fp = filesToTraverse[i];
     logger.info("Visiting JavaScript file: " + fp);


### PR DESCRIPTION
If there was an error during webpack build (like output being wrong) then jsparser was returning without error causing the next build step to fail without real explanation

<!--Dear friend, we, the rest of the NativeScript community thank you for your
contribution! Because we want to present a really nice, readable changelog with each
release, please provide the following information: -->

### Create a meaningful title
<!-- Please, ensure your title is less than 50 characters and starts with a capital letter. We strive to follow the guidelines in the
[How to Write a Git Commit Message] (http://chris.beams.io/posts/git-commit/) article for PR titles. -->

### Description

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[Issue Number]. -->

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->

