### PR TITLE
fix: support 16 KB page sizes

### DIFF
--- a/test-app/gradle.properties
+++ b/test-app/gradle.properties
@@ -19,10 +19,10 @@ android.enableJetifier=true
 android.useAndroidX=true
 
 # Default versions used throughout the gradle configurations
-NS_DEFAULT_BUILD_TOOLS_VERSION=34.0.0
-NS_DEFAULT_COMPILE_SDK_VERSION=34
+NS_DEFAULT_BUILD_TOOLS_VERSION=35.0.0
+NS_DEFAULT_COMPILE_SDK_VERSION=35
 NS_DEFAULT_MIN_SDK_VERSION=17
-NS_DEFAULT_ANDROID_BUILD_TOOLS_VERSION=8.3.2
+NS_DEFAULT_ANDROID_BUILD_TOOLS_VERSION=8.5.0
 
 ns_default_androidx_appcompat_version = 1.5.1
 ns_default_androidx_exifinterface_version = 1.3.7

--- a/test-app/gradle/wrapper/gradle-wrapper.properties
+++ b/test-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -182,6 +182,11 @@ if("${ANDROID_ABI}" MATCHES "armeabi-v7a$" OR "${ANDROID_ABI}" MATCHES "x86$")
     target_link_libraries(NativeScript ${ANDROID_NDK_ROOT}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}/libandroid_support.a)
 endif()
 
+
+if("${ANDROID_ABI}" MATCHES "arm64-v8a$" OR "${ANDROID_ABI}" MATCHES "x86_64$")
+    target_link_options(NativeScript PRIVATE "-Wl,-z,max-page-size=16384")
+endif()
+
 # Command info: https://cmake.org/cmake/help/v3.4/command/find_library.html
 # Searches for a specified prebuilt library and stores the path as a
 # variable. Because CMake includes system libraries in the search path by

--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -114,7 +114,7 @@ android {
 //                arguments "-DANDROID_TOOLCHAIN=clang", "-DANDROID_STL=c++_static", "-DANDROID_NDK_ROOT=${NDK_PATH}"
 
                 cppFlags "-std=c++14"
-                arguments "-DANDROID_STL=c++_shared", "-DANDROID_NDK_ROOT=${NDK_PATH}"
+                arguments "-DANDROID_STL=c++_static", "-DANDROID_NDK_ROOT=${NDK_PATH}"
             }
         }
 


### PR DESCRIPTION
- Enables [support for 16KB page sizes](https://developer.android.com/guide/practices/page-sizes).
- Bumps gradle to 8.5, this also switches `ANDROID_STL` to `static` so the lib size will increase. 
This is the only way to keep the min API below 21 until the next major.
- CompileSdk 35