### PR TITLE
fix: `exit(0)` causes ANR due to destroyed mutex

### DIFF
--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1918,7 +1918,7 @@ void MetadataNode::BuildMetadata(const string& filesPath) {
             // startup because the receiver is triggered.  So even though we are exiting, the receiver will have
             // done its job
 
-            exit(0);
+            _Exit(0);
         }
         else {
           throw NativeScriptException(ss.str());


### PR DESCRIPTION
### Description

When initializing the runtime in direct boot mode the `exit(0)` IO cleanup causes a `SIGABRT` with the following message:
```
libc    : FORTIFY: pthread_mutex_destroy called on a destroyed mutex (0x759399de1718)
```

This `SIGABRT` is caught by the `SIG_handler` which in turn throws a `tsn::NativeScriptException`. I'm not exactly sure what catches this `NativeScriptException`, but whatever it is either deadlocks or keeps re-throwing it until the device runs out of memory.

https://github.com/NativeScript/android/blob/ba50f0337c407a51121fe6fd310c6289eb3e3796/test-app/runtime/src/main/cpp/Runtime.cpp#L49-L66

This bug shows up as an ANR (App not responding) in Crashlytics and Google Play console (as reported in https://github.com/NativeScript/NativeScript/issues/10527).

The same issue was reported on https://github.com/flutter/flutter/issues/103587, which leads me to believe this is not specific to Nativescript's runtime.

My proposed solution is to use `_Exit(0)` instead, which doesn't trigger any cleanup process and simply ends the process.

Full error below:
```
08-28 13:56:32.187  1506  1506 D TNS.Runtime: V8 version 10.3.22
08-28 13:56:32.191  1506  1506 E TNS.error: metadata folder couldn't be opened! (Error: 2) 
--------- beginning of crash
08-28 13:56:32.191  1506  1506 F libc    : FORTIFY: pthread_mutex_destroy called on a destroyed mutex (0x759399de1718)
08-28 13:56:32.191  1506  1506 F TNS.Native: JNI Exception occurred (SIGABRT).
08-28 13:56:32.191  1506  1506 F TNS.Native: =======
08-28 13:56:32.191  1506  1506 F TNS.Native: Check the 'adb logcat' for additional information about the error.
08-28 13:56:32.191  1506  1506 F TNS.Native: =======
08-28 13:56:32.191  1506  1506 E libc++abi: terminating with uncaught exception of type tns::NativeScriptException
```

### Related Pull Requests
https://github.com/NativeScript/android/pull/1712
https://github.com/NativeScript/plugins/issues/262
https://github.com/NativeScript/NativeScript/issues/10527

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->

