### PR TITLE
fix: generate correct metadata when overflowing signed short values

### DIFF
--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
@@ -27,6 +27,8 @@ public class Generator {
     private static final String MDG_BLACKLIST = "blacklist.mdg";
     private static final String METADATA_JAVA_OUT = "mdg-java-out.txt";
 
+    private static boolean verbose_mode = false;
+
     /**
      * @param args arguments
      */
@@ -69,7 +71,13 @@ public class Generator {
             FileOutputStream oss = new FileOutputStream(new File(metadataOutputDir, "treeStringsStream.dat"));
             FileStreamWriter outStringsStream = new FileStreamWriter(oss);
 
-            new Writer(outNodeStream, outValueStream, outStringsStream).writeTree(root);
+            if (verbose_mode) {
+                FileOutputStream ods = new FileOutputStream(new File("metadata-debug.json"));
+                FileStreamWriter outDebugStream = new FileStreamWriter(ods);
+                new Writer(outNodeStream, outValueStream, outStringsStream, outDebugStream).writeTree(root);
+            } else {
+                new Writer(outNodeStream, outValueStream, outStringsStream).writeTree(root);
+            }
         } catch (Throwable ex) {
             System.err.println(String.format("Error executing Metadata Generator: %s", ex.getMessage()));
             ex.printStackTrace(System.out);
@@ -83,6 +91,7 @@ public class Generator {
                 String filePath = arg.replace(ANALYTICS_ARGUMENT_BEGINNING, "");
                 AnalyticsConfiguration.enableAnalytics(filePath);
             } else if (VERBOSE_FLAG_NAME.equals(arg)) {
+                verbose_mode = true;
                 MetadataFilterConsoleLogger.INSTANCE.setEnabled(true);
             } else if (SKIP_FLAG_NAME.equals(arg)) {
                 System.out.println("Skipping metadata generation: skip flag used.");


### PR DESCRIPTION
Follow up of https://github.com/NativeScript/android/pull/1749

What I initally identified as some kind of circular reference is the children turned out to be the result of a wrong short -> unsigned short translation in the metadata generator.

It's impossible for the metadata generator to generate a `nextSiblingId` that is smaller than the actual node id. As such, this PR adds a few protections in place:

1. We fix the combination of 2 unsigned shorts into a single int
2. If we're ever close to overflowing these shorts, the metadata will error out. We should re-evaluate wheter or not we should use 32 bit numbers for this, as that increases the metadata overall size
3. When in debug mode (--log trace) we now generate a json with all the contents of the binary file.
4. If we ever get into this situation again, the runtime will log this error so the user can provide the error combined with the previously mentioned debug json for us to fix.