### PR TITLE
Improve performance of generating JS class from Metadata

### DIFF
--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(
         src/main/cpp/MetadataNode.cpp
         src/main/cpp/MetadataReader.cpp
         src/main/cpp/MetadataTreeNode.cpp
+        src/main/cpp/MetadataEntry.cpp
         src/main/cpp/MethodCache.cpp
         src/main/cpp/ModuleBinding.cpp
         src/main/cpp/ModuleInternal.cpp

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -210,10 +210,11 @@ void CallbackHandlers::CallJavaMethod(const Local<Object> &caller, const string 
     string *returnType = nullptr;
     auto retType = MethodReturnType::Unknown;
     MethodCache::CacheMethodInfo mi;
+    auto &entrySignature = entry->getSig();
 
     auto isolate = args.GetIsolate();
 
-    if ((entry != nullptr) && entry->isResolved) {
+    if ((entry != nullptr) && entry->getIsResolved()) {
         isStatic = entry->isStatic;
 
         if (entry->memberId == nullptr) {
@@ -236,14 +237,14 @@ void CallbackHandlers::CallJavaMethod(const Local<Object> &caller, const string 
                     if (isFromInterface) {
                         auto methodAndClassPair = env.GetInterfaceStaticMethodIDAndJClass(className,
                                                                                           methodName,
-                                                                                          entry->sig);
+                                                                                          entrySignature);
                         entry->memberId = methodAndClassPair.first;
                         clazz = methodAndClassPair.second;
                     } else {
-                        entry->memberId = env.GetStaticMethodID(clazz, methodName, entry->sig);
+                        entry->memberId = env.GetStaticMethodID(clazz, methodName, entrySignature);
                     }
                 } else {
-                    entry->memberId = env.GetMethodID(clazz, methodName, entry->sig);
+                    entry->memberId = env.GetMethodID(clazz, methodName, entrySignature);
                 }
 
                 if (entry->memberId == nullptr) {
@@ -257,14 +258,14 @@ void CallbackHandlers::CallJavaMethod(const Local<Object> &caller, const string 
                     if (isFromInterface) {
                         auto methodAndClassPair = env.GetInterfaceStaticMethodIDAndJClass(className,
                                                                                           methodName,
-                                                                                          entry->sig);
+                                                                                          entrySignature);
                         entry->memberId = methodAndClassPair.first;
                         clazz = methodAndClassPair.second;
                     } else {
-                        entry->memberId = env.GetStaticMethodID(clazz, methodName, entry->sig);
+                        entry->memberId = env.GetStaticMethodID(clazz, methodName, entrySignature);
                     }
                 } else {
-                    entry->memberId = env.GetMethodID(clazz, methodName, entry->sig);
+                    entry->memberId = env.GetMethodID(clazz, methodName, entrySignature);
                 }
 
                 if (entry->memberId == nullptr) {
@@ -279,9 +280,9 @@ void CallbackHandlers::CallJavaMethod(const Local<Object> &caller, const string 
 
         mid = reinterpret_cast<jmethodID>(entry->memberId);
         clazz = entry->clazz;
-        sig = &entry->sig;
-        returnType = &entry->returnType;
-        retType = entry->retType;
+        sig = &entrySignature;
+        returnType = &entry->getReturnType();
+        retType = entry->getRetType();
     } else {
         DEBUG_WRITE("Resolving method: %s on className %s", methodName.c_str(), className.c_str());
 

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -210,11 +210,11 @@ void CallbackHandlers::CallJavaMethod(const Local<Object> &caller, const string 
     string *returnType = nullptr;
     auto retType = MethodReturnType::Unknown;
     MethodCache::CacheMethodInfo mi;
-    auto &entrySignature = entry->getSig();
 
     auto isolate = args.GetIsolate();
 
     if ((entry != nullptr) && entry->getIsResolved()) {
+        auto &entrySignature = entry->getSig();
         isStatic = entry->isStatic;
 
         if (entry->memberId == nullptr) {

--- a/test-app/runtime/src/main/cpp/FieldAccessor.cpp
+++ b/test-app/runtime/src/main/cpp/FieldAccessor.cpp
@@ -19,10 +19,10 @@ Local<Value> FieldAccessor::GetJavaField(Isolate* isolate, const Local<Object>& 
 
     JniLocalRef targetJavaObject;
 
-    auto fieldMetadata = fieldData->metadata;
+    auto &fieldMetadata = fieldData->metadata;
 
-    const auto& fieldTypeName = fieldMetadata->getSig();
-    auto isStatic = fieldMetadata->isStatic;
+    const auto& fieldTypeName = fieldMetadata.getSig();
+    auto isStatic = fieldMetadata.isStatic;
 
     auto isPrimitiveType = fieldTypeName.size() == 1;
     auto isFieldArray = fieldTypeName[0] == '[';
@@ -37,11 +37,11 @@ Local<Value> FieldAccessor::GetJavaField(Isolate* isolate, const Local<Object>& 
                             ("L" + fieldTypeName + ";"));
 
         if (isStatic) {
-            fieldData->clazz = env.FindClass(fieldMetadata->getDeclaringType());
-            fieldData->fid = env.GetStaticFieldID(fieldData->clazz, fieldMetadata->name, fieldJniSig);
+            fieldData->clazz = env.FindClass(fieldMetadata.getDeclaringType());
+            fieldData->fid = env.GetStaticFieldID(fieldData->clazz, fieldMetadata.name, fieldJniSig);
         } else {
-            fieldData->clazz = env.FindClass(fieldMetadata->getDeclaringType());
-            fieldData->fid = env.GetFieldID(fieldData->clazz, fieldMetadata->name, fieldJniSig);
+            fieldData->clazz = env.FindClass(fieldMetadata.getDeclaringType());
+            fieldData->fid = env.GetFieldID(fieldData->clazz, fieldMetadata.name, fieldJniSig);
         }
     }
 
@@ -50,7 +50,7 @@ Local<Value> FieldAccessor::GetJavaField(Isolate* isolate, const Local<Object>& 
 
         if (targetJavaObject.IsNull()) {
             stringstream ss;
-            ss << "Cannot access property '" << fieldMetadata->name.c_str() << "' because there is no corresponding Java object";
+            ss << "Cannot access property '" << fieldMetadata.name.c_str() << "' because there is no corresponding Java object";
             throw NativeScriptException(ss.str());
         }
     }
@@ -188,7 +188,7 @@ Local<Value> FieldAccessor::GetJavaField(Isolate* isolate, const Local<Object>& 
 void FieldAccessor::SetJavaField(Isolate* isolate, const Local<Object>& target, const Local<Value>& value, FieldCallbackData* fieldData) {
     JEnv env;
 
-    auto fieldMetadata = fieldData->metadata;
+    auto &fieldMetadata = fieldData->metadata;
 
     HandleScope handleScope(isolate);
     auto runtime = Runtime::GetRuntime(isolate);
@@ -196,8 +196,8 @@ void FieldAccessor::SetJavaField(Isolate* isolate, const Local<Object>& target, 
 
     JniLocalRef targetJavaObject;
 
-    const auto& fieldTypeName = fieldMetadata->getSig();
-    auto isStatic = fieldMetadata->isStatic;
+    const auto& fieldTypeName = fieldMetadata.getSig();
+    auto isStatic = fieldMetadata.isStatic;
 
 
     auto isPrimitiveType = fieldTypeName.size() == 1;
@@ -213,14 +213,14 @@ void FieldAccessor::SetJavaField(Isolate* isolate, const Local<Object>& target, 
                             ("L" + fieldTypeName + ";"));
 
         if (isStatic) {
-            fieldData->clazz = env.FindClass(fieldMetadata->getDeclaringType());
+            fieldData->clazz = env.FindClass(fieldMetadata.getDeclaringType());
             assert(fieldData->clazz != nullptr);
-            fieldData->fid = env.GetStaticFieldID(fieldData->clazz, fieldMetadata->name, fieldJniSig);
+            fieldData->fid = env.GetStaticFieldID(fieldData->clazz, fieldMetadata.name, fieldJniSig);
             assert(fieldData->fid != nullptr);
         } else {
-            fieldData->clazz = env.FindClass(fieldMetadata->getDeclaringType());
+            fieldData->clazz = env.FindClass(fieldMetadata.getDeclaringType());
             assert(fieldData->clazz != nullptr);
-            fieldData->fid = env.GetFieldID(fieldData->clazz, fieldMetadata->name, fieldJniSig);
+            fieldData->fid = env.GetFieldID(fieldData->clazz, fieldMetadata.name, fieldJniSig);
             assert(fieldData->fid != nullptr);
         }
     }
@@ -230,7 +230,7 @@ void FieldAccessor::SetJavaField(Isolate* isolate, const Local<Object>& target, 
 
         if (targetJavaObject.IsNull()) {
             stringstream ss;
-            ss << "Cannot access property '" << fieldMetadata->name.c_str() << "' because there is no corresponding Java object";
+            ss << "Cannot access property '" << fieldMetadata.name.c_str() << "' because there is no corresponding Java object";
             throw NativeScriptException(ss.str());
         }
     }

--- a/test-app/runtime/src/main/cpp/FieldCallbackData.h
+++ b/test-app/runtime/src/main/cpp/FieldCallbackData.h
@@ -6,13 +6,12 @@
 
 namespace tns {
     struct FieldCallbackData {
-        FieldCallbackData(MetadataEntry *metadata)
+        FieldCallbackData(MetadataEntry metadata)
                 :
                 metadata(metadata), fid(nullptr), clazz(nullptr) {
-
         }
 
-        MetadataEntry* metadata;
+        MetadataEntry metadata;
         jfieldID fid;
         jclass clazz;
     };

--- a/test-app/runtime/src/main/cpp/FieldCallbackData.h
+++ b/test-app/runtime/src/main/cpp/FieldCallbackData.h
@@ -5,25 +5,17 @@
 #include "MetadataEntry.h"
 
 namespace tns {
-struct FieldCallbackData {
-    FieldCallbackData(const MetadataEntry& metadata)
-        :
-        fid(nullptr), clazz(nullptr) {
-        name = metadata.name;
-        signature = metadata.sig;
-        declaringType = metadata.declaringType;
-        isStatic = metadata.isStatic;
-        isFinal = metadata.isFinal;
-    }
+    struct FieldCallbackData {
+        FieldCallbackData(MetadataEntry *metadata)
+                :
+                metadata(metadata), fid(nullptr), clazz(nullptr) {
 
-    std::string name;
-    std::string signature;
-    std::string declaringType;
-    bool isStatic;
-    bool isFinal;
-    jfieldID fid;
-    jclass clazz;
-};
+        }
+
+        MetadataEntry* metadata;
+        jfieldID fid;
+        jclass clazz;
+    };
 
 }
 

--- a/test-app/runtime/src/main/cpp/JsArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/JsArgConverter.cpp
@@ -23,7 +23,7 @@ JsArgConverter::JsArgConverter(const Local<Object> &caller,
     m_argsLen = 1 + v8ProvidedArgumentsLength;
 
     if (m_argsLen > 0) {
-        if ((entry != nullptr) && (entry->isResolved)) {
+        if ((entry != nullptr) && (entry->getIsResolved())) {
             if (entry->parsedSig.empty()) {
                 JniSignatureParser parser(m_methodSignature);
                 entry->parsedSig = parser.Parse();
@@ -58,7 +58,7 @@ JsArgConverter::JsArgConverter(const v8::FunctionCallbackInfo<Value> &args,
     m_argsLen = !hasImplementationObject ? args.Length() : args.Length() - 1;
 
     if (m_argsLen > 0) {
-        if ((entry != nullptr) && (entry->isResolved)) {
+        if ((entry != nullptr) && (entry->getIsResolved())) {
             if (entry->parsedSig.empty()) {
                 JniSignatureParser parser(m_methodSignature);
                 entry->parsedSig = parser.Parse();

--- a/test-app/runtime/src/main/cpp/MetadataEntry.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataEntry.cpp
@@ -1,0 +1,133 @@
+#include  "MetadataNode.h"
+#include "MetadataEntry.h"
+#include "MetadataMethodInfo.h"
+#include "MetadataReader.h"
+
+using namespace tns;
+
+MetadataEntry::MetadataEntry(MetadataTreeNode *m_treeNode, NodeType nodeType) :
+        treeNode(m_treeNode), type(nodeType), isExtensionFunction(false), isStatic(false),
+        isTypeMember(false), memberId(nullptr), clazz(nullptr), mi(nullptr),fi(nullptr), sfi(nullptr),
+        retType(MethodReturnType::Unknown),
+        paramCount(-1), isFinal(false), isResolved(false), retTypeParsed(false),
+        isFinalSet(false), isResolvedSet(false) {}
+
+std::string &MetadataEntry::getName() {
+    if (!name.empty()) return name;
+
+    auto reader = MetadataNode::getMetadataReader();
+
+    if (type == NodeType::Field) {
+        name = reader->ReadName(fi->nameOffset);
+    } else if (type == NodeType::StaticField) {
+        name = reader->ReadName(sfi->nameOffset);
+    } else if (type == NodeType::Method) {
+        name = mi->GetName();
+    }
+
+    return name;
+}
+
+std::string &MetadataEntry::getSig() {
+    if (!sig.empty()) return sig;
+
+    auto reader = MetadataNode::getMetadataReader();
+
+    if (type == NodeType::Field) {
+        sig = reader->ReadTypeName(fi->nodeId);
+    } else if (type == NodeType::StaticField) {
+        sig = reader->ReadTypeName(sfi->nodeId);
+    } else if (type == NodeType::Method) {
+        uint8_t sigLength = mi->GetSignatureLength();
+        if (sigLength > 0)
+            sig = mi->GetSignature();
+
+    }
+
+    return sig;
+}
+
+std::string &MetadataEntry::getReturnType() {
+    if (!returnType.empty()) return returnType;
+
+    auto reader = MetadataNode::getMetadataReader();
+
+    if (type == NodeType::Method) {
+        if (mi->GetSignatureLength() > 0) {
+            returnType = MetadataReader::ParseReturnType(this->getSig());
+        }
+    } else {
+        return returnType;
+    }
+
+    return returnType;
+}
+
+MethodReturnType MetadataEntry::getRetType() {
+    if (retTypeParsed) return retType;
+    auto reader = MetadataNode::getMetadataReader();
+
+    if (type == NodeType::Method && !this->getReturnType().empty()) {
+        retType = MetadataReader::GetReturnType(this->getReturnType());
+    }
+
+    retTypeParsed = true;
+
+    return retType;
+}
+
+std::string &MetadataEntry::getDeclaringType() {
+    if (!declaringType.empty()) return declaringType;
+
+    auto reader = MetadataNode::getMetadataReader();
+
+    if (type == NodeType::StaticField) {
+        declaringType = reader->ReadTypeName(sfi->declaringType);
+    }
+
+    return declaringType;
+}
+
+int MetadataEntry::getParamCount() {
+    if (paramCount != -1) return paramCount;
+
+    auto reader = MetadataNode::getMetadataReader();
+
+    if (type == NodeType::Method) {
+        auto sigLength = mi->GetSignatureLength();
+        if (sigLength > 0) {
+            paramCount = sigLength - 1;
+        } else {
+            paramCount = 0;
+        }
+    }
+
+    return paramCount;
+}
+
+bool MetadataEntry::getIsFinal() {
+    if (isFinalSet) return isFinal;
+
+    if (type == NodeType::Field) {
+        isFinal = fi->finalModifier == MetadataTreeNode::FINAL;
+    } else if (type == NodeType::StaticField) {
+        isFinal = sfi->finalModifier == MetadataTreeNode::FINAL;
+    }
+
+    isFinalSet = true;
+
+    return isFinal;
+}
+
+bool MetadataEntry::getIsResolved() {
+    if (isResolvedSet) return isResolved;
+
+    auto reader = MetadataNode::getMetadataReader();
+    if (type == NodeType::Method) {
+        isResolved = mi->CheckIsResolved() == 1;
+    }
+
+    isResolvedSet = true;
+
+    return isResolved;
+}

--- a/test-app/runtime/src/main/cpp/MetadataEntry.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataEntry.cpp
@@ -22,7 +22,7 @@ std::string &MetadataEntry::getName() {
     } else if (type == NodeType::StaticField) {
         name = reader->ReadName(sfi->nameOffset);
     } else if (type == NodeType::Method) {
-        name = mi->GetName();
+        name = mi.GetName();
     }
 
     return name;
@@ -38,9 +38,9 @@ std::string &MetadataEntry::getSig() {
     } else if (type == NodeType::StaticField) {
         sig = reader->ReadTypeName(sfi->nodeId);
     } else if (type == NodeType::Method) {
-        uint8_t sigLength = mi->GetSignatureLength();
+        uint8_t sigLength = mi.GetSignatureLength();
         if (sigLength > 0)
-            sig = mi->GetSignature();
+            sig = mi.GetSignature();
 
     }
 
@@ -53,7 +53,7 @@ std::string &MetadataEntry::getReturnType() {
     auto reader = MetadataNode::getMetadataReader();
 
     if (type == NodeType::Method) {
-        if (mi->GetSignatureLength() > 0) {
+        if (mi.GetSignatureLength() > 0) {
             returnType = MetadataReader::ParseReturnType(this->getSig());
         }
     } else {
@@ -68,7 +68,7 @@ MethodReturnType MetadataEntry::getRetType() {
     auto reader = MetadataNode::getMetadataReader();
 
     if (type == NodeType::Method && !this->getReturnType().empty()) {
-        retType = MetadataReader::GetReturnType(this->getReturnType());
+        retType = MetadataReader::GetReturnType(this->returnType);
     }
 
     retTypeParsed = true;
@@ -83,6 +83,8 @@ std::string &MetadataEntry::getDeclaringType() {
 
     if (type == NodeType::StaticField) {
         declaringType = reader->ReadTypeName(sfi->declaringType);
+    } else if (type == NodeType::Method && isStatic) {
+        declaringType = mi.GetDeclaringType();
     }
 
     return declaringType;
@@ -94,7 +96,7 @@ int MetadataEntry::getParamCount() {
     auto reader = MetadataNode::getMetadataReader();
 
     if (type == NodeType::Method) {
-        auto sigLength = mi->GetSignatureLength();
+        auto sigLength = mi.GetSignatureLength();
         if (sigLength > 0) {
             paramCount = sigLength - 1;
         } else {
@@ -124,7 +126,7 @@ bool MetadataEntry::getIsResolved() {
 
     auto reader = MetadataNode::getMetadataReader();
     if (type == NodeType::Method) {
-        isResolved = mi->CheckIsResolved() == 1;
+        isResolved = mi.CheckIsResolved() == 1;
     }
 
     isResolvedSet = true;

--- a/test-app/runtime/src/main/cpp/MetadataEntry.h
+++ b/test-app/runtime/src/main/cpp/MetadataEntry.h
@@ -4,56 +4,77 @@
 #include <string>
 #include "jni.h"
 #include "MetadataTreeNode.h"
+#include "MetadataMethodInfo.h"
+#include "MetadataFieldInfo.h"
 
 namespace tns {
-enum class NodeType {
-    Package,
-    Class,
-    Interface,
-    Method,
-    Field,
-    StaticField
-};
+    enum class NodeType {
+        Package,
+        Class,
+        Interface,
+        Method,
+        Field,
+        StaticField
+    };
 
-enum class MethodReturnType {
-    Unknown,
-    Void,
-    Byte,
-    Short,
-    Int,
-    Long,
-    Float,
-    Double,
-    Char,
-    Boolean,
-    String,
-    Object
-};
+    enum class MethodReturnType {
+        Unknown,
+        Void,
+        Byte,
+        Short,
+        Int,
+        Long,
+        Float,
+        Double,
+        Char,
+        Boolean,
+        String,
+        Object
+    };
 
-struct MetadataEntry {
-    MetadataEntry()
-        :
-        isTypeMember(false), name(std::string()), treeNode(nullptr), sig(std::string()), returnType(std::string()), retType(MethodReturnType::Unknown), paramCount(0),
-        isStatic(false), isFinal(false), declaringType(std::string()),
-        isResolved(false), isExtensionFunction(false), memberId(nullptr), clazz(nullptr) {
-    }
-    MetadataTreeNode* treeNode;
-    NodeType type;
-    std::string name;
-    std::string sig;
-    std::string returnType;
-    MethodReturnType retType;
-    std::string declaringType;
-    int paramCount;
-    bool isStatic;
-    bool isFinal;
-    bool isTypeMember;
-    bool isResolved;
-    bool isExtensionFunction;
-    void* memberId;
-    jclass clazz;
-    std::vector<std::string> parsedSig;
-};
+    class MetadataEntry {
+    public:
+
+        MetadataEntry(MetadataTreeNode* m_treeNode, NodeType nodeType);
+
+        std::string& getName();
+        std::string& getSig();
+        std::string& getReturnType();
+        MethodReturnType getRetType();
+        std::string& getDeclaringType();
+        int getParamCount();
+        bool getIsFinal();
+        bool getIsResolved();
+
+        MetadataTreeNode* treeNode;
+        NodeType type;
+        bool isExtensionFunction;
+        bool isStatic;
+        bool isTypeMember;
+        void* memberId;
+        jclass clazz;
+        std::vector<std::string> parsedSig;
+
+        MethodInfo* mi;
+        FieldInfo* fi;
+        StaticFieldInfo* sfi;
+
+        std::string name;
+        std::string sig;
+        std::string returnType;
+        MethodReturnType retType;
+        std::string declaringType;
+        int paramCount;
+        bool isFinal;
+        bool isResolved;
+
+    private:
+
+        bool retTypeParsed;
+        bool isFinalSet;
+        bool isResolvedSet;
+
+    };
 }
 
 #endif /* METADATAENTRY_H_ */

--- a/test-app/runtime/src/main/cpp/MetadataEntry.h
+++ b/test-app/runtime/src/main/cpp/MetadataEntry.h
@@ -35,29 +35,65 @@ namespace tns {
     class MetadataEntry {
     public:
 
-        MetadataEntry(MetadataTreeNode* m_treeNode, NodeType nodeType);
+        MetadataEntry(MetadataTreeNode *m_treeNode, NodeType nodeType);
 
-        std::string& getName();
-        std::string& getSig();
-        std::string& getReturnType();
+        MetadataEntry(const MetadataEntry &other) = default;
+
+        MetadataEntry &operator=(const MetadataEntry &other) {
+            if (this != &other) {
+                treeNode = other.treeNode;
+                type = other.type;
+                isExtensionFunction = other.isExtensionFunction;
+                isStatic = other.isStatic;
+                isTypeMember = other.isTypeMember;
+                memberId = other.memberId;
+                clazz = other.clazz;
+                parsedSig = other.parsedSig;
+                mi = other.mi;
+                fi = other.fi;
+                sfi = other.sfi;
+                name = other.name;
+                sig = other.sig;
+                returnType = other.returnType;
+                retType = other.retType;
+                declaringType = other.declaringType;
+                paramCount = other.paramCount;
+                isFinal = other.isFinal;
+                isStatic = other.isResolved;
+                isResolvedSet = other.isResolvedSet;
+                isFinalSet = other.isFinalSet;
+            }
+            return *this;
+        }
+
+        std::string &getName();
+
+        std::string &getSig();
+
+        std::string &getReturnType();
+
         MethodReturnType getRetType();
-        std::string& getDeclaringType();
+
+        std::string &getDeclaringType();
+
         int getParamCount();
+
         bool getIsFinal();
+
         bool getIsResolved();
 
-        MetadataTreeNode* treeNode;
+        MetadataTreeNode *treeNode;
         NodeType type;
         bool isExtensionFunction;
         bool isStatic;
         bool isTypeMember;
-        void* memberId;
+        void *memberId;
         jclass clazz;
         std::vector<std::string> parsedSig;
 
-        MethodInfo* mi;
-        FieldInfo* fi;
-        StaticFieldInfo* sfi;
+        MethodInfo mi;
+        FieldInfo *fi;
+        StaticFieldInfo *sfi;
 
         std::string name;
         std::string sig;

--- a/test-app/runtime/src/main/cpp/MetadataEntry.h
+++ b/test-app/runtime/src/main/cpp/MetadataEntry.h
@@ -59,7 +59,7 @@ namespace tns {
                 declaringType = other.declaringType;
                 paramCount = other.paramCount;
                 isFinal = other.isFinal;
-                isStatic = other.isResolved;
+                isResolved = other.isResolved;
                 isResolvedSet = other.isResolvedSet;
                 isFinalSet = other.isFinalSet;
             }

--- a/test-app/runtime/src/main/cpp/MetadataMethodInfo.h
+++ b/test-app/runtime/src/main/cpp/MetadataMethodInfo.h
@@ -1,8 +1,6 @@
 #ifndef METHODINFOSMARTPOINTER_H_
 #define METHODINFOSMARTPOINTER_H_
 
-#include "MetadataReader.h"
-
 #include <iostream>
 #include <string>
 #include <vector>
@@ -10,26 +8,42 @@
 using namespace std;
 
 namespace tns {
-class MethodInfo {
+    class MethodInfo {
     public:
-        MethodInfo(uint8_t* pValue, MetadataReader* reader)
-            : m_pData(pValue), m_pStartData(pValue), m_reader(reader), m_signatureLength(0) {
+
+        MethodInfo(uint8_t *pValue)
+                : isStatic(false),  m_pData(pValue), m_pStartData(pValue), m_signatureLength(0),
+                  sizeMeasured(false), nameOffset(0), resolvedData(0),
+                  declaringNodeId(0){
         }
 
         std::string GetName();
+
         uint8_t CheckIsResolved();
+
         uint16_t GetSignatureLength();
+
         std::string GetSignature();
+
         std::string GetDeclaringType(); //used only for static methods
 
         int GetSizeOfReadMethodInfo();
 
+        bool isStatic;
+
     private:
-        uint8_t* m_pData; //where we currently read
-        uint8_t* m_pStartData;  // pointer to the beginning
+        uint8_t *m_pData; //where we currently read
+        uint8_t *m_pStartData;  // pointer to the beginning
         uint16_t m_signatureLength;
-        MetadataReader* m_reader;
-};
+        bool sizeMeasured;
+
+        uint32_t nameOffset;
+        uint8_t resolvedData;
+        uint16_t declaringNodeId;
+        std::vector<uint16_t> nodeIds;
+
+
+    };
 }
 
 #endif /* METHODINFOSMARTPOINTER_H_ */

--- a/test-app/runtime/src/main/cpp/MetadataMethodInfo.h
+++ b/test-app/runtime/src/main/cpp/MetadataMethodInfo.h
@@ -16,6 +16,23 @@ namespace tns {
                   sizeMeasured(false), nameOffset(0), resolvedData(0),
                   declaringNodeId(0){
         }
+        
+        MethodInfo(const MethodInfo& other) = default;
+
+        MethodInfo& operator=(const MethodInfo& other) {
+            if (this != &other) {
+                isStatic = other.isStatic;
+                m_pData = other.m_pData;
+                m_pStartData = other.m_pStartData;
+                m_signatureLength = other.m_signatureLength;
+                sizeMeasured = other.sizeMeasured;
+                nameOffset = other.nameOffset;
+                resolvedData = other.resolvedData;
+                declaringNodeId = other.declaringNodeId;
+                nodeIds = other.nodeIds;
+            }
+            return *this;
+        }
 
         std::string GetName();
 

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1453,7 +1453,7 @@ void MetadataNode::PackageGetterCallback(Local<Name> property, const PropertyCal
                     //        return true;
                     //    }
                     // });
-                    RegisterSymbolHasInstanceCallback(isolate, &child, cachedItem);
+                    RegisterSymbolHasInstanceCallback(isolate, child, cachedItem);
                 }
 
                 V8SetPrivateValue(isolate, thiz, strProperty, cachedItem);
@@ -2138,7 +2138,7 @@ void MetadataNode::SetMissingBaseMethods(
     }
 }
 
-void MetadataNode::RegisterSymbolHasInstanceCallback(Isolate* isolate, MetadataEntry* entry, Local<Value> interface) {
+void MetadataNode::RegisterSymbolHasInstanceCallback(Isolate* isolate, MetadataEntry& entry, Local<Value> interface) {
     if (interface->IsNullOrUndefined()) {
         return;
     }
@@ -2193,9 +2193,9 @@ void MetadataNode::SymbolHasInstanceCallback(const v8::FunctionCallbackInfo<v8::
     info.GetReturnValue().Set(isInstanceOf);
 }
 
-std::string MetadataNode::GetJniClassName(MetadataEntry* entry) {
+std::string MetadataNode::GetJniClassName(MetadataEntry& entry) {
     std::stack<string> s;
-    MetadataTreeNode* n = entry->treeNode;
+    MetadataTreeNode* n = entry.treeNode;
     while (n != nullptr && n->name != "") {
         s.push(n->name);
         n = n->parent;

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -331,7 +331,7 @@ void MetadataNode::FieldAccessorGetterCallback(Local<Name> property, const Prope
 
         if ((!fieldCallbackMetadata.isStatic && thiz->StrictEquals(info.Holder()))
                 // check whether there's a declaring type to get the class from it
-                || (fieldCallbackMetadata.declaringType == "")) {
+                || (fieldCallbackMetadata.getDeclaringType() == "")) {
             info.GetReturnValue().SetUndefined();
             return;
         }
@@ -674,9 +674,10 @@ vector<MetadataNode::MethodCallbackData *> MetadataNode::SetInstanceMethodsFromS
     curPtr += sizeof(uint16_t);
     for (auto i = 0; i < instanceFieldCout; i++) {
         auto entry = MetadataReader::ReadInstanceFieldEntry(&curPtr);
+        auto fieldName = entry.getName();
         auto fieldInfo = new FieldCallbackData(entry);
         fieldInfo->metadata.declaringType = curType;
-        protoFiller.FillPrototypeField(isolate, entry.getName(), fieldInfo);
+        protoFiller.FillPrototypeField(isolate, fieldName, fieldInfo);
     }
 
     auto kotlinPropertiesCount = *reinterpret_cast<uint16_t*>(curPtr);
@@ -768,7 +769,6 @@ vector<MetadataNode::MethodCallbackData*> MetadataNode::SetInstanceMembersFromRu
 
         entry.name = name;
         entry.sig = signature;
-//        MetadataReader::FillReturnType(entry);
         entry.paramCount = paramCount;
         entry.isStatic = false;
 
@@ -1239,7 +1239,7 @@ void MetadataNode::MethodCallback(const v8::FunctionCallbackInfo<v8::Value>& inf
                         className = &c.getDeclaringType();
                     }
                     entry = &c;
-                    DEBUG_WRITE("MetaDataEntry Method %s's signature is: %s", entry->name.c_str(), entry->sig.c_str());
+                    DEBUG_WRITE("MetaDataEntry Method %s's signature is: %s", entry->name.c_str(), entry->getSig().c_str());
                     break;
                 }
             }

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -327,10 +327,11 @@ void MetadataNode::FieldAccessorGetterCallback(Local<Name> property, const Prope
     try {
         auto thiz = info.This();
         auto fieldCallbackData = reinterpret_cast<FieldCallbackData*>(info.Data().As<External>()->Value());
+        auto fieldCallbackMetadata = fieldCallbackData->metadata;
 
-        if ((!fieldCallbackData->isStatic && thiz->StrictEquals(info.Holder()))
+        if ((!fieldCallbackMetadata->isStatic && thiz->StrictEquals(info.Holder()))
                 // check whether there's a declaring type to get the class from it
-                || (fieldCallbackData->declaringType == "")) {
+                || (fieldCallbackMetadata->declaringType == "")) {
             info.GetReturnValue().SetUndefined();
             return;
         }
@@ -354,16 +355,17 @@ void MetadataNode::FieldAccessorSetterCallback(Local<Name> property, Local<Value
     try {
         auto thiz = info.This();
         auto fieldCallbackData = reinterpret_cast<FieldCallbackData*>(info.Data().As<External>()->Value());
+        auto fieldCallbackMetadata = fieldCallbackData->metadata;
 
-        if (!fieldCallbackData->isStatic && thiz->StrictEquals(info.Holder())) {
+        if (!fieldCallbackMetadata->isStatic && thiz->StrictEquals(info.Holder())) {
             auto isolate = info.GetIsolate();
             info.GetReturnValue().Set(v8::Undefined(isolate));
             return;
         }
 
-        if (fieldCallbackData->isFinal) {
+        if (fieldCallbackMetadata->getIsFinal()) {
             stringstream ss;
-            ss << "You are trying to set \"" << fieldCallbackData->name << "\" which is a final field! Final fields can only be read.";
+            ss << "You are trying to set \"" << fieldCallbackMetadata->getName() << "\" which is a final field! Final fields can only be read.";
             string exceptionMessage = ss.str();
 
             throw NativeScriptException(exceptionMessage);
@@ -542,7 +544,7 @@ std::vector<MetadataNode::MethodCallbackData*> MetadataNode::SetInstanceMembers(
         PrototypeTemplateFiller& protoFiller,
         vector<MethodCallbackData*>& instanceMethodsCallbackData,
         const vector<MethodCallbackData*>& baseInstanceMethodsCallbackData,
-        MetadataTreeNode* treeNode) {
+        MetadataTreeNode* treeNode, uint8_t* &curPtr) {
     auto hasCustomMetadata = treeNode->metadata != nullptr;
 
     if (hasCustomMetadata) {
@@ -551,10 +553,9 @@ std::vector<MetadataNode::MethodCallbackData*> MetadataNode::SetInstanceMembers(
             baseInstanceMethodsCallbackData, treeNode);
     }
 
-    SetInstanceFieldsFromStaticMetadata(isolate, protoFiller, treeNode);
     return SetInstanceMethodsFromStaticMetadata(
         isolate, ctorFuncTemplate, protoFiller, instanceMethodsCallbackData,
-        baseInstanceMethodsCallbackData, treeNode);
+        baseInstanceMethodsCallbackData, treeNode, curPtr);
 }
 
 vector<MetadataNode::MethodCallbackData *> MetadataNode::SetInstanceMethodsFromStaticMetadata(
@@ -562,12 +563,12 @@ vector<MetadataNode::MethodCallbackData *> MetadataNode::SetInstanceMethodsFromS
         PrototypeTemplateFiller& protoFiller,
         vector<MethodCallbackData *> &instanceMethodsCallbackData,
         const vector<MethodCallbackData *> &baseInstanceMethodsCallbackData,
-        MetadataTreeNode *treeNode) {
+        MetadataTreeNode *treeNode, uint8_t* &curPtr) {
     SET_PROFILER_FRAME();
 
     std::vector<MethodCallbackData *> instanceMethodData;
 
-    uint8_t *curPtr = s_metadataReader.GetValueData() + treeNode->offsetValue + 1;
+    curPtr = s_metadataReader.GetValueData() + treeNode->offsetValue + 1;
 
     auto nodeType = s_metadataReader.GetNodeType(treeNode);
 
@@ -584,24 +585,25 @@ vector<MetadataNode::MethodCallbackData *> MetadataNode::SetInstanceMethodsFromS
 
     auto context = isolate->GetCurrentContext();
 
-    std::unordered_map<std::string, MethodCallbackData *> collectedExtensionMethodDatas;
+    robin_hood::unordered_map<std::string, MethodCallbackData *> collectedExtensionMethodDatas;
 
     auto extensionFunctionsCount = *reinterpret_cast<uint16_t *>(curPtr);
     curPtr += sizeof(uint16_t);
     for (auto i = 0; i < extensionFunctionsCount; i++) {
-        auto entry = s_metadataReader.ReadExtensionFunctionEntry(&curPtr);
+        auto entry = MetadataReader::ReadExtensionFunctionEntry(&curPtr);
 
-        if (entry.name != lastMethodName) {
+        auto &methodName = entry->getName();
+        if (methodName!= lastMethodName) {
             //
             callbackData = tryGetExtensionMethodCallbackData(collectedExtensionMethodDatas,
-                                                             entry.name);
+                                                             methodName);
             if (callbackData == nullptr) {
                 callbackData = new MethodCallbackData(this);
-                protoFiller.FillPrototypeMethod(isolate, entry.name, callbackData);
+                protoFiller.FillPrototypeMethod(isolate, methodName, callbackData);
 
-                lastMethodName = entry.name;
-                std::pair<std::string, MethodCallbackData *> p(entry.name, callbackData);
-                collectedExtensionMethodDatas.insert(p);
+                lastMethodName = methodName;
+                std::pair<std::string, MethodCallbackData *> p(methodName, callbackData);
+                collectedExtensionMethodDatas.emplace(p);
             }
         }
         callbackData->candidates.push_back(entry);
@@ -613,19 +615,20 @@ vector<MetadataNode::MethodCallbackData *> MetadataNode::SetInstanceMethodsFromS
     curPtr += sizeof(uint16_t);
 
     for (auto i = 0; i < instanceMethodCount; i++) {
-        auto entry = s_metadataReader.ReadInstanceMethodEntry(&curPtr);
+        auto entry = MetadataReader::ReadInstanceMethodEntry(&curPtr);
 
         // attach a function to the prototype of a javascript Object
-        if (entry.name != lastMethodName) {
+        auto &methodName = entry->getName();
+        if (methodName != lastMethodName) {
             // See if we have tracked the callback data before (meaning another version of entry.name exists with different parameters)
             callbackData = tryGetExtensionMethodCallbackData(collectedExtensionMethodDatas,
-                                                             entry.name);
+                                                             methodName);
             if (callbackData == nullptr) {
                 callbackData = new MethodCallbackData(this);
 
                 // If we have no tracking of this callback data, create tracking so that we can find it if need be for future itterations where the entry.name is the same...
-                std::pair<std::string, MethodCallbackData *> p(entry.name, callbackData);
-                collectedExtensionMethodDatas.insert(p);
+                std::pair<std::string, MethodCallbackData *> p(methodName, callbackData);
+                collectedExtensionMethodDatas.emplace(p);
             }
 
             instanceMethodData.push_back(callbackData);
@@ -633,8 +636,8 @@ vector<MetadataNode::MethodCallbackData *> MetadataNode::SetInstanceMethodsFromS
             instanceMethodsCallbackData.push_back(callbackData);
             auto itBegin = baseInstanceMethodsCallbackData.begin();
             auto itEnd = baseInstanceMethodsCallbackData.end();
-            auto itFound = find_if(itBegin, itEnd, [&entry](MethodCallbackData *x) {
-                return x->candidates.front().name == entry.name;
+            auto itFound = find_if(itBegin, itEnd, [&methodName](MethodCallbackData *x) {
+                return x->candidates.front()->name == methodName;
             });
             if (itFound != itEnd) {
                 callbackData->parent = *itFound;
@@ -645,88 +648,35 @@ vector<MetadataNode::MethodCallbackData *> MetadataNode::SetInstanceMethodsFromS
                 Local<FunctionTemplate> funcTemplate = FunctionTemplate::New(isolate, MethodCallback, funcData);
                 auto func = funcTemplate->GetFunction(context).ToLocalChecked();
                 std::string origin = Constants::APP_ROOT_FOLDER_PATH + GetOrCreateInternal(treeNode)->m_name;
-                Local<Function> wrapperFunc = Wrap(isolate, func, entry.name, origin,
+                Local<Function> wrapperFunc = Wrap(isolate, func, methodName, origin,
                                                    false /* isCtorFunc */);
                 Local<Function> ctorFunc = ctorFuncTemplate->GetFunction(context).ToLocalChecked();
                 Local<Value> protoVal;
                 ctorFunc->Get(context,
                               ArgConverter::ConvertToV8String(isolate, "prototype")).ToLocal(
                         &protoVal);
-                Local<String> funcName = ArgConverter::ConvertToV8String(isolate, entry.name);
+                Local<String> funcName = ArgConverter::ConvertToV8String(isolate, methodName);
                 if (!protoVal.IsEmpty() && !protoVal->IsUndefined() && !protoVal->IsNull()) {
                     protoVal.As<Object>()->Set(context, funcName, wrapperFunc);
                 }
             } else {
-                protoFiller.FillPrototypeMethod(isolate, entry.name, callbackData);
+                protoFiller.FillPrototypeMethod(isolate, methodName, callbackData);
             }
 
-            lastMethodName = entry.name;
+            lastMethodName = methodName;
         }
 
         callbackData->candidates.push_back(entry);
-    }
-
-    return instanceMethodData;
-}
-
-MetadataNode::MethodCallbackData *MetadataNode::tryGetExtensionMethodCallbackData(
-        std::unordered_map<std::string, MethodCallbackData *> collectedMethodCallbackDatas,
-        std::string lookupName) {
-
-    if (collectedMethodCallbackDatas.size() < 1) {
-        return nullptr;
-    }
-
-    auto iter = collectedMethodCallbackDatas.find(lookupName);
-
-    if (iter != collectedMethodCallbackDatas.end()) {
-        return iter->second;
-    }
-
-    return nullptr;
-}
-
-void MetadataNode::SetInstanceFieldsFromStaticMetadata(
-        Isolate* isolate, PrototypeTemplateFiller& prototypeTemplate, MetadataTreeNode* treeNode) {
-    SET_PROFILER_FRAME();
-
-    Local<Function> ctorFunction;
-
-    uint8_t* curPtr = s_metadataReader.GetValueData() + treeNode->offsetValue + 1;
-
-    auto nodeType = s_metadataReader.GetNodeType(treeNode);
-
-    auto curType = s_metadataReader.ReadTypeName(treeNode);
-
-    curPtr += sizeof(uint16_t /* baseClassId */);
-
-    if (s_metadataReader.IsNodeTypeInterface(nodeType)) {
-        curPtr += sizeof(uint8_t) + sizeof(uint32_t);
-    }
-
-    auto extensionFunctionsCount = *reinterpret_cast<uint16_t*>(curPtr);
-    curPtr += sizeof(uint16_t);
-    for (auto i = 0; i < extensionFunctionsCount; i++) {
-        auto entry = s_metadataReader.ReadExtensionFunctionEntry(&curPtr);
-    }
-
-    //get candidates from instance methods metadata
-    auto instanceMethodCout = *reinterpret_cast<uint16_t*>(curPtr);
-    curPtr += sizeof(uint16_t);
-
-    //skip metadata methods -- advance the pointer only
-    for (auto i = 0; i < instanceMethodCout; i++) {
-        auto entry = s_metadataReader.ReadInstanceMethodEntry(&curPtr);
     }
 
     //get candidates from instance fields metadata
     auto instanceFieldCout = *reinterpret_cast<uint16_t*>(curPtr);
     curPtr += sizeof(uint16_t);
     for (auto i = 0; i < instanceFieldCout; i++) {
-        auto entry = s_metadataReader.ReadInstanceFieldEntry(&curPtr);
+        auto entry = MetadataReader::ReadInstanceFieldEntry(&curPtr);
         auto fieldInfo = new FieldCallbackData(entry);
-        fieldInfo->declaringType = curType;
-        prototypeTemplate.FillPrototypeField(isolate, entry.name, fieldInfo);
+        fieldInfo->metadata->declaringType = curType;
+        protoFiller.FillPrototypeField(isolate, entry->getName(), fieldInfo);
     }
 
     auto kotlinPropertiesCount = *reinterpret_cast<uint16_t*>(curPtr);
@@ -741,8 +691,8 @@ void MetadataNode::SetInstanceFieldsFromStaticMetadata(
 
         std::string getterMethodName = "";
         if(hasGetter>=1){
-            auto entry = s_metadataReader.ReadInstanceMethodEntry(&curPtr);
-            getterMethodName = entry.name;
+            auto entry = MetadataReader::ReadInstanceMethodEntry(&curPtr);
+            getterMethodName = entry->getName();
         }
 
         auto hasSetter = *reinterpret_cast<uint16_t*>(curPtr);
@@ -750,14 +700,34 @@ void MetadataNode::SetInstanceFieldsFromStaticMetadata(
 
         std::string setterMethodName = "";
         if(hasSetter >= 1){
-            auto entry = s_metadataReader.ReadInstanceMethodEntry(&curPtr);
-            setterMethodName = entry.name;
+            auto entry = MetadataReader::ReadInstanceMethodEntry(&curPtr);
+            setterMethodName = entry->getName();
         }
 
         auto propertyInfo = new PropertyCallbackData(propertyName, getterMethodName, setterMethodName);
-        prototypeTemplate.FillPrototypeProperty(isolate, propertyName, propertyInfo);
+        protoFiller.FillPrototypeProperty(isolate, propertyName, propertyInfo);
     }
+
+    return instanceMethodData;
 }
+
+MetadataNode::MethodCallbackData *MetadataNode::tryGetExtensionMethodCallbackData(
+        const robin_hood::unordered_map<std::string, MethodCallbackData *> &collectedMethodCallbackDatas,
+        const std::string &lookupName) {
+
+    if (collectedMethodCallbackDatas.empty()) {
+        return nullptr;
+    }
+
+    auto iter = collectedMethodCallbackDatas.find(lookupName);
+
+    if (iter != collectedMethodCallbackDatas.end()) {
+        return iter->second;
+    }
+
+    return nullptr;
+}
+
 
 vector<MetadataNode::MethodCallbackData*> MetadataNode::SetInstanceMembersFromRuntimeMetadata(
         Isolate* isolate, PrototypeTemplateFiller& protoFiller,
@@ -794,15 +764,16 @@ vector<MetadataNode::MethodCallbackData*> MetadataNode::SetInstanceMembersFromRu
         // method or field
         assert((chKind == 'M') || (chKind == 'F'));
 
-        MetadataEntry entry;
-        entry.name = name;
-        entry.sig = signature;
-        MetadataReader::FillReturnType(entry);
-        entry.paramCount = paramCount;
-        entry.isStatic = false;
+        auto entry = new MetadataEntry(nullptr, NodeType::Field);
+
+        entry->name = name;
+        entry->sig = signature;
+//        MetadataReader::FillReturnType(entry);
+        entry->paramCount = paramCount;
+        entry->isStatic = false;
 
         if (chKind == 'M') {
-            if (entry.name != lastMethodName) {
+            if (entry->name != lastMethodName) {
                 callbackData = new MethodCallbackData(this);
                 instanceMethodData.push_back(callbackData);
 
@@ -810,78 +781,31 @@ vector<MetadataNode::MethodCallbackData*> MetadataNode::SetInstanceMembersFromRu
                 auto itBegin = baseInstanceMethodsCallbackData.begin();
                 auto itEnd = baseInstanceMethodsCallbackData.end();
                 auto itFound = find_if(itBegin, itEnd, [&entry] (MethodCallbackData *x) {
-                    return x->candidates.front().name == entry.name;
+                    return x->candidates.front()->name == entry->name;
                 });
                 if (itFound != itEnd) {
                     callbackData->parent = *itFound;
                 }
 
-                protoFiller.FillPrototypeMethod(isolate, entry.name, callbackData);
-                lastMethodName = entry.name;
+                protoFiller.FillPrototypeMethod(isolate, entry->name, callbackData);
+                lastMethodName = entry->name;
             }
             callbackData->candidates.push_back(entry);
         } else if (chKind == 'F') {
             auto* fieldInfo = new FieldCallbackData(entry);
-            auto access = entry.isFinal ? AccessControl::ALL_CAN_READ : AccessControl::DEFAULT;
-            protoFiller.FillPrototypeField(isolate, entry.name, fieldInfo, access);
+            auto access = entry->isFinal ? AccessControl::ALL_CAN_READ : AccessControl::DEFAULT;
+            protoFiller.FillPrototypeField(isolate, entry->name, fieldInfo, access);
         }
     }
     return instanceMethodData;
 }
 
-void MetadataNode::SetStaticMembers(Isolate* isolate, Local<Function>& ctorFunction, MetadataTreeNode* treeNode) {
+
+void MetadataNode::SetStaticMembers(Isolate* isolate, Local<Function>& ctorFunction, MetadataTreeNode* treeNode, uint8_t* &curPtr) {
     auto hasCustomMetadata = treeNode->metadata != nullptr;
     auto context = isolate->GetCurrentContext();
 
     if (!hasCustomMetadata) {
-        uint8_t* curPtr = s_metadataReader.GetValueData() + treeNode->offsetValue + 1;
-        auto nodeType = s_metadataReader.GetNodeType(treeNode);
-        auto curType = s_metadataReader.ReadTypeName(treeNode);
-        curPtr += sizeof(uint16_t /* baseClassId */);
-        if (s_metadataReader.IsNodeTypeInterface(nodeType)) {
-            curPtr += sizeof(uint8_t) + sizeof(uint32_t);
-        }
-
-        auto extensionFunctionsCount = *reinterpret_cast<uint16_t*>(curPtr);
-        curPtr += sizeof(uint16_t);
-        for (auto i = 0; i < extensionFunctionsCount; i++) {
-            auto entry = s_metadataReader.ReadExtensionFunctionEntry(&curPtr);
-        }
-
-        auto instanceMethodCout = *reinterpret_cast<uint16_t*>(curPtr);
-        curPtr += sizeof(uint16_t);
-        for (auto i = 0; i < instanceMethodCout; i++) {
-            auto entry = s_metadataReader.ReadInstanceMethodEntry(&curPtr);
-        }
-
-        auto instanceFieldCout = *reinterpret_cast<uint16_t*>(curPtr);
-        curPtr += sizeof(uint16_t);
-        for (auto i = 0; i < instanceFieldCout; i++) {
-            auto entry = s_metadataReader.ReadInstanceFieldEntry(&curPtr);
-        }
-
-        auto kotlinPropertiesCount = *reinterpret_cast<uint16_t*>(curPtr);
-        curPtr += sizeof(uint16_t);
-        for (int i = 0; i < kotlinPropertiesCount; ++i) {
-            uint32_t nameOfffset = *reinterpret_cast<uint32_t*>(curPtr);
-            string propertyName = s_metadataReader.ReadName(nameOfffset);
-            curPtr += sizeof(uint32_t);
-
-            auto hasGetter = *reinterpret_cast<uint16_t*>(curPtr);
-            curPtr += sizeof(uint16_t);
-
-            if(hasGetter>=1){
-                auto entry = s_metadataReader.ReadInstanceMethodEntry(&curPtr);
-            }
-
-            auto hasSetter = *reinterpret_cast<uint16_t*>(curPtr);
-            curPtr += sizeof(uint16_t);
-
-            if(hasSetter >= 1){
-                auto entry = s_metadataReader.ReadInstanceMethodEntry(&curPtr);
-            }
-        }
-
         string lastMethodName;
         MethodCallbackData* callbackData = nullptr;
 
@@ -891,15 +815,16 @@ void MetadataNode::SetStaticMembers(Isolate* isolate, Local<Function>& ctorFunct
         auto staticMethodCout = *reinterpret_cast<uint16_t*>(curPtr);
         curPtr += sizeof(uint16_t);
         for (auto i = 0; i < staticMethodCout; i++) {
-            auto entry = s_metadataReader.ReadStaticMethodEntry(&curPtr);
-            if (entry.name != lastMethodName) {
+            auto entry = MetadataReader::ReadStaticMethodEntry(&curPtr);
+            auto &methodName = entry->getName();
+            if (methodName != lastMethodName) {
                 callbackData = new MethodCallbackData(this);
                 auto funcData = External::New(isolate, callbackData);
                 auto funcTemplate = FunctionTemplate::New(isolate, MethodCallback, funcData);
                 auto func = funcTemplate->GetFunction(context).ToLocalChecked();
-                auto funcName = ArgConverter::ConvertToV8String(isolate, entry.name);
-                ctorFunction->Set(context, funcName, Wrap(isolate, func, entry.name, origin, false /* isCtorFunc */));
-                lastMethodName = entry.name;
+                auto funcName = ArgConverter::ConvertToV8String(isolate, methodName);
+                ctorFunction->Set(context, funcName, Wrap(isolate, func, methodName, origin, false /* isCtorFunc */));
+                lastMethodName = methodName;
             }
             callbackData->candidates.push_back(entry);
         }
@@ -913,9 +838,9 @@ void MetadataNode::SetStaticMembers(Isolate* isolate, Local<Function>& ctorFunct
         auto staticFieldCout = *reinterpret_cast<uint16_t*>(curPtr);
         curPtr += sizeof(uint16_t);
         for (auto i = 0; i < staticFieldCout; i++) {
-            auto entry = s_metadataReader.ReadStaticFieldEntry(&curPtr);
+            auto entry = MetadataReader::ReadStaticFieldEntry(&curPtr);
 
-            auto fieldName = ArgConverter::ConvertToV8String(isolate, entry.name);
+            auto fieldName = ArgConverter::ConvertToV8String(isolate, entry->getName());
             auto fieldData = External::New(isolate, new FieldCallbackData(entry));
             ctorFunction->SetAccessor(context, fieldName, FieldAccessorGetterCallback, FieldAccessorSetterCallback, fieldData, AccessControl::DEFAULT, PropertyAttribute::DontDelete);
         }
@@ -929,29 +854,46 @@ void MetadataNode::SetStaticMembers(Isolate* isolate, Local<Function>& ctorFunct
     }
 }
 
-void MetadataNode::SetInnerTypes(Isolate* isolate, Local<Function>& ctorFunction, MetadataTreeNode* treeNode) {
-    auto context = isolate->GetCurrentContext();
+void MetadataNode::SetInnerTypes(v8::Isolate* isolate, Local<Function>& ctorFunction, MetadataTreeNode *treeNode) {
     if (treeNode->children != nullptr) {
-        const auto& children = *treeNode->children;
-
-        for (auto curChild : children) {
-            auto childNode = GetOrCreateInternal(curChild);
-
-            // The call to GetConstructorFunctionTemplate bootstraps the ctor function for the childNode
-            auto innerTypeCtorFuncTemplate = childNode->GetConstructorFunctionTemplate(isolate, curChild);
-            if(innerTypeCtorFuncTemplate.IsEmpty()) {
-                // this class does not exist, so just ignore it
-                continue;
-            }
-            auto innerTypeCtorFunc = Local<Function>::New(isolate, *GetOrCreateInternal(curChild)->GetPersistentConstructorFunction(isolate));
-            auto innerTypeName = ArgConverter::ConvertToV8String(isolate, curChild->name);
-            // TODO: remove this once we solve https://github.com/NativeScript/android/pull/1771
-            // this avoids a crash, but the companion object is still unaccessible
-            TryCatch tc(isolate);
-            ctorFunction->Set(context, innerTypeName, innerTypeCtorFunc);
+        auto context = isolate->GetCurrentContext();
+        const auto &children = *treeNode->children;
+        for (auto curChild: children) {
+            ctorFunction->SetAccessor(
+                    context,
+                    v8::String::NewFromUtf8(isolate, curChild->name.c_str()).ToLocalChecked(),
+                    InnerTypeAccessorGetterCallback, nullptr, v8::External::New(isolate, curChild)
+            );
         }
     }
 }
+
+void MetadataNode::InnerTypeAccessorGetterCallback(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info) {
+    v8::Isolate* isolate = info.GetIsolate();
+    v8::HandleScope handleScope(isolate);
+
+    MetadataTreeNode* curChild = static_cast<MetadataTreeNode*>(v8::External::Cast(*info.Data())->Value());
+    auto childNode = GetOrCreateInternal(curChild);
+    auto itFound = childNode->m_poCtorCachePerIsolate.find(isolate);
+    if (itFound != childNode->m_poCtorCachePerIsolate.end()) {
+        info.GetReturnValue().Set(itFound->second->Get(isolate));
+        return;
+    }
+    auto innerTypeCtorFuncTemplate= childNode->GetConstructorFunctionTemplate(isolate, curChild);
+
+    if(innerTypeCtorFuncTemplate.IsEmpty()) {
+        info.GetReturnValue().Set(v8::Undefined(isolate));
+        return;
+    }
+
+    auto innerTypeCtorFunc = Local<Function>::New(isolate, *GetOrCreateInternal(curChild)->GetPersistentConstructorFunction(isolate));
+    auto innerTypeName = ArgConverter::ConvertToV8String(isolate, curChild->name);
+    // TODO: remove this once we solve https://github.com/NativeScript/android/pull/1771
+    // this avoids a crash, but the companion object is still unaccessible
+    TryCatch tc(isolate);
+    info.GetReturnValue().Set(innerTypeCtorFunc);
+}
+
 
 Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* isolate, MetadataTreeNode* treeNode) {
     std::vector<MethodCallbackData*> instanceMethodsCallbackData;
@@ -1034,9 +976,11 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
 
     PrototypeTemplateFiller protoFiller{ctorFuncTemplate->PrototypeTemplate()};
 
+    uint8_t* curPtr = nullptr;
+
     auto instanceMethodData = node->SetInstanceMembers(
             isolate, ctorFuncTemplate, protoFiller, instanceMethodsCallbackData,
-            baseInstanceMethodsCallbackData, treeNode);
+            baseInstanceMethodsCallbackData, treeNode, curPtr);
     if (!skippedBaseTypes.empty()) {
         node->SetMissingBaseMethods(isolate, skippedBaseTypes, instanceMethodData, protoFiller);
     }
@@ -1048,13 +992,13 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
 
     auto wrappedCtorFunc = Wrap(isolate, ctorFunc, node->m_treeNode->name, origin, true /* isCtorFunc */);
 
-    node->SetStaticMembers(isolate, wrappedCtorFunc, treeNode);
+    node->SetStaticMembers(isolate, wrappedCtorFunc, treeNode, curPtr);
 
     // insert isolate-specific persistent function handle
     node->m_poCtorCachePerIsolate.insert({isolate, new Persistent<Function>(isolate, wrappedCtorFunc)});
     if (!baseCtorFunc.IsEmpty()) {
-        auto context = isolate->GetCurrentContext();
-        wrappedCtorFunc->SetPrototype(context, baseCtorFunc);
+        auto currentContext = isolate->GetCurrentContext();
+        wrappedCtorFunc->SetPrototype(currentContext, baseCtorFunc);
     }
 
    //cache "ctorFuncTemplate"
@@ -1278,7 +1222,7 @@ void MetadataNode::MethodCallback(const v8::FunctionCallbackInfo<v8::Value>& inf
 
         string* className;
         const auto& first = callbackData->candidates.front();
-        const auto& methodName = first.name;
+        const auto& methodName = first->name;
 
         while ((callbackData != nullptr) && (entry == nullptr)) {
             auto& candidates = callbackData->candidates;
@@ -1288,13 +1232,13 @@ void MetadataNode::MethodCallback(const v8::FunctionCallbackInfo<v8::Value>& inf
             // Iterates through all methods and finds the best match based on the number of arguments
             auto found = false;
             for (auto& c : candidates) {
-                found = (!c.isExtensionFunction && c.paramCount == argLength) || (
-                        c.isExtensionFunction && c.paramCount == argLength + 1);
+                found = (!c->isExtensionFunction && c->getParamCount() == argLength) || (
+                        c->isExtensionFunction && c->getParamCount() == argLength + 1);
                 if (found) {
-                    if(c.isExtensionFunction){
-                        className = &c.declaringType;
+                    if(c->isExtensionFunction){
+                        className = &c->getDeclaringType();
                     }
-                    entry = &c;
+                    entry = c;
                     DEBUG_WRITE("MetaDataEntry Method %s's signature is: %s", entry->name.c_str(), entry->sig.c_str());
                     break;
                 }
@@ -1309,7 +1253,7 @@ void MetadataNode::MethodCallback(const v8::FunctionCallbackInfo<v8::Value>& inf
         auto thiz = info.This();
 
         auto isSuper = false;
-        if (!first.isStatic) {
+        if (!first->isStatic) {
             auto superValue = thiz->GetInternalField(static_cast<int>(ObjectManager::MetadataNodeKeys::CallSuper));
             isSuper = !superValue.IsEmpty() && superValue->IsTrue();
         }
@@ -1318,7 +1262,7 @@ void MetadataNode::MethodCallback(const v8::FunctionCallbackInfo<v8::Value>& inf
             info.GetReturnValue().Set(thiz);
         } else {
             bool isFromInterface = initialCallbackData->node->IsNodeTypeInterface();
-            CallbackHandlers::CallJavaMethod(thiz, *className, methodName, entry, isFromInterface, first.isStatic, isSuper, info);
+            CallbackHandlers::CallJavaMethod(thiz, *className, methodName, entry, isFromInterface, first->isStatic, isSuper, info);
         }
     } catch (NativeScriptException& e) {
         e.ReThrowToV8();
@@ -1446,9 +1390,9 @@ Local<Object> MetadataNode::GetImplementationObject(Isolate* isolate, const Loca
             //DEBUG_WRITE("GetImplementationObject not found since cycle parents reached abovePrototype:%d", (abovePrototype.IsEmpty() || abovePrototype.As<Object>().IsEmpty()) ? -1 :  abovePrototype.As<Object>()->GetIdentityHash());
             return Local<Object>();
         } else {
-            Local<Value> hiddenVal;
-            V8GetPrivateValue(isolate, currentPrototype.As<Object>(), V8StringConstants::GetClassImplementationObject(isolate), hiddenVal);
-            auto value = hiddenVal;
+            Local<Value> _hiddenVal;
+            V8GetPrivateValue(isolate, currentPrototype.As<Object>(), V8StringConstants::GetClassImplementationObject(isolate), _hiddenVal);
+            auto value = _hiddenVal;
 
             if (!value.IsEmpty()) {
                 implementationObject = currentPrototype.As<Object>();
@@ -1858,24 +1802,26 @@ MetadataNode* MetadataNode::GetNodeFromHandle(const Local<Object>& value) {
     return node;
 }
 
-MetadataEntry MetadataNode::GetChildMetadataForPackage(MetadataNode* node, const string& propName) {
-    MetadataEntry child;
-
+MetadataEntry MetadataNode::GetChildMetadataForPackage(MetadataNode *node, std::string propName) {
     assert(node->m_treeNode->children != nullptr);
 
-    const auto& children = *node->m_treeNode->children;
+    MetadataEntry child(nullptr, NodeType::Class);
 
-    for (auto treeNodeChild : children) {
+    const auto &children = *node->m_treeNode->children;
+
+    for (auto treeNodeChild: children) {
         if (propName == treeNodeChild->name) {
             child.name = propName;
             child.treeNode = treeNodeChild;
+            child.type = static_cast<NodeType>(s_metadataReader.GetNodeType(treeNodeChild));
 
-            uint8_t childNodeType = s_metadataReader.GetNodeType(treeNodeChild);
-            if (s_metadataReader.IsNodeTypeInterface(childNodeType)) {
+            if (s_metadataReader.IsNodeTypeInterface((uint8_t) child.type)) {
                 bool isPrefix;
-                string declaringType = s_metadataReader.ReadInterfaceImplementationTypeName(treeNodeChild, isPrefix);
+                string declaringType = s_metadataReader.ReadInterfaceImplementationTypeName(
+                        treeNodeChild, isPrefix);
                 child.declaringType = isPrefix
-                                      ? (declaringType + s_metadataReader.ReadTypeName(child.treeNode))
+                                      ? (declaringType +
+                                         s_metadataReader.ReadTypeName(child.treeNode))
                                       : declaringType;
             }
         }
@@ -2158,15 +2104,15 @@ void MetadataNode::SetMissingBaseMethods(
         MethodCallbackData* callbackData = nullptr;
 
         for (auto i = 0; i < instanceMethodCount; i++) {
-            auto entry = s_metadataReader.ReadInstanceMethodEntry(&curPtr);
+            auto entry = MetadataReader::ReadInstanceMethodEntry(&curPtr);
 
-            auto isConstructor = entry.name == "<init>";
+            auto isConstructor = entry->getName() == "<init>";
             if (isConstructor) {
                 continue;
             }
 
             for (auto data: instanceMethodData) {
-                if (data->candidates.front().name == entry.name) {
+                if (data->candidates.front()->getName() == entry->getName()) {
                     callbackData = data;
                     break;
                 }
@@ -2174,12 +2120,12 @@ void MetadataNode::SetMissingBaseMethods(
 
             if (callbackData == nullptr) {
                 callbackData = new MethodCallbackData(this);
-                protoFiller.FillPrototypeMethod(isolate, entry.name, callbackData);
+                protoFiller.FillPrototypeMethod(isolate, entry->getName(), callbackData);
             }
 
             bool foundSameSig = false;
             for (auto m: callbackData->candidates) {
-                foundSameSig = m.sig == entry.sig;
+                foundSameSig = m->sig == entry->getSig();
                 if (foundSameSig) {
                     break;
                 }
@@ -2289,6 +2235,10 @@ void MetadataNode::onDisposeIsolate(Isolate* isolate) {
             }
         }
     }
+}
+
+MetadataReader* MetadataNode::getMetadataReader() {
+    return &MetadataNode::s_metadataReader;
 }
 
 string MetadataNode::TNS_PREFIX = "com/tns/gen/";

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1802,7 +1802,7 @@ MetadataNode* MetadataNode::GetNodeFromHandle(const Local<Object>& value) {
     return node;
 }
 
-MetadataEntry MetadataNode::GetChildMetadataForPackage(MetadataNode *node, std::string propName) {
+MetadataEntry MetadataNode::GetChildMetadataForPackage(MetadataNode *node, const std::string &propName) {
     assert(node->m_treeNode->children != nullptr);
 
     MetadataEntry child(nullptr, NodeType::Class);

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1984,7 +1984,7 @@ void MetadataNode::EnableProfiler(bool enableProfiler) {
     s_profilerEnabled = enableProfiler;
 }
 
-bool MetadataNode::IsJavascriptKeyword(std::string word) {
+bool MetadataNode::IsJavascriptKeyword(const std::string &word) {
     static set<string> keywords;
 
     if (keywords.empty()) {

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -121,7 +121,7 @@ class MetadataNode {
 
         static MetadataTreeNode* GetOrCreateTreeNodeByName(const std::string& className);
 
-        static MetadataEntry GetChildMetadataForPackage(MetadataNode *node, std::string propName);
+        static MetadataEntry GetChildMetadataForPackage(MetadataNode *node, const std::string &propName);
 
         static MetadataNode* GetInstanceMetadata(v8::Isolate* isolate, const v8::Local<v8::Object>& value);
 

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -161,9 +161,9 @@ class MetadataNode {
         static bool GetExtendLocation(v8::Isolate* isolate, std::string& extendLocation, bool isTypeScriptExtend);
         static ExtendedClassCacheData GetCachedExtendedClassData(v8::Isolate* isolate, const std::string& proxyClassName);
 
-        static void RegisterSymbolHasInstanceCallback(v8::Isolate* isolate, MetadataEntry entry, v8::Local<v8::Value> interface);
+        static void RegisterSymbolHasInstanceCallback(v8::Isolate* isolate, MetadataEntry* entry, v8::Local<v8::Value> interface);
         static void SymbolHasInstanceCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
-        static std::string GetJniClassName(MetadataEntry entry);
+        static std::string GetJniClassName(MetadataEntry* entry);
 
         static v8::Local<v8::Function> Wrap(v8::Isolate* isolate, const v8::Local<v8::Function>& function, const std::string& name, const std::string& origin, bool isCtorFunc);
 
@@ -199,7 +199,7 @@ class MetadataNode {
                 node(_node), parent(nullptr), isSuper(false) {
             }
 
-            std::vector<MetadataEntry*> candidates;
+            std::vector<MetadataEntry> candidates;
             MetadataNode* node;
             MethodCallbackData* parent;
             bool isSuper;

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -60,6 +60,8 @@ class MetadataNode {
         static std::string GetTypeMetadataName(v8::Isolate* isolate, v8::Local<v8::Value>& value);
 
         static void onDisposeIsolate(v8::Isolate* isolate);
+
+        static MetadataReader* getMetadataReader();
     private:
         struct MethodCallbackData;
 
@@ -81,23 +83,23 @@ class MetadataNode {
         v8::Local<v8::FunctionTemplate> GetConstructorFunctionTemplate(v8::Isolate* isolate, MetadataTreeNode* treeNode);
         v8::Local<v8::FunctionTemplate> GetConstructorFunctionTemplate(v8::Isolate* isolate, MetadataTreeNode* treeNode, std::vector<MethodCallbackData*>& instanceMethodsCallbackData);
         v8::Persistent<v8::Function>* GetPersistentConstructorFunction(v8::Isolate* isolate);
-        v8::Local<v8::ObjectTemplate> GetOrCreateArrayObjectTemplate(v8::Isolate* isolate);
+        static v8::Local<v8::ObjectTemplate> GetOrCreateArrayObjectTemplate(v8::Isolate* isolate);
 
         std::vector<MethodCallbackData*> SetInstanceMembers(
                 v8::Isolate* isolate, v8::Local<v8::FunctionTemplate>& ctorFuncTemplate,
                 PrototypeTemplateFiller& protoFiller,
                 std::vector<MethodCallbackData*>& instanceMethodsCallbackData,
                 const std::vector<MethodCallbackData*>& baseInstanceMethodsCallbackData,
-                MetadataTreeNode* treeNode);
+                MetadataTreeNode* treeNode, uint8_t* &curPtr);
         std::vector<MethodCallbackData*> SetInstanceMethodsFromStaticMetadata(
                 v8::Isolate* isolate, v8::Local<v8::FunctionTemplate>& ctorFuncTemplate,
                 PrototypeTemplateFiller& protoFiller,
                 std::vector<MethodCallbackData*>& instanceMethodsCallbackData,
                 const std::vector<MethodCallbackData*>& baseInstanceMethodsCallbackData,
-                MetadataTreeNode* treeNode);
-        MethodCallbackData* tryGetExtensionMethodCallbackData(
-                std::unordered_map<std::string, MethodCallbackData*> collectedMethodCallbackDatas,
-                std::string lookupName);
+                MetadataTreeNode* treeNode, uint8_t* &curPtr);
+        static MethodCallbackData* tryGetExtensionMethodCallbackData(
+                const robin_hood::unordered_map<std::string, MethodCallbackData *> &collectedMethodCallbackDatas,
+                const std::string &lookupName);
         void SetInstanceFieldsFromStaticMetadata(
                 v8::Isolate* isolate, PrototypeTemplateFiller& protoFiller,
                 MetadataTreeNode* treeNode);
@@ -106,8 +108,10 @@ class MetadataNode {
                 std::vector<MethodCallbackData*>& instanceMethodsCallbackData,
                 const std::vector<MethodCallbackData*>& baseInstanceMethodsCallbackData,
                 MetadataTreeNode* treeNode);
-        void SetStaticMembers(v8::Isolate* isolate, v8::Local<v8::Function>& ctorFunction, MetadataTreeNode* treeNode);
-        void SetInnerTypes(v8::Isolate* isolate, v8::Local<v8::Function>& ctorFunction, MetadataTreeNode* treeNode);
+
+        void SetStaticMembers(v8::Isolate* isolate, v8::Local<v8::Function>& ctorFunction, MetadataTreeNode* treeNode, uint8_t* &curPtr);
+        static void InnerTypeAccessorGetterCallback(v8::Local<v8::Name> property, const v8::PropertyCallbackInfo<v8::Value>& info);
+        static void SetInnerTypes(v8::Isolate* isolate, v8::Local<v8::Function>& ctorFunction, MetadataTreeNode* treeNode);
 
         static void BuildMetadata(uint32_t nodesLength, uint8_t* nodeData, uint32_t nameLength, uint8_t* nameData, uint32_t valueLength, uint8_t* valueData);
 
@@ -117,7 +121,7 @@ class MetadataNode {
 
         static MetadataTreeNode* GetOrCreateTreeNodeByName(const std::string& className);
 
-        static MetadataEntry GetChildMetadataForPackage(MetadataNode* node, const std::string& propName);
+        static MetadataEntry GetChildMetadataForPackage(MetadataNode *node, std::string propName);
 
         static MetadataNode* GetInstanceMetadata(v8::Isolate* isolate, const v8::Local<v8::Object>& value);
 
@@ -161,9 +165,9 @@ class MetadataNode {
         static void SymbolHasInstanceCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static std::string GetJniClassName(MetadataEntry entry);
 
-        v8::Local<v8::Function> Wrap(v8::Isolate* isolate, const v8::Local<v8::Function>& function, const std::string& name, const std::string& origin, bool isCtorFunc);
+        static v8::Local<v8::Function> Wrap(v8::Isolate* isolate, const v8::Local<v8::Function>& function, const std::string& name, const std::string& origin, bool isCtorFunc);
 
-        bool CheckClassHierarchy(JEnv& env, jclass currentClass, MetadataTreeNode* curentTreeNode, MetadataTreeNode* baseTreeNode, std::vector<MetadataTreeNode*>& skippedBaseTypes);
+        static bool CheckClassHierarchy(JEnv& env, jclass currentClass, MetadataTreeNode* curentTreeNode, MetadataTreeNode* baseTreeNode, std::vector<MetadataTreeNode*>& skippedBaseTypes);
         void SetMissingBaseMethods(v8::Isolate* isolate,
                                    const std::vector<MetadataTreeNode*>& skippedBaseTypes,
                                    const std::vector<MethodCallbackData*>& instanceMethodData,
@@ -195,7 +199,7 @@ class MetadataNode {
                 node(_node), parent(nullptr), isSuper(false) {
             }
 
-            std::vector<MetadataEntry> candidates;
+            std::vector<MetadataEntry*> candidates;
             MetadataNode* node;
             MethodCallbackData* parent;
             bool isSuper;

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -76,7 +76,7 @@ class MetadataNode {
 
         MetadataNode(MetadataTreeNode* treeNode);
 
-        static bool IsJavascriptKeyword(std::string word);
+        static bool IsJavascriptKeyword(const std::string &word);
         v8::Local<v8::Object> CreatePackageObject(v8::Isolate* isolate);
 
         v8::Local<v8::Function> GetConstructorFunction(v8::Isolate* isolate);

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -161,9 +161,9 @@ class MetadataNode {
         static bool GetExtendLocation(v8::Isolate* isolate, std::string& extendLocation, bool isTypeScriptExtend);
         static ExtendedClassCacheData GetCachedExtendedClassData(v8::Isolate* isolate, const std::string& proxyClassName);
 
-        static void RegisterSymbolHasInstanceCallback(v8::Isolate* isolate, MetadataEntry* entry, v8::Local<v8::Value> interface);
+        static void RegisterSymbolHasInstanceCallback(v8::Isolate* isolate, MetadataEntry& entry, v8::Local<v8::Value> interface);
         static void SymbolHasInstanceCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
-        static std::string GetJniClassName(MetadataEntry* entry);
+        static std::string GetJniClassName(MetadataEntry& entry);
 
         static v8::Local<v8::Function> Wrap(v8::Isolate* isolate, const v8::Local<v8::Function>& function, const std::string& name, const std::string& origin, bool isCtorFunc);
 

--- a/test-app/runtime/src/main/cpp/MetadataReader.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataReader.cpp
@@ -2,21 +2,26 @@
 #include "MetadataMethodInfo.h"
 #include "Util.h"
 #include <sstream>
-#include <android/log.h>
 
 using namespace std;
 using namespace tns;
 
-MetadataReader::MetadataReader()
-    :
-    m_nodesLength(0), m_nodeData(nullptr), m_nameLength(0), m_nameData(nullptr), m_valueLength(0), m_valueData(nullptr), m_root(nullptr), m_getTypeMetadataCallback(nullptr) {
-}
+MetadataReader::MetadataReader() : m_root(nullptr), m_nodesLength(0), m_nameLength(0),
+                                   m_valueLength(0),
+                                   m_nodeData(nullptr), m_nameData(nullptr), m_valueData(nullptr),
+                                   m_getTypeMetadataCallback(nullptr) {}
 
-MetadataReader::MetadataReader(uint32_t nodesLength, uint8_t* nodeData, uint32_t nameLength, uint8_t* nameData, uint32_t valueLength, uint8_t* valueData, GetTypeMetadataCallback getTypeMetadataCallback)
-    :
-    m_nodesLength(nodesLength), m_nodeData(nodeData), m_nameLength(nameLength), m_nameData(nameData), m_valueLength(valueLength), m_valueData(valueData), m_getTypeMetadataCallback(getTypeMetadataCallback) {
+MetadataReader::MetadataReader(uint32_t nodesLength, uint8_t *nodeData, uint32_t nameLength,
+                               uint8_t *nameData, uint32_t valueLength, uint8_t *valueData,
+                               GetTypeMetadataCallback getTypeMetadataCallback)
+        :
+        m_nodesLength(nodesLength), m_nodeData(nodeData), m_nameLength(nameLength),
+        m_nameData(nameData), m_valueLength(valueLength), m_valueData(valueData),
+        m_getTypeMetadataCallback(getTypeMetadataCallback) {
     m_root = BuildTree();
 }
+
+
 
 // helper debug function when need to convert a metadata node to its full name
 //std::string toFullName(MetadataTreeNode* p) {
@@ -28,18 +33,18 @@ MetadataReader::MetadataReader(uint32_t nodesLength, uint8_t* nodeData, uint32_t
 //}
 
 MetadataTreeNode* MetadataReader::BuildTree() {
-    MetadataTreeNodeRawData* rootNodeData = reinterpret_cast<MetadataTreeNodeRawData*>(m_nodeData);
+    MetadataTreeNodeRawData *rootNodeData = reinterpret_cast<MetadataTreeNodeRawData *>(m_nodeData);
 
-    MetadataTreeNodeRawData* curNodeData = rootNodeData;
+    MetadataTreeNodeRawData *curNodeData = rootNodeData;
 
     int len = m_nodesLength / sizeof(MetadataTreeNodeRawData);
 
     m_v.resize(len + 1000);
-    MetadataTreeNode* emptyNode = nullptr;
+    MetadataTreeNode * emptyNode = nullptr;
     fill(m_v.begin(), m_v.end(), emptyNode);
 
     for (int i = 0; i < len; i++) {
-        MetadataTreeNode* node = GetNodeById(i);
+        MetadataTreeNode * node = GetNodeById(i);
         if (nullptr == node) {
             node = new MetadataTreeNode;
             node->name = ReadName(curNodeData->offsetName);
@@ -50,32 +55,24 @@ MetadataTreeNode* MetadataReader::BuildTree() {
         uint16_t curNodeDataId = curNodeData - rootNodeData;
 
         if (curNodeDataId != curNodeData->firstChildId) {
-            node->children = new vector<MetadataTreeNode*>;
-            MetadataTreeNodeRawData* childNodeData = rootNodeData + curNodeData->firstChildId;
+            node->children = new vector<MetadataTreeNode *>;
+            MetadataTreeNodeRawData *childNodeData = rootNodeData + curNodeData->firstChildId;
             while (true) {
 
                 uint16_t childNodeDataId = childNodeData - rootNodeData;
-
-                MetadataTreeNode* childNode;
                 // node (and its next siblings) already visited, so we don't need to visit it again
                 if (m_v[childNodeDataId] != emptyNode) {
-                    childNode = m_v[childNodeDataId];
-                    __android_log_print(ANDROID_LOG_ERROR, "TNS.error", "Consistency error in metadata. A child should never have been visited before its parent. Parent: %s Child: %s. Child metadata id: %u", node->name.c_str(), childNode->name.c_str(), childNodeDataId);
                     break;
-                } else {
-                    childNode = new MetadataTreeNode;
-                    childNode->name = ReadName(childNodeData->offsetName);
-                    childNode->offsetValue = childNodeData->offsetValue;
                 }
+
+                MetadataTreeNode * childNode = new MetadataTreeNode;
                 childNode->parent = node;
+                childNode->name = ReadName(childNodeData->offsetName);
+                childNode->offsetValue = childNodeData->offsetValue;
 
                 node->children->push_back(childNode);
 
                 m_v[childNodeDataId] = childNode;
-
-                if (childNodeDataId == childNodeData->nextSiblingId) {
-                    break;
-                }
 
                 childNodeData = rootNodeData + childNodeData->nextSiblingId;
             }
@@ -87,97 +84,13 @@ MetadataTreeNode* MetadataReader::BuildTree() {
     return GetNodeById(0);
 }
 
-void MetadataReader::FillEntryWithFiedldInfo(FieldInfo* fi, MetadataEntry& entry) {
-    entry.isTypeMember = true;
-    entry.name = ReadName(fi->nameOffset);
-    entry.sig = ReadTypeName(fi->nodeId);
-    entry.isFinal = fi->finalModifier == MetadataTreeNode::FINAL;
-}
 
-void MetadataReader::FillEntryWithMethodInfo(MethodInfo& mi, MetadataEntry& entry) {
-    entry.type = NodeType::Method;
-    entry.isTypeMember = true;
-    entry.name = mi.GetName();
-    entry.isResolved = mi.CheckIsResolved() == 1;
-    uint16_t sigLength = mi.GetSignatureLength();
-    assert(sigLength > 0);
-    entry.paramCount = sigLength - 1;
-    entry.sig = mi.GetSignature();
-    FillReturnType(entry);
-}
-
-
-MetadataEntry MetadataReader::ReadInstanceFieldEntry(uint8_t** data) {
-    FieldInfo* fi = *reinterpret_cast<FieldInfo**>(data);
-
-    MetadataEntry entry;
-    FillEntryWithFiedldInfo(fi, entry);
-    entry.isStatic = false;
-    entry.type = NodeType::Field;
-
-    *data += sizeof(FieldInfo);
-
-    return entry;
-}
-
-MetadataEntry MetadataReader::ReadStaticFieldEntry(uint8_t** data) {
-    StaticFieldInfo* sfi = *reinterpret_cast<StaticFieldInfo**>(data);
-
-    MetadataEntry entry;
-    FillEntryWithFiedldInfo(sfi, entry);
-    entry.isStatic = true;
-    entry.type = NodeType::StaticField;
-    entry.declaringType = ReadTypeName(sfi->declaringType);
-
-    *data += sizeof(StaticFieldInfo);
-
-    return entry;
-}
-
-MetadataEntry MetadataReader::ReadInstanceMethodEntry(uint8_t** data) {
-    MetadataEntry entry;
-    MethodInfo mip(*data, this); //method info pointer+
-
-    FillEntryWithMethodInfo(mip, entry);
-
-    *data += mip.GetSizeOfReadMethodInfo();
-
-    return entry;
-}
-
-MetadataTreeNode* MetadataReader::GetNodeById(uint16_t nodeId) {
+MetadataTreeNode *MetadataReader::GetNodeById(uint16_t nodeId) {
     return m_v[nodeId];
 }
 
-MetadataEntry MetadataReader::ReadStaticMethodEntry(uint8_t** data) {
-    MetadataEntry entry;
-    MethodInfo smip(*data, this); //static method info pointer
 
-    FillEntryWithMethodInfo(smip, entry);
-    entry.isStatic = true;
-    entry.declaringType = smip.GetDeclaringType();
-
-    *data += smip.GetSizeOfReadMethodInfo();
-
-    return entry;
-}
-
-MetadataEntry MetadataReader::ReadExtensionFunctionEntry(uint8_t** data) {
-    MetadataEntry entry;
-    MethodInfo smip(*data, this); //static method info pointer
-
-    FillEntryWithMethodInfo(smip, entry);
-    entry.isStatic = true;
-    entry.declaringType = smip.GetDeclaringType();
-    entry.isExtensionFunction = true;
-
-    *data += smip.GetSizeOfReadMethodInfo();
-
-    return entry;
-}
-
-
-string MetadataReader::ReadTypeName(MetadataTreeNode* treeNode) {
+string MetadataReader::ReadTypeName(MetadataTreeNode *treeNode) {
     string name;
 
     auto itFound = m_typeNameCache.find(treeNode);
@@ -193,7 +106,7 @@ string MetadataReader::ReadTypeName(MetadataTreeNode* treeNode) {
     return name;
 }
 
-string MetadataReader::ReadTypeNameInternal(MetadataTreeNode* treeNode) {
+string MetadataReader::ReadTypeNameInternal(MetadataTreeNode *treeNode) {
     string name;
 
     uint8_t prevNodeType;
@@ -205,7 +118,7 @@ string MetadataReader::ReadTypeNameInternal(MetadataTreeNode* treeNode) {
 
         if (isArrayElement) {
             uint16_t forwardNodeId = treeNode->offsetValue - ARRAY_OFFSET;
-            MetadataTreeNode* forwardNode = GetNodeById(forwardNodeId);
+            MetadataTreeNode * forwardNode = GetNodeById(forwardNodeId);
             name = ReadTypeName(forwardNode);
             uint8_t forwardNodeType = GetNodeType(forwardNode);
             if (IsNodeTypeInterface(forwardNodeType) || IsNodeTypeClass(forwardNodeType)) {
@@ -215,7 +128,7 @@ string MetadataReader::ReadTypeNameInternal(MetadataTreeNode* treeNode) {
             if (!name.empty()) {
                 if (!IsNodeTypeArray(curNodeType)) {
                     if ((IsNodeTypeClass(prevNodeType) || IsNodeTypeInterface(prevNodeType))
-                            && (IsNodeTypeClass(curNodeType) || IsNodeTypeInterface(curNodeType))) {
+                        && (IsNodeTypeClass(curNodeType) || IsNodeTypeInterface(curNodeType))) {
                         name = "$" + name;
                     } else {
                         name = "/" + name;
@@ -234,11 +147,11 @@ string MetadataReader::ReadTypeNameInternal(MetadataTreeNode* treeNode) {
     return name;
 }
 
-uint8_t* MetadataReader::GetValueData() const {
+uint8_t *MetadataReader::GetValueData() const {
     return m_valueData;
 }
 
-uint16_t MetadataReader::GetNodeId(MetadataTreeNode* treeNode) {
+uint16_t MetadataReader::GetNodeId(MetadataTreeNode *treeNode) {
     auto itFound = find(m_v.begin(), m_v.end(), treeNode);
     assert(itFound != m_v.end());
     uint16_t nodeId = itFound - m_v.begin();
@@ -246,11 +159,11 @@ uint16_t MetadataReader::GetNodeId(MetadataTreeNode* treeNode) {
     return nodeId;
 }
 
-MetadataTreeNode* MetadataReader::GetRoot() const {
+MetadataTreeNode *MetadataReader::GetRoot() const {
     return m_root;
 }
 
-uint8_t MetadataReader::GetNodeType(MetadataTreeNode* treeNode) {
+uint8_t MetadataReader::GetNodeType(MetadataTreeNode *treeNode) {
     if (treeNode->type == MetadataTreeNode::INVALID_TYPE) {
         uint8_t nodeType;
 
@@ -264,7 +177,7 @@ uint8_t MetadataReader::GetNodeType(MetadataTreeNode* treeNode) {
             nodeType = MetadataTreeNode::ARRAY;
         } else {
             uint16_t nodeId = offsetValue - ARRAY_OFFSET;
-            MetadataTreeNode* arrElemNode = GetNodeById(nodeId);
+            MetadataTreeNode * arrElemNode = GetNodeById(nodeId);
             nodeType = *(m_valueData + arrElemNode->offsetValue);
         }
 
@@ -274,19 +187,19 @@ uint8_t MetadataReader::GetNodeType(MetadataTreeNode* treeNode) {
     return treeNode->type;
 }
 
-MetadataTreeNode* MetadataReader::GetOrCreateTreeNodeByName(const string& className) {
-    MetadataTreeNode* treeNode = GetRoot();
+MetadataTreeNode *MetadataReader::GetOrCreateTreeNodeByName(const string &className) {
+    MetadataTreeNode * treeNode = GetRoot();
 
     int arrayIdx = -1;
     string arrayName = "[";
 
     while (className[++arrayIdx] == '[') {
-        MetadataTreeNode* child = treeNode->GetChild(arrayName);
+        MetadataTreeNode * child = treeNode->GetChild(arrayName);
 
         if (child == nullptr) {
-            vector<MetadataTreeNode*>* children = treeNode->children;
+            vector<MetadataTreeNode *> *children = treeNode->children;
             if (children == nullptr) {
-                children = treeNode->children = new vector<MetadataTreeNode*>;
+                children = treeNode->children = new vector<MetadataTreeNode *>;
             }
 
             child = new MetadataTreeNode;
@@ -310,19 +223,19 @@ MetadataTreeNode* MetadataReader::GetOrCreateTreeNodeByName(const string& classN
         }
     }
 
-    vector < string > names;
+    vector<string> names;
     Util::SplitString(cn, "/$", names);
 
     if (arrayIdx > 0) {
         bool found = false;
-        MetadataTreeNode* forwardedNode = GetOrCreateTreeNodeByName(cn);
+        MetadataTreeNode * forwardedNode = GetOrCreateTreeNodeByName(cn);
 
         uint16_t forwardedNodeId = GetNodeId(forwardedNode);
         if (treeNode->children == nullptr) {
-            treeNode->children = new vector<MetadataTreeNode*>();
+            treeNode->children = new vector<MetadataTreeNode *>();
         }
-        vector<MetadataTreeNode*>& children = *treeNode->children;
-        for (auto childNode : children) {
+        vector<MetadataTreeNode *> &children = *treeNode->children;
+        for (auto childNode: children) {
             uint32_t childNodeId = (childNode->offsetValue >= ARRAY_OFFSET)
                                    ? (childNode->offsetValue - ARRAY_OFFSET)
                                    :
@@ -336,7 +249,7 @@ MetadataTreeNode* MetadataReader::GetOrCreateTreeNodeByName(const string& classN
         }
 
         if (!found) {
-            MetadataTreeNode* forwardNode = new MetadataTreeNode;
+            MetadataTreeNode * forwardNode = new MetadataTreeNode;
             forwardNode->offsetValue = forwardedNodeId + ARRAY_OFFSET;
             forwardNode->parent = treeNode;
 
@@ -351,15 +264,15 @@ MetadataTreeNode* MetadataReader::GetOrCreateTreeNodeByName(const string& classN
 
     int curIdx = 0;
     for (auto it = names.begin(); it != names.end(); ++it) {
-        MetadataTreeNode* child = treeNode->GetChild(*it);
+        MetadataTreeNode * child = treeNode->GetChild(*it);
 
         if (child == nullptr) {
-            vector < string > api = m_getTypeMetadataCallback(cn, curIdx);
+            vector<string> api = m_getTypeMetadataCallback(cn, curIdx);
 
-            for (const auto& part : api) {
-                vector<MetadataTreeNode*>* children = treeNode->children;
+            for (const auto &part: api) {
+                vector<MetadataTreeNode *> *children = treeNode->children;
                 if (children == nullptr) {
-                    children = treeNode->children = new vector<MetadataTreeNode*>;
+                    children = treeNode->children = new vector<MetadataTreeNode *>;
                 }
 
                 child = new MetadataTreeNode;
@@ -381,7 +294,8 @@ MetadataTreeNode* MetadataReader::GetOrCreateTreeNodeByName(const string& classN
 
                 if ((cKind == 'C') || (cKind == 'I')) {
                     child->metadata = new string(part);
-                    child->type = (cKind == 'C') ? MetadataTreeNode::CLASS : MetadataTreeNode::INTERFACE;
+                    child->type = (cKind == 'C') ? MetadataTreeNode::CLASS
+                                                 : MetadataTreeNode::INTERFACE;
                     if (name == "S") {
                         child->type |= MetadataTreeNode::STATIC;
                     }
@@ -397,7 +311,7 @@ MetadataTreeNode* MetadataReader::GetOrCreateTreeNodeByName(const string& classN
 
                     child->offsetValue = m_valueLength;
                     m_valueData[m_valueLength++] = child->type;
-                    *reinterpret_cast<uint16_t*>(m_valueData + m_valueLength) = baseClassNodeId;
+                    *reinterpret_cast<uint16_t *>(m_valueData + m_valueLength) = baseClassNodeId;
                     m_valueLength += sizeof(uint16_t);
                 } else {
                     child->type = MetadataTreeNode::PACKAGE;
@@ -419,11 +333,12 @@ MetadataTreeNode* MetadataReader::GetOrCreateTreeNodeByName(const string& classN
     return treeNode;
 }
 
-MetadataTreeNode* MetadataReader::GetBaseClassNode(MetadataTreeNode* treeNode) {
-    MetadataTreeNode* baseClassNode = nullptr;
+MetadataTreeNode *MetadataReader::GetBaseClassNode(MetadataTreeNode *treeNode) {
+    MetadataTreeNode * baseClassNode = nullptr;
 
     if (treeNode != nullptr) {
-        uint16_t baseClassNodeId = *reinterpret_cast<uint16_t*>(m_valueData + treeNode->offsetValue + 1);
+        uint16_t baseClassNodeId = *reinterpret_cast<uint16_t *>(m_valueData +
+                                                                 treeNode->offsetValue + 1);
 
         size_t nodeCount = m_v.size();
 

--- a/test-app/runtime/src/main/cpp/MetadataReader.h
+++ b/test-app/runtime/src/main/cpp/MetadataReader.h
@@ -20,60 +20,60 @@ namespace tns {
                        uint8_t *nameData, uint32_t valueLength, uint8_t *valueData,
                        GetTypeMetadataCallback getTypeMetadataCallack);
 
-        inline static MetadataEntry* ReadInstanceFieldEntry(uint8_t **data) {
-            auto entry = new MetadataEntry(nullptr, NodeType::Field);
-            entry->fi = *reinterpret_cast<FieldInfo **>(data);
-            entry->isTypeMember = true;
+        inline static MetadataEntry ReadInstanceFieldEntry(uint8_t **data) {
+            MetadataEntry entry(nullptr, NodeType::Field);
+            entry.fi = *reinterpret_cast<FieldInfo **>(data);
+            entry.isStatic = false;
+            entry.isTypeMember = false;
 
             *data += sizeof(FieldInfo);
 
             return entry;
         }
 
-        inline static MetadataEntry* ReadStaticFieldEntry(uint8_t **data) {
-            auto entry = new MetadataEntry(nullptr, NodeType::StaticField);
-            entry->sfi = *reinterpret_cast<StaticFieldInfo **>(data);
-            entry->isStatic = true;
-            entry->isTypeMember = false;
+        inline static MetadataEntry ReadStaticFieldEntry(uint8_t **data) {
+            MetadataEntry entry(nullptr, NodeType::StaticField);
+            entry.sfi = *reinterpret_cast<StaticFieldInfo **>(data);
+            entry.isStatic = true;
+            entry.isTypeMember = false;
 
             *data += sizeof(StaticFieldInfo);
 
             return entry;
         }
 
-        inline static MetadataEntry* ReadInstanceMethodEntry(uint8_t **data) {
-            auto entry = new MetadataEntry(nullptr, NodeType::Method);
-            entry->isTypeMember = true;
+        inline static MetadataEntry ReadInstanceMethodEntry(uint8_t **data) {
+            MetadataEntry entry(nullptr, NodeType::Method);
+            entry.isTypeMember = true;
 
-            entry->mi = new MethodInfo(*data); //method info pointer+
-            *data += entry->mi->GetSizeOfReadMethodInfo();
-
-            return entry;
-        }
-
-
-        inline static MetadataEntry* ReadStaticMethodEntry(uint8_t **data) {
-            auto entry = new MetadataEntry(nullptr, NodeType::Method);
-            entry->isTypeMember = true;
-            entry->mi = new MethodInfo(*data);
-            entry->mi->isStatic = true;
-            entry->isStatic = true;
-
-            *data += entry->mi->GetSizeOfReadMethodInfo();
+            entry.mi = MethodInfo(*data); // Assign MethodInfo object directly
+            *data += entry.mi.GetSizeOfReadMethodInfo();
 
             return entry;
         }
 
-        inline static MetadataEntry* ReadExtensionFunctionEntry(uint8_t **data) {
-            auto entry = new MetadataEntry(nullptr, NodeType::Method);
+        inline static MetadataEntry ReadStaticMethodEntry(uint8_t **data) {
+            MetadataEntry entry(nullptr, NodeType::Method);
+            entry.isTypeMember = true;
 
-            entry->mi = new MethodInfo(*data); //static method info pointer
+            entry.mi = MethodInfo(*data); // Assign MethodInfo object directly
+            entry.mi.isStatic = true;
+            entry.isStatic = true;
 
-            entry->mi->isStatic = true;
-            entry->isExtensionFunction = true;
-            entry->isStatic = true;
+            *data += entry.mi.GetSizeOfReadMethodInfo();
 
-            *data += entry->mi->GetSizeOfReadMethodInfo();
+            return entry;
+        }
+
+        inline static MetadataEntry ReadExtensionFunctionEntry(uint8_t **data) {
+            MetadataEntry entry(nullptr, NodeType::Method);
+
+            entry.mi = MethodInfo(*data); // Assign MethodInfo object directly
+            entry.mi.isStatic = true;
+            entry.isExtensionFunction = true;
+            entry.isStatic = true;
+
+            *data += entry.mi.GetSizeOfReadMethodInfo();
 
             return entry;
         }
@@ -130,8 +130,8 @@ namespace tns {
         MetadataTreeNode *GetNodeById(uint16_t nodeId);
 
         inline bool IsNodeTypeArray(uint8_t type) {
-            bool isArray = (((type & MetadataTreeNode::PRIMITIVE) == 0)
-                            && ((type & MetadataTreeNode::ARRAY) == MetadataTreeNode::ARRAY));
+            bool isArray = (((type & MetadataTreeNode::PRIMITIVE) == 0) &&
+                            ((type & MetadataTreeNode::ARRAY) == MetadataTreeNode::ARRAY));
 
             return isArray;
         }
@@ -143,16 +143,16 @@ namespace tns {
         }
 
         inline bool IsNodeTypeClass(uint8_t type) {
-            bool isClass = (((type & MetadataTreeNode::PRIMITIVE) == 0)
-                            && ((type & MetadataTreeNode::CLASS) == MetadataTreeNode::CLASS));
+            bool isClass = (((type & MetadataTreeNode::PRIMITIVE) == 0) &&
+                            ((type & MetadataTreeNode::CLASS) == MetadataTreeNode::CLASS));
 
             return isClass;
         }
 
         inline bool IsNodeTypeInterface(uint8_t type) {
-            bool isInterface = (((type & MetadataTreeNode::PRIMITIVE) == 0)
-                                && ((type & MetadataTreeNode::INTERFACE) ==
-                                    MetadataTreeNode::INTERFACE));
+            bool isInterface = (((type & MetadataTreeNode::PRIMITIVE) == 0) &&
+                                ((type & MetadataTreeNode::INTERFACE) ==
+                                 MetadataTreeNode::INTERFACE));
 
             return isInterface;
         }
@@ -163,10 +163,10 @@ namespace tns {
             return isPackage;
         }
 
-//        inline static void FillReturnType(MetadataEntry* entry) {
-//            entry->returnType = ParseReturnType(entry->getSig());
-//            entry->retType = GetReturnType(entry->getReturnType());
-//        }
+        //        inline static void FillReturnType(MetadataEntry* entry) {
+        //            entry->returnType = ParseReturnType(entry->getSig());
+        //            entry->retType = GetReturnType(entry->getReturnType());
+        //        }
 
         inline static std::string ParseReturnType(const std::string &signature) {
             int idx = signature.find(')');
@@ -209,8 +209,7 @@ namespace tns {
                 case 'L':
                     retType = (returnType == "Ljava/lang/String;")
                               ? MethodReturnType::String
-                              :
-                              MethodReturnType::Object;
+                              : MethodReturnType::Object;
                     break;
                 default:
                     assert(false);
@@ -220,7 +219,6 @@ namespace tns {
         }
 
     private:
-
         static const uint32_t ARRAY_OFFSET = 1000000000;
 
         MetadataTreeNode *BuildTree();

--- a/test-app/runtime/src/main/cpp/MetadataReader.h
+++ b/test-app/runtime/src/main/cpp/MetadataReader.h
@@ -7,74 +7,127 @@
 #include <string>
 #include <assert.h>
 #include "robin_hood.h"
+
 namespace tns {
-typedef std::vector<std::string> (*GetTypeMetadataCallback)(const std::string& classname, int index);
+    typedef std::vector<std::string> (*GetTypeMetadataCallback)(const std::string &classname,
+                                                                int index);
 
-class MethodInfo;
-
-class MetadataReader {
+    class MetadataReader {
     public:
         MetadataReader();
 
-        MetadataReader(uint32_t nodesLength, uint8_t* nodeData, uint32_t nameLength, uint8_t* nameData, uint32_t valueLength, uint8_t* valueData, GetTypeMetadataCallback getTypeMetadataCallack);
+        MetadataReader(uint32_t nodesLength, uint8_t *nodeData, uint32_t nameLength,
+                       uint8_t *nameData, uint32_t valueLength, uint8_t *valueData,
+                       GetTypeMetadataCallback getTypeMetadataCallack);
 
-        MetadataEntry ReadInstanceMethodEntry(uint8_t** data);
+        inline static MetadataEntry* ReadInstanceFieldEntry(uint8_t **data) {
+            auto entry = new MetadataEntry(nullptr, NodeType::Field);
+            entry->fi = *reinterpret_cast<FieldInfo **>(data);
+            entry->isTypeMember = true;
 
-        MetadataEntry ReadStaticMethodEntry(uint8_t** data);
+            *data += sizeof(FieldInfo);
 
-        MetadataEntry ReadExtensionFunctionEntry(uint8_t** data);
+            return entry;
+        }
 
-        MetadataEntry ReadInstanceFieldEntry(uint8_t** data);
+        inline static MetadataEntry* ReadStaticFieldEntry(uint8_t **data) {
+            auto entry = new MetadataEntry(nullptr, NodeType::StaticField);
+            entry->sfi = *reinterpret_cast<StaticFieldInfo **>(data);
+            entry->isStatic = true;
+            entry->isTypeMember = false;
 
-        MetadataEntry ReadStaticFieldEntry(uint8_t** data);
+            *data += sizeof(StaticFieldInfo);
 
-       inline std::string ReadTypeName(uint16_t nodeId){
-           MetadataTreeNode* treeNode = GetNodeById(nodeId);
+            return entry;
+        }
 
-           return ReadTypeName(treeNode);
-       }
+        inline static MetadataEntry* ReadInstanceMethodEntry(uint8_t **data) {
+            auto entry = new MetadataEntry(nullptr, NodeType::Method);
+            entry->isTypeMember = true;
 
-       std::string ReadTypeName(MetadataTreeNode* treeNode);
+            entry->mi = new MethodInfo(*data); //method info pointer+
+            *data += entry->mi->GetSizeOfReadMethodInfo();
 
-       inline std::string ReadName(uint32_t offset) {
-           uint16_t length = *reinterpret_cast<short*>(m_nameData + offset);
+            return entry;
+        }
 
-           std::string name(reinterpret_cast<char*>(m_nameData + offset + sizeof(uint16_t)), length);
 
-           return name;
-       }
+        inline static MetadataEntry* ReadStaticMethodEntry(uint8_t **data) {
+            auto entry = new MetadataEntry(nullptr, NodeType::Method);
+            entry->isTypeMember = true;
+            entry->mi = new MethodInfo(*data);
+            entry->mi->isStatic = true;
+            entry->isStatic = true;
 
-       inline std::string ReadInterfaceImplementationTypeName(MetadataTreeNode* treeNode, bool& isPrefix) {
-           uint8_t* data = m_valueData + treeNode->offsetValue + sizeof(uint8_t) + sizeof(uint16_t);
+            *data += entry->mi->GetSizeOfReadMethodInfo();
 
-           isPrefix = *data == 1;
+            return entry;
+        }
 
-           uint32_t pos = *reinterpret_cast<uint32_t*>(data + sizeof(uint8_t));
+        inline static MetadataEntry* ReadExtensionFunctionEntry(uint8_t **data) {
+            auto entry = new MetadataEntry(nullptr, NodeType::Method);
 
-           uint16_t len = *reinterpret_cast<uint16_t*>(m_nameData + pos);
+            entry->mi = new MethodInfo(*data); //static method info pointer
 
-           char* ptr = reinterpret_cast<char*>(m_nameData + pos + sizeof(uint16_t));
+            entry->mi->isStatic = true;
+            entry->isExtensionFunction = true;
+            entry->isStatic = true;
 
-           std::string name(ptr, len);
+            *data += entry->mi->GetSizeOfReadMethodInfo();
 
-           assert(name.length() == len);
+            return entry;
+        }
 
-           return name;
-       }
+        inline std::string ReadTypeName(uint16_t nodeId) {
+            MetadataTreeNode *treeNode = GetNodeById(nodeId);
 
-        uint8_t* GetValueData() const;
+            return ReadTypeName(treeNode);
+        }
 
-        uint8_t GetNodeType(MetadataTreeNode* treeNode);
+        std::string ReadTypeName(MetadataTreeNode *treeNode);
 
-        uint16_t GetNodeId(MetadataTreeNode* treeNode);
+        inline std::string ReadName(uint32_t offset) {
+            uint16_t length = *reinterpret_cast<short *>(m_nameData + offset);
 
-        MetadataTreeNode* GetRoot() const;
+            std::string name(reinterpret_cast<char *>(m_nameData + offset + sizeof(uint16_t)),
+                             length);
 
-        MetadataTreeNode* GetOrCreateTreeNodeByName(const std::string& className);
+            return name;
+        }
 
-        MetadataTreeNode* GetBaseClassNode(MetadataTreeNode* treeNode);
+        inline std::string
+        ReadInterfaceImplementationTypeName(MetadataTreeNode *treeNode, bool &isPrefix) {
+            uint8_t *data =
+                    m_valueData + treeNode->offsetValue + sizeof(uint8_t) + sizeof(uint16_t);
 
-        MetadataTreeNode* GetNodeById(uint16_t nodeId);
+            isPrefix = *data == 1;
+
+            uint32_t pos = *reinterpret_cast<uint32_t *>(data + sizeof(uint8_t));
+
+            uint16_t len = *reinterpret_cast<uint16_t *>(m_nameData + pos);
+
+            char *ptr = reinterpret_cast<char *>(m_nameData + pos + sizeof(uint16_t));
+
+            std::string name(ptr, len);
+
+            assert(name.length() == len);
+
+            return name;
+        }
+
+        uint8_t *GetValueData() const;
+
+        uint8_t GetNodeType(MetadataTreeNode *treeNode);
+
+        uint16_t GetNodeId(MetadataTreeNode *treeNode);
+
+        MetadataTreeNode *GetRoot() const;
+
+        MetadataTreeNode *GetOrCreateTreeNodeByName(const std::string &className);
+
+        MetadataTreeNode *GetBaseClassNode(MetadataTreeNode *treeNode);
+
+        MetadataTreeNode *GetNodeById(uint16_t nodeId);
 
         inline bool IsNodeTypeArray(uint8_t type) {
             bool isArray = (((type & MetadataTreeNode::PRIMITIVE) == 0)
@@ -98,7 +151,8 @@ class MetadataReader {
 
         inline bool IsNodeTypeInterface(uint8_t type) {
             bool isInterface = (((type & MetadataTreeNode::PRIMITIVE) == 0)
-                                && ((type & MetadataTreeNode::INTERFACE) == MetadataTreeNode::INTERFACE));
+                                && ((type & MetadataTreeNode::INTERFACE) ==
+                                    MetadataTreeNode::INTERFACE));
 
             return isInterface;
         }
@@ -109,18 +163,18 @@ class MetadataReader {
             return isPackage;
         }
 
-        inline static void FillReturnType(MetadataEntry& entry) {
-            entry.returnType = ParseReturnType(entry.sig);
-            entry.retType = GetReturnType(entry.returnType);
-        }
+//        inline static void FillReturnType(MetadataEntry* entry) {
+//            entry->returnType = ParseReturnType(entry->getSig());
+//            entry->retType = GetReturnType(entry->getReturnType());
+//        }
 
-        inline static std::string ParseReturnType(const std::string& signature) {
+        inline static std::string ParseReturnType(const std::string &signature) {
             int idx = signature.find(')');
             auto returnType = signature.substr(idx + 1);
             return returnType;
         }
 
-        inline static MethodReturnType GetReturnType(const std::string& returnType) {
+        inline static MethodReturnType GetReturnType(const std::string &returnType) {
             MethodReturnType retType;
             char retTypePrefix = returnType[0];
             switch (retTypePrefix) {
@@ -169,26 +223,26 @@ class MetadataReader {
 
         static const uint32_t ARRAY_OFFSET = 1000000000;
 
-        MetadataTreeNode* BuildTree();
+        MetadataTreeNode *BuildTree();
 
-        std::string ReadTypeNameInternal(MetadataTreeNode* treeNode);
+        std::string ReadTypeNameInternal(MetadataTreeNode *treeNode);
 
-        void FillEntryWithFiedldInfo(FieldInfo* fi, MetadataEntry& entry);
+        void FillEntryWithFiedldInfo(FieldInfo *fi, MetadataEntry &entry);
 
-        void FillEntryWithMethodInfo(MethodInfo& mi, MetadataEntry& entry);
+        void FillEntryWithMethodInfo(MethodInfo &mi, MetadataEntry &entry);
 
-        MetadataTreeNode* m_root;
+        MetadataTreeNode *m_root;
         uint32_t m_nodesLength;
         uint32_t m_nameLength;
         uint32_t m_valueLength;
-        uint8_t* m_nodeData;
-        uint8_t* m_nameData;
-        uint8_t* m_valueData;
-        std::vector<MetadataTreeNode*> m_v;
+        uint8_t *m_nodeData;
+        uint8_t *m_nameData;
+        uint8_t *m_valueData;
+        std::vector<MetadataTreeNode *> m_v;
         GetTypeMetadataCallback m_getTypeMetadataCallback;
 
-        robin_hood::unordered_map<MetadataTreeNode*, std::string> m_typeNameCache;
-};
+        robin_hood::unordered_map<MetadataTreeNode *, std::string> m_typeNameCache;
+    };
 }
 
 #endif /* METADATAREADER_H_ */

--- a/test-app/runtime/src/main/cpp/MetadataReader.h
+++ b/test-app/runtime/src/main/cpp/MetadataReader.h
@@ -163,11 +163,6 @@ namespace tns {
             return isPackage;
         }
 
-        //        inline static void FillReturnType(MetadataEntry* entry) {
-        //            entry->returnType = ParseReturnType(entry->getSig());
-        //            entry->retType = GetReturnType(entry->getReturnType());
-        //        }
-
         inline static std::string ParseReturnType(const std::string &signature) {
             int idx = signature.find(')');
             auto returnType = signature.substr(idx + 1);


### PR DESCRIPTION
Java classes can have 100s and even thousands of methods and properties on them, for example `android.view.View` has 673 methods on it, similarly `android.R` class has always been slow to access since it has many nested classes. A common issue that many of us have faced and tried to workaround in various ways using metadata filtering and other hacks. But it doesn't properly fix the problem, even classes that have a few methods, take too long to load the first time. This can have affect on TTI, navigating to new pages that access a java class my many methods because everything is running on UI thread. 

This PR tries to fix the issue once and for all, loading classes is now super fast. Almost as fast as the iOS runtime. But how?

1. Classes will still load all their properties and methods eagerly like before but we avoid loading metadata information we don't need like the method name, signature, return type etc etc for methods. When you call a java method the first time, that information is loaded and cached for further calls.
2. We don't eagerly load Inner type members like `android.R.integer`. For example accessing `android.R.integer` only loads methods, properties on `android.R` & `android.R.integer` and any base classes. Previously it would load all classes in `android.R` then load your class `android.R.integer` which would take 100s of ms!
3. In java you can have method overloads, to tackle this the current runtime stores method information in a `std::unordered_map` and for every method it adds to the prototype, it will check whether there is existing method information of a method with same name. This is fine for small classes but when class is huge, the lookup becomes quite slow. To fix this we have used `robin_hood::unordered_map` that results in great performance gain.

There are still places that could see improvement but as of now with theses changes, most classes will load in 0.1-0.2ms.

This is a big change and is spread across multiple files.