### PR TITLE
feat: support import.meta.hot.data for persistent objects across hmr …

### DIFF
--- a/test-app/app/src/main/assets/app/hmrHotKeyExt.js
+++ b/test-app/app/src/main/assets/app/hmrHotKeyExt.js
@@ -1,0 +1,50 @@
+export function getHotData() {
+  return import.meta?.hot?.data;
+}
+
+export function setHotValue(value) {
+  const hot = import.meta?.hot;
+  if (!hot || !hot.data) {
+    throw new Error("import.meta.hot.data is not available");
+  }
+  hot.data.value = value;
+  return hot.data.value;
+}
+
+export function getHotValue() {
+  const hot = import.meta?.hot;
+  return hot?.data?.value;
+}
+
+export function testHotApi() {
+  const hot = import.meta?.hot;
+  const result = {
+    ok: false,
+    hasHot: !!hot,
+    hasData: !!hot?.data,
+    hasAccept: typeof hot?.accept === "function",
+    hasDispose: typeof hot?.dispose === "function",
+    hasDecline: typeof hot?.decline === "function",
+    hasInvalidate: typeof hot?.invalidate === "function",
+    pruneIsFalse: hot?.prune === false,
+  };
+
+  try {
+    hot?.accept?.(() => {});
+    hot?.dispose?.(() => {});
+    hot?.decline?.();
+    hot?.invalidate?.();
+    result.ok =
+      result.hasHot &&
+      result.hasData &&
+      result.hasAccept &&
+      result.hasDispose &&
+      result.hasDecline &&
+      result.hasInvalidate &&
+      result.pruneIsFalse;
+  } catch (e) {
+    result.error = e?.message ?? String(e);
+  }
+
+  return result;
+}

--- a/test-app/app/src/main/assets/app/hmrHotKeyExt.mjs
+++ b/test-app/app/src/main/assets/app/hmrHotKeyExt.mjs
@@ -1,0 +1,51 @@
+export function getHotData() {
+  return import.meta?.hot?.data;
+}
+
+export function setHotValue(value) {
+  const hot = import.meta?.hot;
+  if (!hot || !hot.data) {
+    throw new Error("import.meta.hot.data is not available");
+  }
+  hot.data.value = value;
+  return hot.data.value;
+}
+
+export function getHotValue() {
+  const hot = import.meta?.hot;
+  return hot?.data?.value;
+}
+
+export function testHotApi() {
+  const hot = import.meta?.hot;
+  const result = {
+    ok: false,
+    hasHot: !!hot,
+    hasData: !!hot?.data,
+    hasAccept: typeof hot?.accept === "function",
+    hasDispose: typeof hot?.dispose === "function",
+    hasDecline: typeof hot?.decline === "function",
+    hasInvalidate: typeof hot?.invalidate === "function",
+    pruneIsFalse: hot?.prune === false,
+  };
+
+  try {
+    // accept([deps], cb?) — deps ignored, cb registered if provided
+    hot?.accept?.(() => {});
+    hot?.dispose?.(() => {});
+    hot?.decline?.();
+    hot?.invalidate?.();
+    result.ok =
+      result.hasHot &&
+      result.hasData &&
+      result.hasAccept &&
+      result.hasDispose &&
+      result.hasDecline &&
+      result.hasInvalidate &&
+      result.pruneIsFalse;
+  } catch (e) {
+    result.error = e?.message ?? String(e);
+  }
+
+  return result;
+}


### PR DESCRIPTION
- Support for import.meta.hot.data
- More stability and correctness to HMR with HTTP module loading

Matches behavior in https://github.com/NativeScript/ios/pull/329