### PR TITLE
fix: ensure dex cache directory exists before proxy generation

### DIFF
--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -123,6 +123,18 @@ public final class RuntimeHelper {
 
                 ClassLoader classLoader = context.getClassLoader();
                 File dexDir = new File(rootDir, "code_cache/secondary-dexes");
+                if (!dexDir.exists()) {
+                    dexDir.mkdirs();
+                }
+                if (!dexDir.exists() || !dexDir.canWrite()) {
+                    if (logger.isEnabled()) {
+                        logger.write("Unable to use dex dir: " + dexDir.getAbsolutePath() + ", falling back to files/secondary-dexes");
+                    }
+                    dexDir = new File(appDir, "secondary-dexes");
+                    if (!dexDir.exists()) {
+                        dexDir.mkdirs();
+                    }
+                }
                 String dexThumb = null;
                 try {
                     dexThumb = Util.getDexThumb(context);

--- a/test-app/runtime-binding-generator/src/main/java/com/tns/bindings/ProxyGenerator.java
+++ b/test-app/runtime-binding-generator/src/main/java/com/tns/bindings/ProxyGenerator.java
@@ -58,6 +58,10 @@ public class ProxyGenerator {
 
     private String saveProxy(String proxyName, byte[] proxyBytes) throws IOException {
         File file = new File(path + File.separator + proxyName + ".dex");
+        File parentDir = file.getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs();
+        }
         file.createNewFile();
         FileOutputStream stream = new FileOutputStream(file);
         stream.write(proxyBytes);


### PR DESCRIPTION
## Summary

- Hardens dex cache directory setup to verify the directory exists and is writable after `mkdirs()`, falling back to `files/secondary-dexes` if `code_cache/secondary-dexes` is unusable
- Adds defensive `mkdirs()` in `ProxyGenerator.saveProxy()` before `createNewFile()` as a safety net

## Context

`ProxyGenerator.saveProxy()` calls `File.createNewFile()` which fails with ENOENT when the parent directory is missing. The runtime constructs the dex cache path manually (`<dataDir>/code_cache/secondary-dexes`) rather than using `Context.getCodeCacheDir()`, and while `DexFactory` calls `mkdirs()` at init time, it never checks the return value.

On newer Android versions (API 28+), the OS can clear `code_cache` to reclaim storage, and stricter permission models can cause `mkdirs()` to silently fail. This was always fragile but rarely triggered on older Android versions where `code_cache` was reliably present.
