### PR TITLE
fix: dex loader parent injection release vs debug

### DIFF
--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -766,7 +766,13 @@ public class Runtime {
             this.logger = logger;
 
             boolean isMainThread = this.workerId == 0;
-            this.dexFactory = new DexFactory(logger, classLoader, dexDir, dexThumb, classStorageService, isMainThread);
+            // Parent-classloader injection is for debug/HMR cases where generated
+            // classes must be visible to framework reflection. In release, keep
+            // runtime-generated proxies in their isolated DexClassLoader; injecting
+            // through a temporary DexClassLoader can make ART reject the same dex
+            // path as registered by multiple class loaders.
+            boolean injectIntoParentClassLoader = isMainThread && isDebuggable;
+            this.dexFactory = new DexFactory(logger, classLoader, dexDir, dexThumb, classStorageService, injectIntoParentClassLoader);
 
             if (logger.isEnabled()) {
                 logger.write("Initializing NativeScript JAVA");


### PR DESCRIPTION
- control whether runtime-generated classes are injected into the parent class loader based on whether the app is running in debug mode on the main thread, improving class loader behavior for debug scenarios while avoiding issues in release builds.

closes https://github.com/NativeScript/android/issues/1962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Refined class loader behavior to properly handle debuggable and release builds, enhancing app stability and isolation across different build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->