### PR TITLE
fix: propagate custom ndkVersion to the runtime build

### DIFF
--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -87,7 +87,7 @@ android {
     }
 
     if (hasNdkVersion) {
-        ndkVersion ndkVersion
+        ndkVersion project.ndkVersion
     } else {
         ndkVersion defaultNdkVersion
     }


### PR DESCRIPTION
While building the runtime with a custom NDK version I noticed it never actually took effect. It comes down to this in `test-app/runtime/build.gradle`:

```groovy
if (hasNdkVersion) {
    ndkVersion ndkVersion
}
```

This was added in cbd0ab18 to forward a `-PndkVersion` property into the `android` DSL. The catch is that inside the `android {}` block Groovy resolves names against the extension first, so the `ndkVersion` argument hits the extension's own getter, which is still empty there, and the line just assigns that empty value back to itself. The project property is never read. The `else` branch only works because `defaultNdkVersion` isn't a property on the extension, so it falls through to script scope.

Reading it explicitly with `project.ndkVersion` fixes it. Easy to check: pass `-PndkVersion=<something>` and `android.ndkVersion` comes out empty before this change and holds the value after. It usually goes unnoticed because most builds take the `else` branch, and an empty `ndkVersion` just makes AGP fall back to a default NDK rather than failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android NDK version configuration in the build system to use Gradle properties for improved build configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->