### PR TITLE
fix: point android-dts-generator submodule at main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "test-app/build-tools/android-dts-generator"]
 	path = test-app/build-tools/android-dts-generator
 	url = https://github.com/NativeScript/android-dts-generator.git
-	branch = master
+	branch = main


### PR DESCRIPTION
The `android-dts-generator` submodule tracks `branch = master` in `.gitmodules`, but that repo renamed its default branch to `main` and deleted `master`. `git ls-remote https://github.com/NativeScript/android-dts-generator.git` only lists `main` now.

A normal recursive clone isn't affected, since it checks out the recorded commit and ignores the branch field, and that commit is reachable. What does break is `git submodule update --remote`, which tries to resolve `origin/master` and finds nothing there. This just points the submodule at the branch that actually exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build tools repository configuration to track the latest development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->