### PR TITLE
fix: normalize "." and ".." in resolved module paths to dedupe modules

### DIFF
--- a/test-app/app/src/main/assets/app/esm-dedup/counter.mjs
+++ b/test-app/app/src/main/assets/app/esm-dedup/counter.mjs
@@ -1,0 +1,8 @@
+// Singleton module: an ES module is evaluated once, so every importer must
+// observe this same `state` object regardless of how the specifier spelled the
+// path to this file.
+export const state = { count: 0 };
+
+export function increment() {
+    state.count++;
+}

--- a/test-app/app/src/main/assets/app/esm-dedup/nested/viaParentDir.mjs
+++ b/test-app/app/src/main/assets/app/esm-dedup/nested/viaParentDir.mjs
@@ -1,0 +1,6 @@
+// Reaches the same counter.mjs one directory up: "../counter.mjs".
+import { state, increment } from "../counter.mjs";
+
+increment();
+
+export const seenState = state;

--- a/test-app/app/src/main/assets/app/esm-dedup/viaSameDir.mjs
+++ b/test-app/app/src/main/assets/app/esm-dedup/viaSameDir.mjs
@@ -1,0 +1,6 @@
+// Reaches counter.mjs as a same-directory sibling: "./counter.mjs".
+import { state, increment } from "./counter.mjs";
+
+increment();
+
+export const seenState = state;

--- a/test-app/app/src/main/assets/app/tests/testESModules.mjs
+++ b/test-app/app/src/main/assets/app/tests/testESModules.mjs
@@ -61,4 +61,21 @@ describe("ES Modules", () => {
         (err) => { expect(err).toBeUndefined(); done(); }
       );
   });
+
+  it("resolves './x' and '../x' to a single shared module instance", (done) => {
+    Promise.all([
+      import("~/esm-dedup/viaSameDir.mjs"),
+      import("~/esm-dedup/nested/viaParentDir.mjs"),
+    ]).then(
+      ([sameDir, parentDir]) => {
+        // The same counter.mjs is reached as "./counter.mjs" and as
+        // "../counter.mjs"; it must be one module instance sharing one state
+        // object, incremented once per importer.
+        expect(sameDir.seenState).toBe(parentDir.seenState);
+        expect(sameDir.seenState.count).toBe(2);
+        done();
+      },
+      (err) => { expect(err).toBeUndefined(); done(); }
+    );
+  });
 });

--- a/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.cpp
@@ -593,6 +593,14 @@ v8::MaybeLocal<v8::Module> ResolveModuleCallback(v8::Local<v8::Context> context,
         if (found) break;
     }
 
+    // Canonicalize "." / ".." segments so a file reached through different
+    // spellings (e.g. "./x" from /a/b and "../x" from /a/b/c both name /a/b/x)
+    // maps to one registry key and is compiled once. The HTTP branch
+    // canonicalizes via CanonicalizeHttpUrlKey.
+    if (found) {
+        absPath = NormalizeDotSegments(absPath);
+    }
+
     // 6) Handle special cases if file not found
     if (!found) {
         // Check for Node.js built-in modules


### PR DESCRIPTION
`ResolveModuleCallback` builds the on-disk path for a relative specifier without collapsing `.` and `..` segments, so the same file imported as `./x` from `/a/b` and as `../x` from `/a/b/c` lands under two different registry keys. `stat()` resolves the segments so both locate the file, but the differing keys make V8 compile and evaluate the module twice: two instances with separate module state, broken cyclic resolution, and an `import.meta.dirname` of `/a/b/c/..` for the `..` spelling.

This normalizes the resolved path before it becomes the registry key, the same way the HTTP branch already canonicalizes through `CanonicalizeHttpUrlKey`. The pass is lexical (matching how specifiers are joined, not a `realpath`) and applies to every on-disk candidate kind; it is a no-op for already-canonical paths.

Test: a test-app spec imports one module as `./counter.mjs` and `../counter.mjs` and asserts they share one instance (`===`, and a counter incremented to 2). It fails before the change and passes after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module loading so the same module is treated consistently even when reached through different relative paths.
  * Shared state now updates reliably across multiple import locations, preventing duplicate copies of the same counter.
  * Added coverage to verify that imports from different paths observe the same live state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->