### PR TITLE
feat: support native ES classes with lazy registration

### DIFF
--- a/test-app/app/src/main/assets/app/mainpage.js
+++ b/test-app/app/src/main/assets/app/mainpage.js
@@ -42,6 +42,7 @@ require("./tests/testGC");
 require("./tests/testsMemoryManagement");
 require("./tests/testFieldGetSet");
 require("./tests/extendedClassesTests");
+require("./tests/testNativeESClasses");
 //require("./tests/extendClassNameTests"); // as tests now run with SBG, this test fails the whole build process
 require("./tests/testJniReferenceLeak");
 require("./tests/testNativeModules");

--- a/test-app/app/src/main/assets/app/mainpage.js
+++ b/test-app/app/src/main/assets/app/mainpage.js
@@ -46,6 +46,7 @@ require("./tests/testGC");
 require("./tests/testsMemoryManagement");
 require("./tests/testFieldGetSet");
 require("./tests/extendedClassesTests");
+require("./tests/testNativeESClasses");
 //require("./tests/extendClassNameTests"); // as tests now run with SBG, this test fails the whole build process
 require("./tests/testJniReferenceLeak");
 require("./tests/testNativeModules");

--- a/test-app/app/src/main/assets/app/tests/testNativeESClasses.js
+++ b/test-app/app/src/main/assets/app/tests/testNativeESClasses.js
@@ -303,17 +303,162 @@ describe("Tests native ES class extensions (class X extends NativeType)", functi
         }).not.toThrow();
     });
 
-    it("When_the_NativeClass_decorator_is_applied_it_should_be_a_noop", function () {
+    it("When_java_instantiates_an_es_class_the_js_constructor_and_fields_should_run", function () {
+        var constructorRuns = 0;
+
+        class ESAllocCtorObject extends java.lang.Object {
+            field = 42;
+
+            constructor() {
+                super();
+                constructorRuns++;
+                this.initializedFromJs = true;
+            }
+        }
+
+        // Objects Java allocates — Class.newInstance here, but equally view
+        // inflation or framework construction — are adopted into a real ES
+        // construct so class fields and the constructor body run on both paths.
+        var allocated = ESAllocCtorObject.class.newInstance();
+        expect(constructorRuns).toBe(1);
+        expect(allocated.field).toBe(42);
+        expect(allocated.initializedFromJs).toBe(true);
+        expect(allocated instanceof ESAllocCtorObject).toBe(true);
+
+        var constructed = new ESAllocCtorObject();
+        expect(constructorRuns).toBe(2);
+        expect(constructed.field).toBe(42);
+        expect(constructed.initializedFromJs).toBe(true);
+    });
+
+    it("When_java_instantiates_an_es_class_private_fields_should_be_readable", function () {
+        class ESPrivateAllocObject extends java.lang.Object {
+            #a = 1;
+
+            constructor() {
+                super();
+            }
+
+            someMethod() {
+                return this.#a;
+            }
+        }
+
+        expect(new ESPrivateAllocObject().someMethod()).toBe(1);
+        expect(ESPrivateAllocObject.class.newInstance().someMethod()).toBe(1);
+    });
+
+    it("When_java_instantiates_an_es_class_super_args_should_not_construct_again", function () {
+        class ESAdoptOnceObject extends com.tns.tests.DummyClass {
+            constructor() {
+                super("from-super");
+            }
+        }
+
+        // Java already called the no-arg DummyClass ctor (nameField = "dummy").
+        // Adopt must not run DummyClass(String).
+        var allocated = ESAdoptOnceObject.class.newInstance();
+        expect(allocated.nameField).toBe("dummy");
+        expect(allocated instanceof ESAdoptOnceObject).toBe(true);
+
+        var constructed = new ESAdoptOnceObject();
+        expect(constructed.nameField).toBe("from-super");
+        expect(constructed instanceof ESAdoptOnceObject).toBe(true);
+    });
+
+    it("When_an_es_class_constructor_throws_both_paths_should_surface_the_error", function () {
+        class ESThrowingCtorObject extends java.lang.Object {
+            constructor() {
+                super();
+                throw new Error("adopt construct failed");
+            }
+        }
+
+        var threw = false;
+        try {
+            ESThrowingCtorObject.class.newInstance();
+        } catch (e) {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+
+        threw = false;
+        try {
+            new ESThrowingCtorObject();
+        } catch (e) {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+    });
+
+    it("When_the_NativeClass_decorator_is_applied_it_should_apply_android_options", function () {
         expect(typeof global.NativeClass).toBe("function");
 
-        const DecoratedButton = global.NativeClass(class DecoratedButton extends com.tns.tests.Button1 {
+        const ESDecoratedPlain = global.NativeClass(class ESDecoratedPlainObject extends com.tns.tests.Button1 {
             getIMAGE_ID_PROP() {
                 return "decorated";
             }
         });
 
-        var button = new DecoratedButton();
+        var button = new ESDecoratedPlain();
+        expect(button instanceof ESDecoratedPlain).toBe(true);
         expect(button.getIMAGE_ID_PROP()).toBe("decorated");
+
+        var ran = { value: false };
+        const ESDecoratedInterfaces = global.NativeClass({
+            android: {
+                interfaces: [java.lang.Runnable]
+            }
+        })(
+            class ESDecoratedInterfacesObject extends java.lang.Object {
+                run() {
+                    ran.value = true;
+                }
+            }
+        );
+
+        var instance = new ESDecoratedInterfaces();
+        expect(instance instanceof java.lang.Runnable).toBe(true);
+
+        var thread = new java.lang.Thread(instance);
+        thread.run();
+        expect(ran.value).toBe(true);
+    });
+
+    it("When_NativeClass_sets_an_android_name_the_proxy_should_register_immediately", function () {
+        const ESEagerNamed = global.NativeClass({
+            android: {
+                name: "com.tns.gen.ESEagerNamedObject"
+            }
+        })(class UnusedJsNameForEager extends java.lang.Object {
+        });
+
+        expect(ESEagerNamed.class.getName()).toBe("com.tns.gen.ESEagerNamedObject");
+        expect(java.lang.Class.forName("com.tns.gen.ESEagerNamedObject", false, appClassLoader).equals(ESEagerNamed.class)).toBe(true);
+        expect(new ESEagerNamed() instanceof ESEagerNamed).toBe(true);
+    });
+
+    it("When_NativeClass_runs_on_a_worker_it_should_be_a_noop", function (done) {
+        var worker = new Worker("../shared/Workers/EvalWorker.js");
+        worker.onmessage = function (msg) {
+            expect(msg.data.isFunction).toBe(true);
+            expect(msg.data.isWorker).toBe(true);
+            expect(msg.data.hasName).toBe(false);
+            expect(msg.data.found).toBe(false);
+            worker.terminate();
+            done();
+        };
+        worker.onerror = function (error) {
+            fail("worker failed: " + error.message);
+            worker.terminate();
+            done();
+        };
+        worker.postMessage({
+            eval: "var C = NativeClass({ android: { name: 'com.tns.gen.TNSWorkerNativeClassName' } })(class TNSWorkerNativeClass extends java.lang.Object {}); " +
+                  "var found = false; " +
+                  "try { java.lang.Class.forName('com.tns.gen.TNSWorkerNativeClassName'); found = true; } catch (e) {} " +
+                  "postMessage({ isFunction: typeof NativeClass === 'function', isWorker: !!__ns__worker, hasName: C.nativeClassName === 'com.tns.gen.TNSWorkerNativeClassName', found: found });"
+        });
     });
 
     it("When_anonymous_es_classes_extend_native_types_each_should_get_a_distinct_proxy", function () {

--- a/test-app/app/src/main/assets/app/tests/testNativeESClasses.js
+++ b/test-app/app/src/main/assets/app/tests/testNativeESClasses.js
@@ -1,0 +1,338 @@
+describe("Tests native ES class extensions (class X extends NativeType)", function () {
+
+    var appClassLoader = com.tns.Runtime.class.getClassLoader();
+
+    // DummyClass.method2(Object) returns "obj=" + obj.toString(), forcing a Java-side virtual
+    // toString dispatch through the generated proxy. (java.lang.String.valueOf is unusable for
+    // this: accessing `java.lang.String.null` in other suites permanently replaces `valueOf` on
+    // the ctor function with the runtime's null-returning valueOf.)
+    function javaToString(obj) {
+        return new com.tns.tests.DummyClass().method2(obj);
+    }
+
+    it("When_extending_a_class_with_es_class_syntax_instances_should_construct_and_dispatch_overrides", function () {
+        class EsButton extends com.tns.tests.Button1 {
+            getIMAGE_ID_PROP() {
+                return "es class override";
+            }
+        }
+
+        var button = new EsButton();
+
+        expect(button instanceof EsButton).toBe(true);
+        expect(button instanceof com.tns.tests.Button1).toBe(true);
+        expect(button.getIMAGE_ID_PROP()).toBe("es class override");
+        // non-overridden base methods still work
+        expect(button.echo("hello")).toBe("hello");
+    });
+
+    it("When_java_calls_a_virtual_method_it_should_dispatch_to_the_es_class_override", function () {
+        class EchoButton extends com.tns.tests.Button1 {
+            echo(s) {
+                return "es:" + s;
+            }
+        }
+
+        var button = new EchoButton();
+
+        // triggerEcho calls this.echo(s) on the Java side - it must route
+        // through the generated proxy back into the ES class method
+        expect(button.triggerEcho("x")).toBe("es:x");
+    });
+
+    it("When_calling_super_method_from_an_es_class_override_it_should_invoke_the_java_implementation", function () {
+        class SuperEchoButton extends com.tns.tests.Button1 {
+            echo(s) {
+                return "es:" + super.echo(s);
+            }
+        }
+
+        var button = new SuperEchoButton();
+
+        expect(button.echo("y")).toBe("es:y");
+        // round trip: Java triggerEcho -> proxy echo -> JS override -> super.echo -> Java echo
+        expect(button.triggerEcho("z")).toBe("es:z");
+    });
+
+    it("When_the_es_class_constructor_passes_arguments_to_super_the_matching_java_constructor_should_be_used", function () {
+        class CtorButton extends com.tns.tests.Button1 {
+            constructor(value) {
+                super(value); // Button1(int) overload
+                this.value = value;
+            }
+        }
+
+        var button = new CtorButton(5);
+
+        expect(button.value).toBe(5);
+        expect(button instanceof com.tns.tests.Button1).toBe(true);
+    });
+
+    it("When_accessing_the_class_property_before_any_instance_exists_the_class_should_be_registered_lazily", function () {
+        class LazyTouch extends java.lang.Object {
+            toString() {
+                return "lazy touch";
+            }
+        }
+
+        // no `new` has happened - static touch must register the proxy class
+        var clazz = LazyTouch.class;
+
+        expect(clazz).not.toBe(null);
+        expect(clazz.getName()).toContain("LazyTouch");
+
+        // the class is fully functional before any JS-side construction:
+        // Java instantiates it through reflection and dispatches to the JS override
+        var created = clazz.newInstance();
+        expect(javaToString(created)).toBe("obj=lazy touch");
+    });
+
+    it("When_passing_the_es_class_to_a_java_method_expecting_a_class_it_should_marshal_to_java_lang_Class", function () {
+        class MarshalledClass extends com.tns.tests.DummyClass {
+        }
+
+        // Class.isAssignableFrom(Class) - MarshalledClass is registered lazily during marshalling
+        expect(com.tns.tests.DummyClass.class.isAssignableFrom(MarshalledClass)).toBe(true);
+        expect(java.lang.Object.class.isAssignableFrom(MarshalledClass)).toBe(true);
+    });
+
+    it("When_passing_the_es_class_where_java_lang_Object_is_expected_it_should_marshal_to_its_java_lang_Class", function () {
+        class ObjectMarshalledClass extends java.lang.Object {
+        }
+
+        var list = new java.util.ArrayList();
+        list.add(ObjectMarshalledClass);
+
+        var stored = list.get(0);
+        expect(stored.getName()).toBe(ObjectMarshalledClass.class.getName());
+    });
+
+    it("When_extending_an_es_class_that_extends_a_native_class_each_level_should_get_its_own_proxy", function () {
+        class LevelOne extends com.tns.tests.Button1 {
+            getIMAGE_ID_PROP() {
+                return "level one";
+            }
+            echo(s) {
+                return "L1:" + s;
+            }
+        }
+
+        class LevelTwo extends LevelOne {
+            getIMAGE_ID_PROP() {
+                return "level two + " + super.getIMAGE_ID_PROP();
+            }
+        }
+
+        var two = new LevelTwo();
+        expect(two instanceof LevelTwo).toBe(true);
+        expect(two instanceof LevelOne).toBe(true);
+        expect(two instanceof com.tns.tests.Button1).toBe(true);
+        expect(two.getIMAGE_ID_PROP()).toBe("level two + level one");
+        // method defined only on the intermediate level must be part of the proxy overrides
+        expect(two.triggerEcho("q")).toBe("L1:q");
+
+        var one = new LevelOne();
+        expect(one.getIMAGE_ID_PROP()).toBe("level one");
+        expect(one instanceof LevelTwo).toBe(false);
+
+        expect(one.getClass().getName()).not.toBe(two.getClass().getName());
+    });
+
+    it("When_constructing_the_es_class_multiple_times_all_instances_should_share_one_proxy_class", function () {
+        class SharedProxyButton extends com.tns.tests.Button1 {
+        }
+
+        var first = new SharedProxyButton();
+        var second = new SharedProxyButton();
+
+        expect(first.getClass().equals(second.getClass())).toBe(true);
+        expect(first.getClass().equals(SharedProxyButton.class)).toBe(true);
+    });
+
+    it("When_reading_base_class_statics_through_the_es_class_they_should_resolve_to_the_java_members", function () {
+        class StaticsButton extends com.tns.tests.Button1 {
+            static jsStatic = 42;
+            static jsStaticMethod() {
+                return "js static";
+            }
+        }
+
+        // Java statics are reachable through the constructor prototype chain
+        expect(StaticsButton.STATIC_IMAGE_ID).toBe("static image id");
+        expect(StaticsButton.SGetStaticImageId()).toBe("static image id");
+
+        // plain JS statics live on the JS constructor and are untouched
+        expect(StaticsButton.jsStatic).toBe(42);
+        expect(StaticsButton.jsStaticMethod()).toBe("js static");
+    });
+
+    it("When_the_es_class_is_registered_its_proxy_should_be_discoverable_through_the_app_class_loader", function () {
+        class DiscoverableEsClass extends java.lang.Object {
+            toString() {
+                return "discoverable es class";
+            }
+        }
+
+        var instance = new DiscoverableEsClass();
+        var className = instance.getClass().getName();
+
+        var found = java.lang.Class.forName(className, false, appClassLoader);
+
+        expect(found.getName()).toBe(className);
+        expect(found.equals(instance.getClass())).toBe(true);
+        expect(found.equals(DiscoverableEsClass.class)).toBe(true);
+    });
+
+    it("When_implementing_an_interface_with_es_class_syntax_java_should_dispatch_to_the_js_methods", function () {
+        var runCount = 0;
+
+        class EsRunnable extends java.lang.Runnable {
+            run() {
+                runCount++;
+            }
+        }
+
+        var runnable = new EsRunnable();
+        expect(runnable instanceof java.lang.Runnable).toBe(true);
+
+        // Thread.run() (not started) invokes target.run() synchronously on the current thread
+        var thread = new java.lang.Thread(runnable);
+        thread.run();
+
+        expect(runCount).toBe(1);
+    });
+
+    it("When_declaring_static_interfaces_the_proxy_should_implement_them", function () {
+        var ran = { value: false };
+
+        class WithInterfaces extends java.lang.Object {
+            static interfaces = [java.lang.Runnable];
+
+            run() {
+                ran.value = true;
+            }
+        }
+
+        var instance = new WithInterfaces();
+
+        expect(instance instanceof java.lang.Runnable).toBe(true);
+
+        var thread = new java.lang.Thread(instance);
+        thread.run();
+
+        expect(ran.value).toBe(true);
+    });
+
+    it("When_getting_the_class_name_it_should_be_stable_and_descriptive", function () {
+        class StableNameClass extends java.lang.Object {
+        }
+
+        var name = StableNameClass.class.getName();
+
+        // runtime generated proxies are named <base>_es<hash>_<jsClassName>, mirroring the
+        // legacy <base>_<file>_<line>_<column>_<name> scheme (the com.tns.gen prefix is only
+        // present on build-time pre-generated bindings)
+        expect(name).toContain("java.lang.Object_es");
+        expect(name).toContain("StableNameClass");
+        // repeated access resolves to the very same class
+        expect(StableNameClass.class.getName()).toBe(name);
+    });
+
+    it("When_passing_an_es_class_instance_to_java_and_reading_it_back_it_should_be_the_same_object", function () {
+        class RoundTripObject extends java.lang.Object {
+            toString() {
+                return "round trip";
+            }
+        }
+
+        var instance = new RoundTripObject();
+        var list = new java.util.ArrayList();
+        list.add(instance);
+
+        var stored = list.get(0);
+        expect(stored.equals(instance)).toBe(true);
+        expect(javaToString(stored)).toBe("obj=round trip");
+    });
+
+    it("When_calling_extend_on_an_es_class_it_should_throw_a_descriptive_error", function () {
+        class NotExtendable extends com.tns.tests.Button1 {
+        }
+
+        expect(function () {
+            NotExtendable.extend({
+                toString: function () {
+                    return "should not work";
+                }
+            });
+        }).toThrow();
+    });
+
+    it("When_extending_a_class_created_with_legacy_extend_the_old_behavior_should_be_preserved", function () {
+        var LegacyButton = com.tns.tests.Button1.extend({
+            getIMAGE_ID_PROP: function () {
+                return "legacy override";
+            }
+        });
+
+        class EsOnLegacy extends LegacyButton {
+        }
+
+        // the legacy proxy is used - ES levels above `.extend()`-created classes get no proxy of their own
+        var instance = new EsOnLegacy();
+        expect(instance instanceof com.tns.tests.Button1).toBe(true);
+        expect(instance.getIMAGE_ID_PROP()).toBe("legacy override");
+    });
+
+    it("When_a_plain_js_class_hierarchy_is_used_the_runtime_should_not_interfere", function () {
+        class PlainBase {
+            value() {
+                return 1;
+            }
+        }
+
+        class PlainDerived extends PlainBase {
+            value() {
+                return super.value() + 1;
+            }
+        }
+
+        var plain = new PlainDerived();
+        expect(plain.value()).toBe(2);
+        expect(function () {
+            return plain instanceof java.lang.Object;
+        }).not.toThrow();
+    });
+
+    it("When_the_NativeClass_decorator_is_applied_it_should_be_a_noop", function () {
+        expect(typeof global.NativeClass).toBe("function");
+
+        const DecoratedButton = global.NativeClass(class DecoratedButton extends com.tns.tests.Button1 {
+            getIMAGE_ID_PROP() {
+                return "decorated";
+            }
+        });
+
+        var button = new DecoratedButton();
+        expect(button.getIMAGE_ID_PROP()).toBe("decorated");
+    });
+
+    it("When_anonymous_es_classes_extend_native_types_each_should_get_a_distinct_proxy", function () {
+        var First = class extends java.lang.Object {
+            toString() {
+                return "first anonymous";
+            }
+        };
+        var Second = class extends java.lang.Object {
+            toString() {
+                return "second anonymous";
+            }
+        };
+
+        var firstInstance = new First();
+        var secondInstance = new Second();
+
+        expect(javaToString(firstInstance)).toBe("obj=first anonymous");
+        expect(javaToString(secondInstance)).toBe("obj=second anonymous");
+        expect(firstInstance.getClass().equals(secondInstance.getClass())).toBe(false);
+    });
+});

--- a/test-app/app/src/main/assets/app/tests/testNativeESClasses.js
+++ b/test-app/app/src/main/assets/app/tests/testNativeESClasses.js
@@ -202,6 +202,31 @@ describe("Tests native ES class extensions (class X extends NativeType)", functi
         expect(runCount).toBe(1);
     });
 
+    it("When_two_es_classes_implement_the_same_interface_js_instances_should_stay_distinct", function () {
+        var aCount = 0;
+        var bCount = 0;
+
+        class EsRunnableA extends java.lang.Runnable {
+            run() {
+                aCount++;
+            }
+        }
+
+        class EsRunnableB extends java.lang.Runnable {
+            run() {
+                bCount++;
+            }
+        }
+
+        new java.lang.Thread(new EsRunnableA()).run();
+        new java.lang.Thread(new EsRunnableB()).run();
+
+        expect(aCount).toBe(1);
+        expect(bCount).toBe(1);
+        // DexFactory shares one interface proxy; JS identity is per instance.
+        expect(EsRunnableA.class.equals(EsRunnableB.class)).toBe(true);
+    });
+
     it("When_declaring_static_interfaces_the_proxy_should_implement_them", function () {
         var ran = { value: false };
 
@@ -348,6 +373,30 @@ describe("Tests native ES class extensions (class X extends NativeType)", functi
         expect(ESPrivateAllocObject.class.newInstance().someMethod()).toBe(1);
     });
 
+    it("When_java_instantiates_an_es_class_nested_native_construction_should_not_steal_adopt", function () {
+        class ESNestedAdoptObject extends java.lang.Object {
+            constructor() {
+                // Valid before super(): must not consume the pending adopt id
+                // that belongs to ESNestedAdoptObject.
+                var list = new java.util.ArrayList();
+                list.add("nested");
+                super();
+                this.list = list;
+            }
+        }
+
+        var allocated = ESNestedAdoptObject.class.newInstance();
+        expect(allocated instanceof ESNestedAdoptObject).toBe(true);
+        expect(allocated.list instanceof java.util.ArrayList).toBe(true);
+        expect(allocated.list.size()).toBe(1);
+        expect(allocated.list.get(0)).toBe("nested");
+        expect(allocated.getClass().getName()).toContain("ESNestedAdoptObject");
+
+        var constructed = new ESNestedAdoptObject();
+        expect(constructed.list.get(0)).toBe("nested");
+        expect(constructed.getClass().equals(allocated.getClass())).toBe(true);
+    });
+
     it("When_java_instantiates_an_es_class_super_args_should_not_construct_again", function () {
         class ESAdoptOnceObject extends com.tns.tests.DummyClass {
             constructor() {
@@ -438,6 +487,17 @@ describe("Tests native ES class extensions (class X extends NativeType)", functi
         expect(new ESEagerNamed() instanceof ESEagerNamed).toBe(true);
     });
 
+    it("When_NativeClass_sets_an_unqualified_android_name_it_should_throw", function () {
+        expect(function () {
+            global.NativeClass({
+                android: {
+                    name: "UnqualifiedName"
+                }
+            })(class UnqualifiedNativeClass extends java.lang.Object {
+            });
+        }).toThrow();
+    });
+
     it("When_NativeClass_runs_on_a_worker_it_should_be_a_noop", function (done) {
         var worker = new Worker("../shared/Workers/EvalWorker.js");
         worker.onmessage = function (msg) {
@@ -462,16 +522,22 @@ describe("Tests native ES class extensions (class X extends NativeType)", functi
     });
 
     it("When_anonymous_es_classes_extend_native_types_each_should_get_a_distinct_proxy", function () {
-        var First = class extends java.lang.Object {
-            toString() {
-                return "first anonymous";
+        // Array-literal class expressions stay anonymous (no inferred name),
+        // so both hash as ESClass and exercise the _2 suffix collision path.
+        var classes = [
+            class extends java.lang.Object {
+                toString() {
+                    return "first anonymous";
+                }
+            },
+            class extends java.lang.Object {
+                toString() {
+                    return "second anonymous";
+                }
             }
-        };
-        var Second = class extends java.lang.Object {
-            toString() {
-                return "second anonymous";
-            }
-        };
+        ];
+        var First = classes[0];
+        var Second = classes[1];
 
         var firstInstance = new First();
         var secondInstance = new Second();

--- a/test-app/app/src/main/assets/internal/ts_helpers.js
+++ b/test-app/app/src/main/assets/internal/ts_helpers.js
@@ -166,12 +166,35 @@
 		}
 	}
 
-	// No-op decorator for plain ES classes extending native types.
-	// The runtime registers such classes lazily (on first construction, static usage or when
-	// passed to native APIs), so the decorator only exists so shared iOS/Android sources and
-	// non-transformed code keep working.
-	function NativeClass(target) {
+	function applyNativeClassOptions(target, options) {
+		// Workers must not mint or rename process-global native classes.
+		if (global.__ns__worker) {
+			return target;
+		}
+		// This runtime implements `android`; `ios` is accepted and ignored.
+		var android = options && options.android;
+		var interfaces = (android && android.interfaces) || (options && options.interfaces);
+		var name = android && android.name;
+
+		if (interfaces && interfaces.length > 0) {
+			target.interfaces = (target.interfaces && target.interfaces instanceof Array ? target.interfaces.concat(interfaces) : interfaces.slice());
+		}
+		if (name) {
+			target.nativeClassName = name;
+			// Accessing `.class` lazily registers the proxy under the explicit name.
+			void target.class;
+		}
 		return target;
+	}
+
+	function NativeClass(arg) {
+		if (typeof arg === "function") {
+			return applyNativeClassOptions(arg, {});
+		}
+		var options = arg || {};
+		return function (target) {
+			return applyNativeClassOptions(target, options);
+		};
 	}
 
 	Object.defineProperty(global, "__native", { value: __native });
@@ -182,7 +205,5 @@
 		global.JavaProxy = JavaProxy;
 	}
 	global.Interfaces = Interfaces;
-	if (!global.NativeClass) {
-		global.NativeClass = NativeClass;
-	}
+	global.NativeClass = NativeClass;
 })()

--- a/test-app/app/src/main/assets/internal/ts_helpers.js
+++ b/test-app/app/src/main/assets/internal/ts_helpers.js
@@ -166,6 +166,14 @@
 		}
 	}
 
+	// No-op decorator for plain ES classes extending native types.
+	// The runtime registers such classes lazily (on first construction, static usage or when
+	// passed to native APIs), so the decorator only exists so shared iOS/Android sources and
+	// non-transformed code keep working.
+	function NativeClass(target) {
+		return target;
+	}
+
 	Object.defineProperty(global, "__native", { value: __native });
 	Object.defineProperty(global, "__extends", { value: __extends });
 	Object.defineProperty(global, "__decorate", { value: __decorate });
@@ -174,4 +182,7 @@
 		global.JavaProxy = JavaProxy;
 	}
 	global.Interfaces = Interfaces;
+	if (!global.NativeClass) {
+		global.NativeClass = NativeClass;
+	}
 })()

--- a/test-app/app/src/main/assets/internal/ts_helpers.js
+++ b/test-app/app/src/main/assets/internal/ts_helpers.js
@@ -177,9 +177,18 @@
 		var name = android && android.name;
 
 		if (interfaces && interfaces.length > 0) {
-			target.interfaces = (target.interfaces && target.interfaces instanceof Array ? target.interfaces.concat(interfaces) : interfaces.slice());
+			var merged = (target.interfaces && target.interfaces instanceof Array ? target.interfaces.concat(interfaces) : interfaces.slice());
+			target.interfaces = merged;
+			// Legacy `.extend()` reads interfaces from the implementation object
+			// (the prototype). Keep both so downleveled ES5 targets still work.
+			if (target.prototype) {
+				target.prototype.interfaces = merged;
+			}
 		}
 		if (name) {
+			if (name.indexOf(".") === -1) {
+				throw new Error("NativeClass android.name must be a fully qualified Java class name.");
+			}
 			target.nativeClassName = name;
 			// Accessing `.class` lazily registers the proxy under the explicit name.
 			void target.class;

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -95,7 +95,7 @@ bool CallbackHandlers::RegisterInstance(Isolate *isolate, const Local<Object> &j
     auto objectManager = runtime->GetObjectManager();
 
     int adoptObjectId = -1;
-    if (MetadataNode::TryConsumePendingESAdopt(isolate, adoptObjectId)) {
+    if (MetadataNode::TryConsumePendingESAdopt(isolate, fullClassName, adoptObjectId)) {
         // Adopt path: Java already created this object. Bind it to the ES
         // construct and do not NewObject again (that would be a second
         // instance, or recurse through initInstance).

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -185,6 +185,50 @@ jclass CallbackHandlers::ResolveClass(Isolate *isolate, const string &baseClassN
     return globalRefToGeneratedClass;
 }
 
+jclass CallbackHandlers::ResolveClass(Isolate *isolate, const string &baseClassName,
+                                      const string &fullClassName,
+                                      const vector<string> &methodOverrides,
+                                      const vector<string> &implementedInterfaces,
+                                      bool isInterface) {
+    JEnv env;
+    jclass globalRefToGeneratedClass = env.CheckForClassInCache(fullClassName);
+
+    if (globalRefToGeneratedClass == nullptr) {
+        JniLocalRef javaBaseClassName(env.NewStringUTF(baseClassName.c_str()));
+        JniLocalRef javaFullClassName(env.NewStringUTF(fullClassName.c_str()));
+
+        jobjectArray methodOverridesArr = GetJavaStringArray(env, methodOverrides.size());
+        for (size_t i = 0; i < methodOverrides.size(); i++) {
+            JniLocalRef name(env.NewStringUTF(methodOverrides[i].c_str()));
+            env.SetObjectArrayElement(methodOverridesArr, i, name);
+        }
+
+        jobjectArray implementedInterfacesArr = GetJavaStringArray(env, implementedInterfaces.size());
+        for (size_t i = 0; i < implementedInterfaces.size(); i++) {
+            JniLocalRef name(env.NewStringUTF(implementedInterfaces[i].c_str()));
+            env.SetObjectArrayElement(implementedInterfacesArr, i, name);
+        }
+
+        auto runtime = Runtime::GetRuntime(isolate);
+
+        // create or load generated binding (java class)
+        jclass generatedClass = (jclass) env.CallObjectMethod(runtime->GetJavaRuntime(),
+                                                              RESOLVE_CLASS_METHOD_ID,
+                                                              (jstring) javaBaseClassName,
+                                                              (jstring) javaFullClassName,
+                                                              methodOverridesArr,
+                                                              implementedInterfacesArr,
+                                                              isInterface);
+
+        globalRefToGeneratedClass = env.InsertClassIntoCache(fullClassName, generatedClass);
+
+        env.DeleteGlobalRef(methodOverridesArr);
+        env.DeleteGlobalRef(implementedInterfacesArr);
+    }
+
+    return globalRefToGeneratedClass;
+}
+
 // Called by ExtendMethodCallback when extending a class
 string CallbackHandlers::ResolveClassName(Isolate *isolate, jclass &clazz) {
     auto runtime = Runtime::GetRuntime(isolate);

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -163,6 +163,50 @@ jclass CallbackHandlers::ResolveClass(Isolate *isolate, const string &baseClassN
     return globalRefToGeneratedClass;
 }
 
+jclass CallbackHandlers::ResolveClass(Isolate *isolate, const string &baseClassName,
+                                      const string &fullClassName,
+                                      const vector<string> &methodOverrides,
+                                      const vector<string> &implementedInterfaces,
+                                      bool isInterface) {
+    JEnv env;
+    jclass globalRefToGeneratedClass = env.CheckForClassInCache(fullClassName);
+
+    if (globalRefToGeneratedClass == nullptr) {
+        JniLocalRef javaBaseClassName(env.NewStringUTF(baseClassName.c_str()));
+        JniLocalRef javaFullClassName(env.NewStringUTF(fullClassName.c_str()));
+
+        jobjectArray methodOverridesArr = GetJavaStringArray(env, methodOverrides.size());
+        for (size_t i = 0; i < methodOverrides.size(); i++) {
+            JniLocalRef name(env.NewStringUTF(methodOverrides[i].c_str()));
+            env.SetObjectArrayElement(methodOverridesArr, i, name);
+        }
+
+        jobjectArray implementedInterfacesArr = GetJavaStringArray(env, implementedInterfaces.size());
+        for (size_t i = 0; i < implementedInterfaces.size(); i++) {
+            JniLocalRef name(env.NewStringUTF(implementedInterfaces[i].c_str()));
+            env.SetObjectArrayElement(implementedInterfacesArr, i, name);
+        }
+
+        auto runtime = Runtime::GetRuntime(isolate);
+
+        // create or load generated binding (java class)
+        jclass generatedClass = (jclass) env.CallObjectMethod(runtime->GetJavaRuntime(),
+                                                              RESOLVE_CLASS_METHOD_ID,
+                                                              (jstring) javaBaseClassName,
+                                                              (jstring) javaFullClassName,
+                                                              methodOverridesArr,
+                                                              implementedInterfacesArr,
+                                                              isInterface);
+
+        globalRefToGeneratedClass = env.InsertClassIntoCache(fullClassName, generatedClass);
+
+        env.DeleteGlobalRef(methodOverridesArr);
+        env.DeleteGlobalRef(implementedInterfacesArr);
+    }
+
+    return globalRefToGeneratedClass;
+}
+
 // Called by ExtendMethodCallback when extending a class
 string CallbackHandlers::ResolveClassName(Isolate *isolate, jclass &clazz) {
     auto runtime = Runtime::GetRuntime(isolate);

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -94,6 +94,18 @@ bool CallbackHandlers::RegisterInstance(Isolate *isolate, const Local<Object> &j
     auto runtime = Runtime::GetRuntime(isolate);
     auto objectManager = runtime->GetObjectManager();
 
+    int adoptObjectId = -1;
+    if (MetadataNode::TryConsumePendingESAdopt(isolate, adoptObjectId)) {
+        // Adopt path: Java already created this object. Bind it to the ES
+        // construct and do not NewObject again (that would be a second
+        // instance, or recurse through initInstance).
+        objectManager->Link(jsObject, adoptObjectId, nullptr);
+        JEnv env;
+        jclass instanceClass = env.FindClass(fullClassName);
+        objectManager->SetJavaClass(jsObject, instanceClass);
+        return true;
+    }
+
     // The Java constructor may synchronously call back into JS (extended
     // class init) - that whole window is a JS-initiated chain.
     JavaCallScope javaCallScope(runtime);

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -42,6 +42,18 @@ namespace tns {
                                    const v8::Local<v8::Object> &implementationObject,
                                    bool isInterface);
 
+        /*
+         * ResolveClass variant with explicitly collected method override names and implemented
+         * interface names. Used for plain ES class extensions where the overrides span multiple
+         * prototype levels and are non-enumerable (so the implementationObject-based scan above
+         * cannot see them).
+         */
+        static jclass ResolveClass(v8::Isolate *isolate, const std::string &baseClassName,
+                                   const std::string &fullClassName,
+                                   const std::vector<std::string> &methodOverrides,
+                                   const std::vector<std::string> &implementedInterfaces,
+                                   bool isInterface);
+
         static std::string ResolveClassName(v8::Isolate *isolate, jclass &clazz);
 
         static v8::Local<v8::Value>

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -41,6 +41,18 @@ namespace tns {
                                    const v8::Local<v8::Object> &implementationObject,
                                    bool isInterface);
 
+        /*
+         * ResolveClass variant with explicitly collected method override names and implemented
+         * interface names. Used for plain ES class extensions where the overrides span multiple
+         * prototype levels and are non-enumerable (so the implementationObject-based scan above
+         * cannot see them).
+         */
+        static jclass ResolveClass(v8::Isolate *isolate, const std::string &baseClassName,
+                                   const std::string &fullClassName,
+                                   const std::vector<std::string> &methodOverrides,
+                                   const std::vector<std::string> &implementedInterfaces,
+                                   bool isInterface);
+
         static std::string ResolveClassName(v8::Isolate *isolate, jclass &clazz);
 
         static v8::Local<v8::Value>

--- a/test-app/runtime/src/main/cpp/JsArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/JsArgConverter.cpp
@@ -166,7 +166,7 @@ bool JsArgConverter::ConvertArg(const Local<Value> &arg, int index) {
             // JEnv caches classes as global refs - mark as global so the dtor doesn't delete it
             SetConvertedObject(index, clazz, true /* isGlobal */);
         } else {
-            sprintf(buff, "Cannot convert function to %s at index %d", typeSignature.c_str(), index);
+            snprintf(buff, sizeof(buff), "Cannot convert function to %s at index %d", typeSignature.c_str(), index);
         }
     } else if (arg->IsObject()) {
         auto context = m_isolate->GetCurrentContext();

--- a/test-app/runtime/src/main/cpp/JsArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/JsArgConverter.cpp
@@ -1,5 +1,6 @@
 #include "JsArgConverter.h"
 #include "ObjectManager.h"
+#include "MetadataNode.h"
 #include "JniSignatureParser.h"
 #include "JsArgToArrayConverter.h"
 #include "ArgConverter.h"
@@ -150,6 +151,22 @@ bool JsArgConverter::ConvertArg(const Local<Value> &arg, int index) {
 
         if (!success) {
             sprintf(buff, "Cannot convert string to %s at index %d", typeSignature.c_str(), index);
+        }
+    } else if (arg->IsFunction() &&
+               (typeSignature == "Ljava/lang/Class;" || typeSignature == "Ljava/lang/Object;") &&
+               !MetadataNode::TryResolveClassCtorTypeName(m_isolate, arg.As<Function>()).empty()) {
+        // a native type ctor (or a plain ES class extending one - registered lazily here)
+        // passed where Java expects a java.lang.Class. Typed nulls (`SomeClass.null`) and other
+        // functions resolve to an empty name and keep flowing through the object branch below.
+        auto typeName = MetadataNode::TryResolveClassCtorTypeName(m_isolate, arg.As<Function>());
+        JEnv env;
+        jclass clazz = env.FindClass(typeName);
+        success = clazz != nullptr;
+        if (success) {
+            // JEnv caches classes as global refs - mark as global so the dtor doesn't delete it
+            SetConvertedObject(index, clazz, true /* isGlobal */);
+        } else {
+            sprintf(buff, "Cannot convert function to %s at index %d", typeSignature.c_str(), index);
         }
     } else if (arg->IsObject()) {
         auto context = m_isolate->GetCurrentContext();

--- a/test-app/runtime/src/main/cpp/JsArgToArrayConverter.cpp
+++ b/test-app/runtime/src/main/cpp/JsArgToArrayConverter.cpp
@@ -134,6 +134,20 @@ bool JsArgToArrayConverter::ConvertArg(Local<Context> context, const Local<Value
         SetConvertedObject(env, index, stringObject);
 
         success = true;
+    } else if (arg->IsFunction() && !MetadataNode::TryResolveClassCtorTypeName(isolate, arg.As<Function>()).empty()) {
+        // a native type ctor (or a plain ES class extending one - registered lazily here)
+        // marshals to its java.lang.Class. Typed nulls (`SomeClass.null`) and other functions
+        // resolve to an empty name and keep flowing through the object branch below.
+        auto typeName = MetadataNode::TryResolveClassCtorTypeName(isolate, arg.As<Function>());
+        jclass clazz = env.FindClass(typeName);
+        if (clazz != nullptr) {
+            // JEnv caches classes as global refs - mark as global so the dtor doesn't delete it
+            SetConvertedObject(env, index, clazz, true /* isGlobal */);
+            success = true;
+        } else {
+            s << "Cannot marshal JavaScript function at index " << index
+              << " to Java type. Only native type constructors can be marshalled (to java.lang.Class).";
+        }
     } else if (arg->IsObject()) {
         auto jsObj = arg->ToObject(context).ToLocalChecked();
 

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1178,7 +1178,7 @@ MetadataNode::TypeMetadata* MetadataNode::TryGetTypeMetadata(Isolate* isolate, c
         return nullptr;
     }
 
-    return reinterpret_cast<TypeMetadata*>(hiddenVal.As<External>()->Value());
+    return reinterpret_cast<TypeMetadata*>(hiddenVal.As<External>()->Value(v8::kExternalPointerTypeTagDefault));
 }
 
 std::string MetadataNode::TryResolveClassCtorTypeName(Isolate* isolate, const Local<Function>& func) {
@@ -1221,10 +1221,39 @@ std::string SanitizeESClassNamePart(const std::string& name) {
     std::string result;
     result.reserve(name.size());
     for (char c : name) {
-        bool isValid = isalpha(c) || isdigit(c) || c == '_';
+        auto uc = static_cast<unsigned char>(c);
+        bool isValid = isalnum(uc) || c == '_';
         result += isValid ? c : '_';
     }
     return result;
+}
+
+std::string BuildESClassProxyIdentity(const std::string& scriptName, const std::string& baseClassName, const std::string& className,
+                                      const std::vector<std::string>& methodOverrides, const std::vector<std::string>& implementedInterfaces) {
+    auto sortedMethods = methodOverrides;
+    auto sortedInterfaces = implementedInterfaces;
+    std::sort(sortedMethods.begin(), sortedMethods.end());
+    std::sort(sortedInterfaces.begin(), sortedInterfaces.end());
+
+    std::string identity = scriptName + "|" + baseClassName + "|" + className;
+    for (const auto& method : sortedMethods) {
+        identity += "|m:" + method;
+    }
+    for (const auto& iface : sortedInterfaces) {
+        identity += "|i:" + iface;
+    }
+    return identity;
+}
+
+bool TryGetConstructorPrototype(Isolate* isolate, const Local<Function>& ctorFunc, Local<Object>& out) {
+    auto context = isolate->GetCurrentContext();
+    Local<Value> protoValue;
+    if (!ctorFunc->Get(context, V8StringConstants::GetPrototype(isolate)).ToLocal(&protoValue)
+            || protoValue.IsEmpty() || !protoValue->IsObject()) {
+        return false;
+    }
+    out = protoValue.As<Object>();
+    return true;
 }
 
 // True only for genuine `class` syntax constructors. Function source text is the reliable
@@ -1232,9 +1261,11 @@ std::string SanitizeESClassNamePart(const std::string& name) {
 // `class` declaration/expression source (possibly behind leading comments/whitespace, which V8
 // does not emit for the class case - the text starts with "class").
 bool IsESClassConstructor(v8::Isolate* isolate, const v8::Local<v8::Function>& func) {
+    v8::TryCatch tc(isolate);
     auto context = isolate->GetCurrentContext();
     v8::Local<v8::String> sourceText;
     if (!func->FunctionProtoToString(context).ToLocal(&sourceText)) {
+        tc.Reset();
         return false;
     }
 
@@ -1431,7 +1462,7 @@ MetadataNode::TypeMetadata* MetadataNode::EnsureExtendedESClass(Isolate* isolate
             scriptName = ArgConverter::ConvertToString(resourceName.As<String>());
         }
 
-        string extendNameAndLocation = "es" + HashESClassId(scriptName + "|" + baseClassName + "|" + className) + "_" + className;
+        string extendNameAndLocation = "es" + HashESClassId(BuildESClassProxyIdentity(scriptName, baseClassName, className, methodOverrides, implementedInterfaces)) + "_" + className;
         string candidate = TNS_PREFIX + CreateFullClassName(baseClassName, extendNameAndLocation);
 
         // collision handling for distinct classes that produce the same deterministic name
@@ -1492,6 +1523,13 @@ bool MetadataNode::TryConstructESDerivedInstance(Isolate* isolate, const string&
         return false;
     }
 
+    // DexFactory collapses every interface extension onto one shared
+    // com.tns.gen.<interface> proxy. That name does not identify a single ES
+    // class, so Java-born instances stay on the legacy wrapper path.
+    if (cacheData.node != nullptr && cacheData.node->IsNodeTypeInterface()) {
+        return false;
+    }
+
     Local<Function> ctor = Local<Function>::New(isolate, *cacheData.extendedCtorFunction);
     auto typeMetadata = TryGetTypeMetadata(isolate, ctor);
     if (typeMetadata == nullptr || !typeMetadata->isESDerived) {
@@ -1499,10 +1537,12 @@ bool MetadataNode::TryConstructESDerivedInstance(Isolate* isolate, const string&
     }
 
     cache->PendingESAdoptObjectId = javaObjectID;
+    cache->PendingESAdoptClassName = proxyClassName;
     TryCatch tc(isolate);
     auto context = isolate->GetCurrentContext();
     bool ok = !ctor->CallAsConstructor(context, 0, nullptr).IsEmpty();
     cache->PendingESAdoptObjectId = -1;
+    cache->PendingESAdoptClassName.clear();
     if (!ok) {
         throw NativeScriptException(tc, "Failed to construct ES class for native instance");
     }
@@ -1517,14 +1557,18 @@ bool MetadataNode::TryConstructESDerivedInstance(Isolate* isolate, const string&
     return true;
 }
 
-bool MetadataNode::TryConsumePendingESAdopt(Isolate* isolate, int& javaObjectID) {
+bool MetadataNode::TryConsumePendingESAdopt(Isolate* isolate, const string& fullClassName, int& javaObjectID) {
     auto cache = GetMetadataNodeCache(isolate);
     if (cache->PendingESAdoptObjectId == -1) {
+        return false;
+    }
+    if (cache->PendingESAdoptClassName != fullClassName) {
         return false;
     }
 
     javaObjectID = cache->PendingESAdoptObjectId;
     cache->PendingESAdoptObjectId = -1;
+    cache->PendingESAdoptClassName.clear();
     return true;
 }
 
@@ -1618,7 +1662,10 @@ void MetadataNode::InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v
             }
 
             if (typeMetadata != nullptr && typeMetadata->isESDerived) {
-                auto esImplementationObject = newTargetFunc->Get(context, V8StringConstants::GetPrototype(isolate)).ToLocalChecked().As<Object>();
+                Local<Object> esImplementationObject;
+                if (!TryGetConstructorPrototype(isolate, newTargetFunc, esImplementationObject)) {
+                    throw NativeScriptException(string("Cannot resolve the prototype of the ES class constructor."));
+                }
 
                 SetInstanceMetadata(isolate, thiz, node);
                 thiz->SetInternalField(static_cast<int>(ObjectManager::MetadataNodeKeys::CallSuper), True(isolate));
@@ -1705,8 +1752,10 @@ void MetadataNode::ClassConstructorCallback(const v8::FunctionCallbackInfo<v8::V
             }
 
             if (typeMetadata != nullptr && typeMetadata->isESDerived) {
-                auto context = isolate->GetCurrentContext();
-                auto implementationObject = newTargetFunc->Get(context, V8StringConstants::GetPrototype(isolate)).ToLocalChecked().As<Object>();
+                Local<Object> implementationObject;
+                if (!TryGetConstructorPrototype(isolate, newTargetFunc, implementationObject)) {
+                    throw NativeScriptException(string("Cannot resolve the prototype of the ES class constructor."));
+                }
 
                 SetInstanceMetadata(isolate, thiz, node);
                 thiz->SetInternalField(static_cast<int>(ObjectManager::MetadataNodeKeys::CallSuper), True(isolate));

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1439,6 +1439,7 @@ MetadataNode::TypeMetadata* MetadataNode::EnsureExtendedESClass(Isolate* isolate
 
     // Compute the proxy class name
     string fullClassName;
+    string generatedCandidate;
     if (!nativeClassName.empty() && nativeClassName.find('.') != string::npos) {
         fullClassName = nativeClassName;
     } else if (isInterface) {
@@ -1463,20 +1464,25 @@ MetadataNode::TypeMetadata* MetadataNode::EnsureExtendedESClass(Isolate* isolate
         }
 
         string extendNameAndLocation = "es" + HashESClassId(BuildESClassProxyIdentity(scriptName, baseClassName, className, methodOverrides, implementedInterfaces)) + "_" + className;
-        string candidate = TNS_PREFIX + CreateFullClassName(baseClassName, extendNameAndLocation);
-
-        // collision handling for distinct classes that produce the same deterministic name
-        // (e.g. a class factory evaluated multiple times in the same script)
-        fullClassName = candidate;
-        int suffix = 2;
-        while (GetCachedExtendedClassData(isolate, fullClassName).extendedCtorFunction != nullptr) {
-            fullClassName = candidate + "_" + std::to_string(suffix++);
-        }
+        generatedCandidate = TNS_PREFIX + CreateFullClassName(baseClassName, extendNameAndLocation);
+        fullClassName = generatedCandidate;
     }
 
-    // Resolve (generate or load) the Java proxy class through the regular DexFactory pipeline
-    auto clazz = CallbackHandlers::ResolveClass(isolate, baseClassName, fullClassName, methodOverrides, implementedInterfaces, isInterface);
-    auto fullExtendedName = CallbackHandlers::ResolveClassName(isolate, clazz);
+    // Resolve through DexFactory, then key collision checks on the name it
+    // actually produced. Class.getName() drops the com.tns.gen/ request prefix,
+    // so looking up ExtendedCtorFuncCache with the request name never hit.
+    jclass clazz = nullptr;
+    string fullExtendedName;
+    int suffix = 2;
+    while (true) {
+        clazz = CallbackHandlers::ResolveClass(isolate, baseClassName, fullClassName, methodOverrides, implementedInterfaces, isInterface);
+        fullExtendedName = CallbackHandlers::ResolveClassName(isolate, clazz);
+        if (generatedCandidate.empty()
+                || GetCachedExtendedClassData(isolate, fullExtendedName).extendedCtorFunction == nullptr) {
+            break;
+        }
+        fullClassName = generatedCandidate + "_" + std::to_string(suffix++);
+    }
 
     // Tag the ES ctor the same way ExtendMethodCallback tags `.extend()`-created functions, so
     // the rest of the runtime (construction, Java-initiated instantiation, `.class`, marshalling)

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -11,6 +11,7 @@
 #include "Runtime.h"
 #include <sstream>
 #include <cctype>
+#include <algorithm>
 #include <dirent.h>
 #include <errno.h>
 #include <android/log.h>
@@ -147,7 +148,20 @@ bool MetadataNode::IsNodeTypeInterface() {
 }
 
 string MetadataNode::GetTypeMetadataName(Isolate* isolate, Local<Value>& value) {
-    auto data = GetTypeMetadata(isolate, value.As<Function>());
+    if (value.IsEmpty() || !value->IsFunction()) {
+        throw NativeScriptException(string("Cannot resolve native type - the value is not a constructor function."));
+    }
+
+    auto func = value.As<Function>();
+    auto data = TryGetTypeMetadata(isolate, func);
+    if (data == nullptr) {
+        // may be a not-yet-registered plain ES class extension
+        data = EnsureExtendedESClass(isolate, func);
+    }
+
+    if (data == nullptr) {
+        throw NativeScriptException(string("Cannot resolve native type - the function does not stand for a native type or an extension of one."));
+    }
 
     return data->name;
 }
@@ -258,7 +272,22 @@ void MetadataNode::ClassAccessorGetterCallback(Local<Name> property, const Prope
     try {
         auto thiz = info.This();
         auto isolate = info.GetIsolate();
-        auto data = GetTypeMetadata(isolate, thiz.As<Function>());
+
+        if (thiz.IsEmpty() || !thiz->IsFunction()) {
+            throw NativeScriptException(string("The 'class' property may only be accessed on a native type or an extended class constructor function."));
+        }
+
+        auto func = thiz.As<Function>();
+        auto data = TryGetTypeMetadata(isolate, func);
+        if (data == nullptr) {
+            // Plain ES class extension accessed statically before any instance was constructed
+            // (e.g. `MyView.class`) - lazily register it now
+            data = EnsureExtendedESClass(isolate, func);
+        }
+
+        if (data == nullptr) {
+            throw NativeScriptException(string("Cannot resolve java.lang.Class - the function does not stand for a native type or an extension of one."));
+        }
 
         auto value = CallbackHandlers::FindClass(isolate, data->name);
         info.GetReturnValue().Set(value);
@@ -1051,6 +1080,310 @@ void MetadataNode::SetTypeMetadata(Isolate* isolate, Local<Function> value, Type
     V8SetPrivateValue(isolate, value, String::NewFromUtf8(isolate, "typemetadata").ToLocalChecked(),  External::New(isolate, data));
 }
 
+MetadataNode::TypeMetadata* MetadataNode::TryGetTypeMetadata(Isolate* isolate, const Local<Function>& value) {
+    Local<Value> hiddenVal;
+    V8GetPrivateValue(isolate, value, String::NewFromUtf8(isolate, "typemetadata").ToLocalChecked(), hiddenVal);
+
+    if (hiddenVal.IsEmpty() || !hiddenVal->IsExternal()) {
+        return nullptr;
+    }
+
+    return reinterpret_cast<TypeMetadata*>(hiddenVal.As<External>()->Value());
+}
+
+std::string MetadataNode::TryResolveClassCtorTypeName(Isolate* isolate, const Local<Function>& func) {
+    // A ctor function that had its `.null` accessed doubles as the typed null value for its
+    // type (see NullObjectAccessorGetterCallback - the marker private is set on the ctor and
+    // the ctor itself is returned). Such functions must marshal as typed nulls, not as
+    // java.lang.Class references.
+    Local<Value> nullNodeMarker;
+    V8GetPrivateValue(isolate, func, V8StringConstants::GetNullNodeName(isolate), nullNodeMarker);
+    if (!nullNodeMarker.IsEmpty()) {
+        return std::string();
+    }
+
+    auto typeMetadata = TryGetTypeMetadata(isolate, func);
+
+    if (typeMetadata == nullptr) {
+        typeMetadata = EnsureExtendedESClass(isolate, func);
+    }
+
+    return typeMetadata != nullptr ? typeMetadata->name : std::string();
+}
+
+namespace {
+// short deterministic identifier so the same ES class gets the same proxy class name across
+// application launches (keeps the DexFactory on-disk dex cache warm) without depending on
+// line/column numbers that shift with unrelated code edits
+std::string HashESClassId(const std::string& input) {
+    uint32_t hash = 2166136261u;
+    for (char c : input) {
+        hash ^= static_cast<uint8_t>(c);
+        hash *= 16777619u;
+    }
+
+    char buff[9];
+    snprintf(buff, sizeof(buff), "%08x", hash);
+    return std::string(buff);
+}
+
+std::string SanitizeESClassNamePart(const std::string& name) {
+    std::string result;
+    result.reserve(name.size());
+    for (char c : name) {
+        bool isValid = isalpha(c) || isdigit(c) || c == '_';
+        result += isValid ? c : '_';
+    }
+    return result;
+}
+
+// True only for genuine `class` syntax constructors. Function source text is the reliable
+// discriminator: per spec, Function.prototype.toString for a class constructor reproduces the
+// `class` declaration/expression source (possibly behind leading comments/whitespace, which V8
+// does not emit for the class case - the text starts with "class").
+bool IsESClassConstructor(v8::Isolate* isolate, const v8::Local<v8::Function>& func) {
+    auto context = isolate->GetCurrentContext();
+    v8::Local<v8::String> sourceText;
+    if (!func->FunctionProtoToString(context).ToLocal(&sourceText)) {
+        return false;
+    }
+
+    auto source = tns::ArgConverter::ConvertToString(sourceText);
+    return source.compare(0, 5, "class") == 0;
+}
+} // namespace
+
+MetadataNode::TypeMetadata* MetadataNode::EnsureExtendedESClass(Isolate* isolate, Local<v8::Function> ctorFunc) {
+    // Already registered - a native class ctor, a legacy `.extend()`-created ctor or an
+    // ES class ctor registered by a previous call
+    auto existingMetadata = TryGetTypeMetadata(isolate, ctorFunc);
+    if (existingMetadata != nullptr) {
+        return existingMetadata;
+    }
+
+    auto context = isolate->GetCurrentContext();
+
+    // Only genuine `class` syntax constructors participate in lazy ES registration. Downleveled
+    // ES5 "classes" (TypeScript ES5 output, the JavaProxy decorator target, ts_helpers __extends
+    // children) have the same shape - an untagged function whose prototype chain reaches a native
+    // ctor - but must keep flowing through the legacy `.extend()` pipeline.
+    if (!IsESClassConstructor(isolate, ctorFunc)) {
+        return nullptr;
+    }
+
+    // Walk the constructor prototype chain (mirrors the `class X extends Y` chain) and collect
+    // every plain (unregistered) ES constructor level until we reach a constructor holding type
+    // metadata. ES-registered ancestors are flattened into this registration; legacy
+    // `.extend()`-created ancestors are not supported and make this function bail out so callers
+    // preserve their old behavior.
+    std::vector<Local<v8::Function>> chainCtors;
+    Local<v8::Function> current = ctorFunc;
+    TypeMetadata* baseTypeMetadata = nullptr;
+    while (true) {
+        chainCtors.push_back(current);
+
+        Local<Value> parentValue = current->GetPrototype();
+        if (parentValue.IsEmpty() || !parentValue->IsObject() || !parentValue->IsFunction()) {
+            // no native type in the chain - a plain JS class, leave it alone
+            return nullptr;
+        }
+
+        auto parent = parentValue.As<v8::Function>();
+        auto parentMetadata = TryGetTypeMetadata(isolate, parent);
+        if (parentMetadata == nullptr) {
+            current = parent;
+            continue;
+        }
+
+        if (parentMetadata->isESDerived) {
+            // Flatten: the parent's registered proxy class sits directly under the pure native
+            // base, so keep walking (collecting the parent's prototype for scanning) until we
+            // reach it
+            current = parent;
+            continue;
+        }
+
+        auto cachedData = GetCachedExtendedClassData(isolate, parentMetadata->name);
+        if (cachedData.extendedCtorFunction != nullptr) {
+            // legacy `.extend()`-created ancestor - not supported for ES class chaining
+            return nullptr;
+        }
+
+        baseTypeMetadata = parentMetadata;
+        break;
+    }
+
+    string baseClassName = baseTypeMetadata->name;
+    auto node = GetOrCreate(baseClassName);
+    if (node == nullptr) {
+        return nullptr;
+    }
+
+    uint8_t nodeType = s_metadataReader.GetNodeType(node->m_treeNode);
+    bool isInterface = s_metadataReader.IsNodeTypeInterface(nodeType);
+
+    // Collect overridden method names level by level, most-derived first, so JS shadowing
+    // semantics carry over. ES class methods are non-enumerable, so unlike the legacy
+    // implementation-object scan we must use ALL_PROPERTIES.
+    std::vector<std::string> methodOverrides;
+    std::vector<std::string> implementedInterfaces;
+    robin_hood::unordered_set<std::string> visitedNames;
+    std::string nativeClassName;
+
+    auto prototypeKey = V8StringConstants::GetPrototype(isolate);
+    auto interfacesKey = ArgConverter::ConvertToV8String(isolate, "interfaces");
+    auto nativeClassNameKey = ArgConverter::ConvertToV8String(isolate, "nativeClassName");
+    auto propertyFilter = static_cast<PropertyFilter>(PropertyFilter::ALL_PROPERTIES | PropertyFilter::SKIP_SYMBOLS);
+
+    for (auto& levelCtor : chainCtors) {
+        Local<Value> protoValue;
+        if (!levelCtor->Get(context, prototypeKey).ToLocal(&protoValue) || protoValue.IsEmpty() || !protoValue->IsObject()) {
+            continue;
+        }
+        auto levelPrototype = protoValue.As<Object>();
+
+        Local<Array> propNames;
+        if (levelPrototype->GetOwnPropertyNames(context, propertyFilter).ToLocal(&propNames)) {
+            for (uint32_t i = 0; i < propNames->Length(); i++) {
+                Local<Value> nameValue;
+                if (!propNames->Get(context, i).ToLocal(&nameValue) || !nameValue->IsString()) {
+                    continue;
+                }
+
+                string name = ArgConverter::ConvertToString(nameValue.As<String>());
+                if (name == "constructor" || name == "super") {
+                    continue;
+                }
+
+                // skip names already handled by a more derived level (JS shadowing semantics)
+                if (!visitedNames.insert(name).second) {
+                    continue;
+                }
+
+                // inspect the descriptor instead of reading the property, so user-defined
+                // accessors are not invoked during registration
+                Local<Value> descriptor;
+                if (!levelPrototype->GetOwnPropertyDescriptor(context, nameValue.As<Name>()).ToLocal(&descriptor)
+                        || descriptor.IsEmpty() || !descriptor->IsObject()) {
+                    continue;
+                }
+
+                Local<Value> methodValue;
+                if (descriptor.As<Object>()->Get(context, V8StringConstants::GetValue(isolate)).ToLocal(&methodValue)
+                        && !methodValue.IsEmpty() && methodValue->IsFunction()) {
+                    methodOverrides.push_back(name);
+                }
+            }
+        }
+
+        // `static interfaces = [...]` - additional interfaces the proxy should implement
+        bool hasOwnInterfaces;
+        if (levelCtor->HasOwnProperty(context, interfacesKey).To(&hasOwnInterfaces) && hasOwnInterfaces) {
+            Local<Value> interfacesValue;
+            if (levelCtor->Get(context, interfacesKey).ToLocal(&interfacesValue) && interfacesValue->IsArray()) {
+                auto interfacesArr = interfacesValue.As<Array>();
+                for (uint32_t i = 0; i < interfacesArr->Length(); i++) {
+                    Local<Value> element;
+                    if (!interfacesArr->Get(context, i).ToLocal(&element) || !element->IsFunction()) {
+                        continue;
+                    }
+
+                    auto interfaceName = GetTypeMetadataName(isolate, element);
+                    interfaceName = Util::ReplaceAll(interfaceName, std::string("/"), std::string("."));
+                    if (std::find(implementedInterfaces.begin(), implementedInterfaces.end(), interfaceName) == implementedInterfaces.end()) {
+                        implementedInterfaces.push_back(interfaceName);
+                    }
+                }
+            }
+        }
+
+        // `static nativeClassName = 'com.my.Thing'` - explicit proxy class name (most-derived wins)
+        if (nativeClassName.empty()) {
+            bool hasOwnNativeClassName;
+            if (levelCtor->HasOwnProperty(context, nativeClassNameKey).To(&hasOwnNativeClassName) && hasOwnNativeClassName) {
+                Local<Value> nativeClassNameValue;
+                if (levelCtor->Get(context, nativeClassNameKey).ToLocal(&nativeClassNameValue) && nativeClassNameValue->IsString()) {
+                    nativeClassName = ArgConverter::ConvertToString(nativeClassNameValue.As<String>());
+                }
+            }
+        }
+    }
+
+    // Compute the proxy class name
+    string fullClassName;
+    if (!nativeClassName.empty() && nativeClassName.find('.') != string::npos) {
+        fullClassName = nativeClassName;
+    } else if (isInterface) {
+        // interface extensions reuse the shared interface proxy, exactly like
+        // `new SomeInterface({...})` - all methods dispatch back to JS through the instance
+        fullClassName = node->m_implType;
+    } else {
+        string className;
+        auto jsClassName = ctorFunc->GetName();
+        if (!jsClassName.IsEmpty() && jsClassName->IsString()) {
+            className = SanitizeESClassNamePart(ArgConverter::ConvertToString(jsClassName.As<String>()));
+        }
+        if (className.empty()) {
+            className = "ESClass";
+        }
+
+        string scriptName;
+        auto scriptOrigin = ctorFunc->GetScriptOrigin();
+        auto resourceName = scriptOrigin.ResourceName();
+        if (!resourceName.IsEmpty() && resourceName->IsString()) {
+            scriptName = ArgConverter::ConvertToString(resourceName.As<String>());
+        }
+
+        string extendNameAndLocation = "es" + HashESClassId(scriptName + "|" + baseClassName + "|" + className) + "_" + className;
+        string candidate = TNS_PREFIX + CreateFullClassName(baseClassName, extendNameAndLocation);
+
+        // collision handling for distinct classes that produce the same deterministic name
+        // (e.g. a class factory evaluated multiple times in the same script)
+        fullClassName = candidate;
+        int suffix = 2;
+        while (GetCachedExtendedClassData(isolate, fullClassName).extendedCtorFunction != nullptr) {
+            fullClassName = candidate + "_" + std::to_string(suffix++);
+        }
+    }
+
+    // Resolve (generate or load) the Java proxy class through the regular DexFactory pipeline
+    auto clazz = CallbackHandlers::ResolveClass(isolate, baseClassName, fullClassName, methodOverrides, implementedInterfaces, isInterface);
+    auto fullExtendedName = CallbackHandlers::ResolveClassName(isolate, clazz);
+
+    // Tag the ES ctor the same way ExtendMethodCallback tags `.extend()`-created functions, so
+    // the rest of the runtime (construction, Java-initiated instantiation, `.class`, marshalling)
+    // treats it like any other extended class ctor
+    auto typeMetadata = new TypeMetadata(fullExtendedName, true /* isESDerived */);
+    SetTypeMetadata(isolate, ctorFunc, typeMetadata);
+
+    // The ES class prototype acts as the implementation object. Mark it the way
+    // ExtendMethodCallback marks implementation objects, so GetImplementationObject (used
+    // during Java-initiated instantiation) can find it on the instance prototype chain.
+    Local<Value> ctorPrototypeValue;
+    if (ctorFunc->Get(context, prototypeKey).ToLocal(&ctorPrototypeValue) && ctorPrototypeValue->IsObject()) {
+        auto ctorPrototype = ctorPrototypeValue.As<Object>();
+        auto implementationObjectPropertyName = V8StringConstants::GetClassImplementationObject(isolate);
+        Local<Value> hiddenVal;
+        V8GetPrivateValue(isolate, ctorPrototype, implementationObjectPropertyName, hiddenVal);
+        if (hiddenVal.IsEmpty()) {
+            V8SetPrivateValue(isolate, ctorPrototype, implementationObjectPropertyName, String::NewFromUtf8(isolate, fullExtendedName.c_str()).ToLocalChecked());
+        }
+    }
+
+    s_name2NodeCache.emplace(fullExtendedName, node);
+
+    auto cache = GetMetadataNodeCache(isolate);
+    auto itCached = cache->ExtendedCtorFuncCache.find(fullExtendedName);
+    if (itCached == cache->ExtendedCtorFuncCache.end()) {
+        ExtendedClassCacheData cacheData(ctorFunc, fullExtendedName, node);
+        cache->ExtendedCtorFuncCache.emplace(fullExtendedName, cacheData);
+    }
+
+    DEBUG_WRITE("EnsureExtendedESClass: registered %s (base %s)", fullExtendedName.c_str(), baseClassName.c_str());
+
+    return typeMetadata;
+}
+
 MetadataNode* MetadataNode::GetInstanceMetadata(Isolate* isolate, const Local<Object>& value) {
     MetadataNode* node = nullptr;
     auto cache = GetMetadataNodeCache(isolate);
@@ -1129,6 +1462,30 @@ void MetadataNode::InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v
         Local<String> v8ExtendName;
         auto context = isolate->GetCurrentContext();
 
+        // Plain ES class implementing an interface: `class Handler extends java.lang.Runnable {}`
+        // invokes this callback through `super()` with new.target set to the ES constructor and
+        // no implementation object argument. The methods live on the ES class prototype.
+        auto newTargetValue = info.NewTarget();
+        if (!newTargetValue.IsEmpty() && newTargetValue->IsFunction()) {
+            auto newTargetFunc = newTargetValue.As<Function>();
+            auto typeMetadata = TryGetTypeMetadata(isolate, newTargetFunc);
+            if (typeMetadata == nullptr) {
+                typeMetadata = EnsureExtendedESClass(isolate, newTargetFunc);
+            }
+
+            if (typeMetadata != nullptr && typeMetadata->isESDerived) {
+                auto esImplementationObject = newTargetFunc->Get(context, V8StringConstants::GetPrototype(isolate)).ToLocalChecked().As<Object>();
+
+                SetInstanceMetadata(isolate, thiz, node);
+                thiz->SetInternalField(static_cast<int>(ObjectManager::MetadataNodeKeys::CallSuper), True(isolate));
+                V8SetPrivateValue(isolate, thiz, V8StringConstants::GetImplementationObject(isolate), esImplementationObject);
+
+                ArgsWrapper esArgWrapper(info, ArgType::Interface);
+                CallbackHandlers::RegisterInstance(isolate, thiz, typeMetadata->name, esArgWrapper, esImplementationObject, true);
+                return;
+            }
+        }
+
         if (info.Length() == 1) {
             if (!info[0]->IsObject()) {
                 throw NativeScriptException(string("First argument must be implementation object"));
@@ -1190,6 +1547,32 @@ void MetadataNode::ClassConstructorCallback(const v8::FunctionCallbackInfo<v8::V
 
         string extendName;
         auto className = node->m_name;
+
+        // Plain ES class extension: `class MyView extends android.view.View {}` invokes this
+        // callback through `super(...)` with new.target set to the most derived ES constructor.
+        // Lazily register the ES class as an extended class and construct its proxy instead of
+        // the base class.
+        auto newTargetValue = info.NewTarget();
+        if (!newTargetValue.IsEmpty() && newTargetValue->IsFunction()) {
+            auto newTargetFunc = newTargetValue.As<Function>();
+            auto typeMetadata = TryGetTypeMetadata(isolate, newTargetFunc);
+            if (typeMetadata == nullptr) {
+                typeMetadata = EnsureExtendedESClass(isolate, newTargetFunc);
+            }
+
+            if (typeMetadata != nullptr && typeMetadata->isESDerived) {
+                auto context = isolate->GetCurrentContext();
+                auto implementationObject = newTargetFunc->Get(context, V8StringConstants::GetPrototype(isolate)).ToLocalChecked().As<Object>();
+
+                SetInstanceMetadata(isolate, thiz, node);
+                thiz->SetInternalField(static_cast<int>(ObjectManager::MetadataNodeKeys::CallSuper), True(isolate));
+                V8SetPrivateValue(isolate, thiz, V8StringConstants::GetImplementationObject(isolate), implementationObject);
+
+                ArgsWrapper esArgWrapper(info, ArgType::Class);
+                CallbackHandlers::RegisterInstance(isolate, thiz, typeMetadata->name, esArgWrapper, implementationObject, false, className);
+                return;
+            }
+        }
 
         SetInstanceMetadata(isolate, thiz, node);
 
@@ -1577,6 +1960,24 @@ void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value
         }
 
         SET_PROFILER_FRAME();
+
+        {
+            // `.extend()` on an ES class receiver would silently drop the ES-level overrides
+            // (the legacy scan sees only the implementation object) - fail loudly instead.
+            // Reject ctors already registered as ES-derived and unregistered genuine `class`
+            // syntax ctors. Downleveled classes (JavaProxy targets, ts_helpers __extends
+            // children) stringify as "function ..." and keep working through the legacy path.
+            auto thisValue = info.This();
+            if (!thisValue.IsEmpty() && thisValue->IsFunction()) {
+                auto thisFunc = thisValue.As<Function>();
+                auto thisMetadata = TryGetTypeMetadata(info.GetIsolate(), thisFunc);
+                bool isESClassReceiver = (thisMetadata != nullptr && thisMetadata->isESDerived) ||
+                                         (thisMetadata == nullptr && IsESClassConstructor(info.GetIsolate(), thisFunc));
+                if (isESClassReceiver) {
+                    throw NativeScriptException(string("Cannot call 'extend' on a class extension created with ES class syntax. Extend it with `class X extends Y {}` instead."));
+                }
+            }
+        }
 
         Local<Object> implementationObject;
         Local<String> extendName;

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1251,6 +1251,13 @@ MetadataNode::TypeMetadata* MetadataNode::EnsureExtendedESClass(Isolate* isolate
         return existingMetadata;
     }
 
+    // Only the main isolate mints ES-derived Java proxies. Workers keep
+    // NativeClass / lazy registration as a no-op so they cannot claim
+    // process-global names. Legacy `.extend()` is unchanged.
+    if (Runtime::GetRuntime(isolate)->IsWorker()) {
+        return nullptr;
+    }
+
     auto context = isolate->GetCurrentContext();
 
     // Only genuine `class` syntax constructors participate in lazy ES registration. Downleveled
@@ -1472,6 +1479,53 @@ MetadataNode::TypeMetadata* MetadataNode::EnsureExtendedESClass(Isolate* isolate
     DEBUG_WRITE("EnsureExtendedESClass: registered %s (base %s)", fullExtendedName.c_str(), baseClassName.c_str());
 
     return typeMetadata;
+}
+
+bool MetadataNode::TryConstructESDerivedInstance(Isolate* isolate, const string& proxyClassName, int javaObjectID, Local<Object>& out) {
+    auto cache = GetMetadataNodeCache(isolate);
+    if (cache->PendingESAdoptObjectId != -1) {
+        return false;
+    }
+
+    auto cacheData = GetCachedExtendedClassData(isolate, proxyClassName);
+    if (cacheData.extendedCtorFunction == nullptr) {
+        return false;
+    }
+
+    Local<Function> ctor = Local<Function>::New(isolate, *cacheData.extendedCtorFunction);
+    auto typeMetadata = TryGetTypeMetadata(isolate, ctor);
+    if (typeMetadata == nullptr || !typeMetadata->isESDerived) {
+        return false;
+    }
+
+    cache->PendingESAdoptObjectId = javaObjectID;
+    TryCatch tc(isolate);
+    auto context = isolate->GetCurrentContext();
+    bool ok = !ctor->CallAsConstructor(context, 0, nullptr).IsEmpty();
+    cache->PendingESAdoptObjectId = -1;
+    if (!ok) {
+        throw NativeScriptException(tc, "Failed to construct ES class for native instance");
+    }
+
+    auto objectManager = Runtime::GetRuntime(isolate)->GetObjectManager();
+    auto cached = objectManager->GetJsObjectByJavaObject(javaObjectID);
+    if (cached.IsEmpty()) {
+        return false;
+    }
+
+    out = cached;
+    return true;
+}
+
+bool MetadataNode::TryConsumePendingESAdopt(Isolate* isolate, int& javaObjectID) {
+    auto cache = GetMetadataNodeCache(isolate);
+    if (cache->PendingESAdoptObjectId == -1) {
+        return false;
+    }
+
+    javaObjectID = cache->PendingESAdoptObjectId;
+    cache->PendingESAdoptObjectId = -1;
+    return true;
 }
 
 MetadataNode* MetadataNode::GetInstanceMetadata(Isolate* isolate, const Local<Object>& value) {

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -12,6 +12,7 @@
 #include "Runtime.h"
 #include <sstream>
 #include <cctype>
+#include <algorithm>
 #include <dirent.h>
 #include <errno.h>
 #include <android/log.h>
@@ -198,7 +199,20 @@ bool MetadataNode::IsNodeTypeInterface() {
 }
 
 string MetadataNode::GetTypeMetadataName(Isolate* isolate, Local<Value>& value) {
-    auto data = GetTypeMetadata(isolate, value.As<Function>());
+    if (value.IsEmpty() || !value->IsFunction()) {
+        throw NativeScriptException(string("Cannot resolve native type - the value is not a constructor function."));
+    }
+
+    auto func = value.As<Function>();
+    auto data = TryGetTypeMetadata(isolate, func);
+    if (data == nullptr) {
+        // may be a not-yet-registered plain ES class extension
+        data = EnsureExtendedESClass(isolate, func);
+    }
+
+    if (data == nullptr) {
+        throw NativeScriptException(string("Cannot resolve native type - the function does not stand for a native type or an extension of one."));
+    }
 
     return data->name;
 }
@@ -325,7 +339,22 @@ void MetadataNode::ClassAccessorGetterCallback(const FunctionCallbackInfo<Value>
     try {
         auto thiz = info.This();
         auto isolate = info.GetIsolate();
-        auto data = GetTypeMetadata(isolate, thiz.As<Function>());
+
+        if (thiz.IsEmpty() || !thiz->IsFunction()) {
+            throw NativeScriptException(string("The 'class' property may only be accessed on a native type or an extended class constructor function."));
+        }
+
+        auto func = thiz.As<Function>();
+        auto data = TryGetTypeMetadata(isolate, func);
+        if (data == nullptr) {
+            // Plain ES class extension accessed statically before any instance was constructed
+            // (e.g. `MyView.class`) - lazily register it now
+            data = EnsureExtendedESClass(isolate, func);
+        }
+
+        if (data == nullptr) {
+            throw NativeScriptException(string("Cannot resolve java.lang.Class - the function does not stand for a native type or an extension of one."));
+        }
 
         auto value = CallbackHandlers::FindClass(isolate, data->name);
         info.GetReturnValue().Set(value);
@@ -1141,6 +1170,310 @@ void MetadataNode::SetTypeMetadata(Isolate* isolate, Local<Function> value, Type
     V8SetPrivateValue(isolate, value, String::NewFromUtf8(isolate, "typemetadata").ToLocalChecked(),  External::New(isolate, data, v8::kExternalPointerTypeTagDefault));
 }
 
+MetadataNode::TypeMetadata* MetadataNode::TryGetTypeMetadata(Isolate* isolate, const Local<Function>& value) {
+    Local<Value> hiddenVal;
+    V8GetPrivateValue(isolate, value, String::NewFromUtf8(isolate, "typemetadata").ToLocalChecked(), hiddenVal);
+
+    if (hiddenVal.IsEmpty() || !hiddenVal->IsExternal()) {
+        return nullptr;
+    }
+
+    return reinterpret_cast<TypeMetadata*>(hiddenVal.As<External>()->Value());
+}
+
+std::string MetadataNode::TryResolveClassCtorTypeName(Isolate* isolate, const Local<Function>& func) {
+    // A ctor function that had its `.null` accessed doubles as the typed null value for its
+    // type (see NullObjectAccessorGetterCallback - the marker private is set on the ctor and
+    // the ctor itself is returned). Such functions must marshal as typed nulls, not as
+    // java.lang.Class references.
+    Local<Value> nullNodeMarker;
+    V8GetPrivateValue(isolate, func, V8StringConstants::GetNullNodeName(isolate), nullNodeMarker);
+    if (!nullNodeMarker.IsEmpty()) {
+        return std::string();
+    }
+
+    auto typeMetadata = TryGetTypeMetadata(isolate, func);
+
+    if (typeMetadata == nullptr) {
+        typeMetadata = EnsureExtendedESClass(isolate, func);
+    }
+
+    return typeMetadata != nullptr ? typeMetadata->name : std::string();
+}
+
+namespace {
+// short deterministic identifier so the same ES class gets the same proxy class name across
+// application launches (keeps the DexFactory on-disk dex cache warm) without depending on
+// line/column numbers that shift with unrelated code edits
+std::string HashESClassId(const std::string& input) {
+    uint32_t hash = 2166136261u;
+    for (char c : input) {
+        hash ^= static_cast<uint8_t>(c);
+        hash *= 16777619u;
+    }
+
+    char buff[9];
+    snprintf(buff, sizeof(buff), "%08x", hash);
+    return std::string(buff);
+}
+
+std::string SanitizeESClassNamePart(const std::string& name) {
+    std::string result;
+    result.reserve(name.size());
+    for (char c : name) {
+        bool isValid = isalpha(c) || isdigit(c) || c == '_';
+        result += isValid ? c : '_';
+    }
+    return result;
+}
+
+// True only for genuine `class` syntax constructors. Function source text is the reliable
+// discriminator: per spec, Function.prototype.toString for a class constructor reproduces the
+// `class` declaration/expression source (possibly behind leading comments/whitespace, which V8
+// does not emit for the class case - the text starts with "class").
+bool IsESClassConstructor(v8::Isolate* isolate, const v8::Local<v8::Function>& func) {
+    auto context = isolate->GetCurrentContext();
+    v8::Local<v8::String> sourceText;
+    if (!func->FunctionProtoToString(context).ToLocal(&sourceText)) {
+        return false;
+    }
+
+    auto source = tns::ArgConverter::ConvertToString(sourceText);
+    return source.compare(0, 5, "class") == 0;
+}
+} // namespace
+
+MetadataNode::TypeMetadata* MetadataNode::EnsureExtendedESClass(Isolate* isolate, Local<v8::Function> ctorFunc) {
+    // Already registered - a native class ctor, a legacy `.extend()`-created ctor or an
+    // ES class ctor registered by a previous call
+    auto existingMetadata = TryGetTypeMetadata(isolate, ctorFunc);
+    if (existingMetadata != nullptr) {
+        return existingMetadata;
+    }
+
+    auto context = isolate->GetCurrentContext();
+
+    // Only genuine `class` syntax constructors participate in lazy ES registration. Downleveled
+    // ES5 "classes" (TypeScript ES5 output, the JavaProxy decorator target, ts_helpers __extends
+    // children) have the same shape - an untagged function whose prototype chain reaches a native
+    // ctor - but must keep flowing through the legacy `.extend()` pipeline.
+    if (!IsESClassConstructor(isolate, ctorFunc)) {
+        return nullptr;
+    }
+
+    // Walk the constructor prototype chain (mirrors the `class X extends Y` chain) and collect
+    // every plain (unregistered) ES constructor level until we reach a constructor holding type
+    // metadata. ES-registered ancestors are flattened into this registration; legacy
+    // `.extend()`-created ancestors are not supported and make this function bail out so callers
+    // preserve their old behavior.
+    std::vector<Local<v8::Function>> chainCtors;
+    Local<v8::Function> current = ctorFunc;
+    TypeMetadata* baseTypeMetadata = nullptr;
+    while (true) {
+        chainCtors.push_back(current);
+
+        Local<Value> parentValue = current->GetPrototype();
+        if (parentValue.IsEmpty() || !parentValue->IsObject() || !parentValue->IsFunction()) {
+            // no native type in the chain - a plain JS class, leave it alone
+            return nullptr;
+        }
+
+        auto parent = parentValue.As<v8::Function>();
+        auto parentMetadata = TryGetTypeMetadata(isolate, parent);
+        if (parentMetadata == nullptr) {
+            current = parent;
+            continue;
+        }
+
+        if (parentMetadata->isESDerived) {
+            // Flatten: the parent's registered proxy class sits directly under the pure native
+            // base, so keep walking (collecting the parent's prototype for scanning) until we
+            // reach it
+            current = parent;
+            continue;
+        }
+
+        auto cachedData = GetCachedExtendedClassData(isolate, parentMetadata->name);
+        if (cachedData.extendedCtorFunction != nullptr) {
+            // legacy `.extend()`-created ancestor - not supported for ES class chaining
+            return nullptr;
+        }
+
+        baseTypeMetadata = parentMetadata;
+        break;
+    }
+
+    string baseClassName = baseTypeMetadata->name;
+    auto node = GetOrCreate(baseClassName);
+    if (node == nullptr) {
+        return nullptr;
+    }
+
+    uint8_t nodeType = s_metadataReader.GetNodeType(node->m_treeNode);
+    bool isInterface = s_metadataReader.IsNodeTypeInterface(nodeType);
+
+    // Collect overridden method names level by level, most-derived first, so JS shadowing
+    // semantics carry over. ES class methods are non-enumerable, so unlike the legacy
+    // implementation-object scan we must use ALL_PROPERTIES.
+    std::vector<std::string> methodOverrides;
+    std::vector<std::string> implementedInterfaces;
+    robin_hood::unordered_set<std::string> visitedNames;
+    std::string nativeClassName;
+
+    auto prototypeKey = V8StringConstants::GetPrototype(isolate);
+    auto interfacesKey = ArgConverter::ConvertToV8String(isolate, "interfaces");
+    auto nativeClassNameKey = ArgConverter::ConvertToV8String(isolate, "nativeClassName");
+    auto propertyFilter = static_cast<PropertyFilter>(PropertyFilter::ALL_PROPERTIES | PropertyFilter::SKIP_SYMBOLS);
+
+    for (auto& levelCtor : chainCtors) {
+        Local<Value> protoValue;
+        if (!levelCtor->Get(context, prototypeKey).ToLocal(&protoValue) || protoValue.IsEmpty() || !protoValue->IsObject()) {
+            continue;
+        }
+        auto levelPrototype = protoValue.As<Object>();
+
+        Local<Array> propNames;
+        if (levelPrototype->GetOwnPropertyNames(context, propertyFilter).ToLocal(&propNames)) {
+            for (uint32_t i = 0; i < propNames->Length(); i++) {
+                Local<Value> nameValue;
+                if (!propNames->Get(context, i).ToLocal(&nameValue) || !nameValue->IsString()) {
+                    continue;
+                }
+
+                string name = ArgConverter::ConvertToString(nameValue.As<String>());
+                if (name == "constructor" || name == "super") {
+                    continue;
+                }
+
+                // skip names already handled by a more derived level (JS shadowing semantics)
+                if (!visitedNames.insert(name).second) {
+                    continue;
+                }
+
+                // inspect the descriptor instead of reading the property, so user-defined
+                // accessors are not invoked during registration
+                Local<Value> descriptor;
+                if (!levelPrototype->GetOwnPropertyDescriptor(context, nameValue.As<Name>()).ToLocal(&descriptor)
+                        || descriptor.IsEmpty() || !descriptor->IsObject()) {
+                    continue;
+                }
+
+                Local<Value> methodValue;
+                if (descriptor.As<Object>()->Get(context, V8StringConstants::GetValue(isolate)).ToLocal(&methodValue)
+                        && !methodValue.IsEmpty() && methodValue->IsFunction()) {
+                    methodOverrides.push_back(name);
+                }
+            }
+        }
+
+        // `static interfaces = [...]` - additional interfaces the proxy should implement
+        bool hasOwnInterfaces;
+        if (levelCtor->HasOwnProperty(context, interfacesKey).To(&hasOwnInterfaces) && hasOwnInterfaces) {
+            Local<Value> interfacesValue;
+            if (levelCtor->Get(context, interfacesKey).ToLocal(&interfacesValue) && interfacesValue->IsArray()) {
+                auto interfacesArr = interfacesValue.As<Array>();
+                for (uint32_t i = 0; i < interfacesArr->Length(); i++) {
+                    Local<Value> element;
+                    if (!interfacesArr->Get(context, i).ToLocal(&element) || !element->IsFunction()) {
+                        continue;
+                    }
+
+                    auto interfaceName = GetTypeMetadataName(isolate, element);
+                    interfaceName = Util::ReplaceAll(interfaceName, std::string("/"), std::string("."));
+                    if (std::find(implementedInterfaces.begin(), implementedInterfaces.end(), interfaceName) == implementedInterfaces.end()) {
+                        implementedInterfaces.push_back(interfaceName);
+                    }
+                }
+            }
+        }
+
+        // `static nativeClassName = 'com.my.Thing'` - explicit proxy class name (most-derived wins)
+        if (nativeClassName.empty()) {
+            bool hasOwnNativeClassName;
+            if (levelCtor->HasOwnProperty(context, nativeClassNameKey).To(&hasOwnNativeClassName) && hasOwnNativeClassName) {
+                Local<Value> nativeClassNameValue;
+                if (levelCtor->Get(context, nativeClassNameKey).ToLocal(&nativeClassNameValue) && nativeClassNameValue->IsString()) {
+                    nativeClassName = ArgConverter::ConvertToString(nativeClassNameValue.As<String>());
+                }
+            }
+        }
+    }
+
+    // Compute the proxy class name
+    string fullClassName;
+    if (!nativeClassName.empty() && nativeClassName.find('.') != string::npos) {
+        fullClassName = nativeClassName;
+    } else if (isInterface) {
+        // interface extensions reuse the shared interface proxy, exactly like
+        // `new SomeInterface({...})` - all methods dispatch back to JS through the instance
+        fullClassName = node->m_implType;
+    } else {
+        string className;
+        auto jsClassName = ctorFunc->GetName();
+        if (!jsClassName.IsEmpty() && jsClassName->IsString()) {
+            className = SanitizeESClassNamePart(ArgConverter::ConvertToString(jsClassName.As<String>()));
+        }
+        if (className.empty()) {
+            className = "ESClass";
+        }
+
+        string scriptName;
+        auto scriptOrigin = ctorFunc->GetScriptOrigin();
+        auto resourceName = scriptOrigin.ResourceName();
+        if (!resourceName.IsEmpty() && resourceName->IsString()) {
+            scriptName = ArgConverter::ConvertToString(resourceName.As<String>());
+        }
+
+        string extendNameAndLocation = "es" + HashESClassId(scriptName + "|" + baseClassName + "|" + className) + "_" + className;
+        string candidate = TNS_PREFIX + CreateFullClassName(baseClassName, extendNameAndLocation);
+
+        // collision handling for distinct classes that produce the same deterministic name
+        // (e.g. a class factory evaluated multiple times in the same script)
+        fullClassName = candidate;
+        int suffix = 2;
+        while (GetCachedExtendedClassData(isolate, fullClassName).extendedCtorFunction != nullptr) {
+            fullClassName = candidate + "_" + std::to_string(suffix++);
+        }
+    }
+
+    // Resolve (generate or load) the Java proxy class through the regular DexFactory pipeline
+    auto clazz = CallbackHandlers::ResolveClass(isolate, baseClassName, fullClassName, methodOverrides, implementedInterfaces, isInterface);
+    auto fullExtendedName = CallbackHandlers::ResolveClassName(isolate, clazz);
+
+    // Tag the ES ctor the same way ExtendMethodCallback tags `.extend()`-created functions, so
+    // the rest of the runtime (construction, Java-initiated instantiation, `.class`, marshalling)
+    // treats it like any other extended class ctor
+    auto typeMetadata = new TypeMetadata(fullExtendedName, true /* isESDerived */);
+    SetTypeMetadata(isolate, ctorFunc, typeMetadata);
+
+    // The ES class prototype acts as the implementation object. Mark it the way
+    // ExtendMethodCallback marks implementation objects, so GetImplementationObject (used
+    // during Java-initiated instantiation) can find it on the instance prototype chain.
+    Local<Value> ctorPrototypeValue;
+    if (ctorFunc->Get(context, prototypeKey).ToLocal(&ctorPrototypeValue) && ctorPrototypeValue->IsObject()) {
+        auto ctorPrototype = ctorPrototypeValue.As<Object>();
+        auto implementationObjectPropertyName = V8StringConstants::GetClassImplementationObject(isolate);
+        Local<Value> hiddenVal;
+        V8GetPrivateValue(isolate, ctorPrototype, implementationObjectPropertyName, hiddenVal);
+        if (hiddenVal.IsEmpty()) {
+            V8SetPrivateValue(isolate, ctorPrototype, implementationObjectPropertyName, String::NewFromUtf8(isolate, fullExtendedName.c_str()).ToLocalChecked());
+        }
+    }
+
+    s_name2NodeCache.emplace(fullExtendedName, node);
+
+    auto cache = GetMetadataNodeCache(isolate);
+    auto itCached = cache->ExtendedCtorFuncCache.find(fullExtendedName);
+    if (itCached == cache->ExtendedCtorFuncCache.end()) {
+        ExtendedClassCacheData cacheData(ctorFunc, fullExtendedName, node);
+        cache->ExtendedCtorFuncCache.emplace(fullExtendedName, cacheData);
+    }
+
+    DEBUG_WRITE("EnsureExtendedESClass: registered %s (base %s)", fullExtendedName.c_str(), baseClassName.c_str());
+
+    return typeMetadata;
+}
+
 MetadataNode* MetadataNode::GetInstanceMetadata(Isolate* isolate, const Local<Object>& value) {
     MetadataNode* node = nullptr;
     auto cache = GetMetadataNodeCache(isolate);
@@ -1219,6 +1552,30 @@ void MetadataNode::InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v
         Local<String> v8ExtendName;
         auto context = isolate->GetCurrentContext();
 
+        // Plain ES class implementing an interface: `class Handler extends java.lang.Runnable {}`
+        // invokes this callback through `super()` with new.target set to the ES constructor and
+        // no implementation object argument. The methods live on the ES class prototype.
+        auto newTargetValue = info.NewTarget();
+        if (!newTargetValue.IsEmpty() && newTargetValue->IsFunction()) {
+            auto newTargetFunc = newTargetValue.As<Function>();
+            auto typeMetadata = TryGetTypeMetadata(isolate, newTargetFunc);
+            if (typeMetadata == nullptr) {
+                typeMetadata = EnsureExtendedESClass(isolate, newTargetFunc);
+            }
+
+            if (typeMetadata != nullptr && typeMetadata->isESDerived) {
+                auto esImplementationObject = newTargetFunc->Get(context, V8StringConstants::GetPrototype(isolate)).ToLocalChecked().As<Object>();
+
+                SetInstanceMetadata(isolate, thiz, node);
+                thiz->SetInternalField(static_cast<int>(ObjectManager::MetadataNodeKeys::CallSuper), True(isolate));
+                V8SetPrivateValue(isolate, thiz, V8StringConstants::GetImplementationObject(isolate), esImplementationObject);
+
+                ArgsWrapper esArgWrapper(info, ArgType::Interface);
+                CallbackHandlers::RegisterInstance(isolate, thiz, typeMetadata->name, esArgWrapper, esImplementationObject, true);
+                return;
+            }
+        }
+
         if (info.Length() == 1) {
             if (!info[0]->IsObject()) {
                 throw NativeScriptException(string("First argument must be implementation object"));
@@ -1280,6 +1637,32 @@ void MetadataNode::ClassConstructorCallback(const v8::FunctionCallbackInfo<v8::V
 
         string extendName;
         auto className = node->m_name;
+
+        // Plain ES class extension: `class MyView extends android.view.View {}` invokes this
+        // callback through `super(...)` with new.target set to the most derived ES constructor.
+        // Lazily register the ES class as an extended class and construct its proxy instead of
+        // the base class.
+        auto newTargetValue = info.NewTarget();
+        if (!newTargetValue.IsEmpty() && newTargetValue->IsFunction()) {
+            auto newTargetFunc = newTargetValue.As<Function>();
+            auto typeMetadata = TryGetTypeMetadata(isolate, newTargetFunc);
+            if (typeMetadata == nullptr) {
+                typeMetadata = EnsureExtendedESClass(isolate, newTargetFunc);
+            }
+
+            if (typeMetadata != nullptr && typeMetadata->isESDerived) {
+                auto context = isolate->GetCurrentContext();
+                auto implementationObject = newTargetFunc->Get(context, V8StringConstants::GetPrototype(isolate)).ToLocalChecked().As<Object>();
+
+                SetInstanceMetadata(isolate, thiz, node);
+                thiz->SetInternalField(static_cast<int>(ObjectManager::MetadataNodeKeys::CallSuper), True(isolate));
+                V8SetPrivateValue(isolate, thiz, V8StringConstants::GetImplementationObject(isolate), implementationObject);
+
+                ArgsWrapper esArgWrapper(info, ArgType::Class);
+                CallbackHandlers::RegisterInstance(isolate, thiz, typeMetadata->name, esArgWrapper, implementationObject, false, className);
+                return;
+            }
+        }
 
         SetInstanceMetadata(isolate, thiz, node);
 
@@ -1667,6 +2050,24 @@ void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value
         }
 
         SET_PROFILER_FRAME();
+
+        {
+            // `.extend()` on an ES class receiver would silently drop the ES-level overrides
+            // (the legacy scan sees only the implementation object) - fail loudly instead.
+            // Reject ctors already registered as ES-derived and unregistered genuine `class`
+            // syntax ctors. Downleveled classes (JavaProxy targets, ts_helpers __extends
+            // children) stringify as "function ..." and keep working through the legacy path.
+            auto thisValue = info.This();
+            if (!thisValue.IsEmpty() && thisValue->IsFunction()) {
+                auto thisFunc = thisValue.As<Function>();
+                auto thisMetadata = TryGetTypeMetadata(info.GetIsolate(), thisFunc);
+                bool isESClassReceiver = (thisMetadata != nullptr && thisMetadata->isESDerived) ||
+                                         (thisMetadata == nullptr && IsESClassConstructor(info.GetIsolate(), thisFunc));
+                if (isESClassReceiver) {
+                    throw NativeScriptException(string("Cannot call 'extend' on a class extension created with ES class syntax. Extend it with `class X extends Y {}` instead."));
+                }
+            }
+        }
 
         Local<Object> implementationObject;
         Local<String> extendName;

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -60,7 +60,7 @@ class MetadataNode {
          */
         static bool TryConstructESDerivedInstance(v8::Isolate* isolate, const std::string& proxyClassName, int javaObjectID, v8::Local<v8::Object>& out);
 
-        static bool TryConsumePendingESAdopt(v8::Isolate* isolate, int& javaObjectID);
+        static bool TryConsumePendingESAdopt(v8::Isolate* isolate, const std::string& fullClassName, int& javaObjectID);
 
         static v8::Local<v8::Object> GetImplementationObject(v8::Isolate* isolate, const v8::Local<v8::Object>& object);
 
@@ -340,9 +340,10 @@ class MetadataNode {
 
             // Java object id being adopted by an in-flight ES construct
             // (CreateJSInstanceNative → CallAsConstructor → super()).
-            // RegisterInstance consumes it so super() binds that id and does
-            // not NewObject again.
+            // RegisterInstance consumes it only when fullClassName matches, so
+            // a nested `new OtherNative()` before super() cannot steal the id.
             int PendingESAdoptObjectId = -1;
+            std::string PendingESAdoptClassName;
 
             ~MetadataNodeCache() {
                 delete MetadataKey;

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -71,6 +71,14 @@ class MetadataNode {
 
         static bool TryGetPackageName(v8::Isolate* isolate, const v8::Local<v8::Object>& value, std::string& out);
 
+        /*
+         * Resolves the Java class name a constructor function stands for, lazily registering a
+         * Java proxy class when the function is a plain ES `class X extends NativeType {}` that
+         * has not been registered yet. Returns an empty string when the function is not part of
+         * a native inheritance chain. Used when marshalling a constructor function to a Java
+         * `java.lang.Class` (or `java.lang.Object`) argument.
+         */
+        static std::string TryResolveClassCtorTypeName(v8::Isolate* isolate, const v8::Local<v8::Function>& func);
 
         static MetadataReader* getMetadataReader();
     private:
@@ -140,7 +148,23 @@ class MetadataNode {
 
         static TypeMetadata* GetTypeMetadata(v8::Isolate* isolate, const v8::Local<v8::Function>& value);
 
+        // Safe variant of GetTypeMetadata - returns nullptr when the function carries no type
+        // metadata (e.g. a plain ES class constructor) instead of crashing
+        static TypeMetadata* TryGetTypeMetadata(v8::Isolate* isolate, const v8::Local<v8::Function>& value);
+
         static void SetTypeMetadata(v8::Isolate* isolate, v8::Local<v8::Function> value, TypeMetadata* data);
+
+        /*
+         * Lazily registers a Java proxy class for a plain ES `class X extends NativeType {}`
+         * constructor function (no `.extend()` call, no downleveling). Walks the constructor
+         * prototype chain to the native base, collects overridden method names from every ES
+         * level's prototype and implemented interfaces from `static interfaces = [...]`, resolves
+         * the proxy class through the regular DexFactory pipeline and tags the constructor the
+         * same way `.extend()` tags its result (typemetadata + ExtendedCtorFuncCache entry).
+         * Returns nullptr when ctorFunc is not part of a native inheritance chain or the chain
+         * goes through a legacy `.extend()`-created class. Idempotent.
+         */
+        static TypeMetadata* EnsureExtendedESClass(v8::Isolate* isolate, v8::Local<v8::Function> ctorFunc);
 
         static std::string CreateFullClassName(const std::string& className, const std::string& extendNameAndLocation);
         static void MethodCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
@@ -239,12 +263,16 @@ class MetadataNode {
         };
 
         struct TypeMetadata {
-            TypeMetadata(const std::string& _name)
+            TypeMetadata(const std::string& _name, bool _isESDerived = false)
                 :
-                name(_name) {
+                name(_name), isESDerived(_isESDerived) {
             }
 
             std::string name;
+
+            // true when the class was registered lazily from a plain ES
+            // `class X extends NativeType {}` constructor (see EnsureExtendedESClass)
+            bool isESDerived;
         };
 
         struct CtorCacheData {

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -52,6 +52,16 @@ class MetadataNode {
 
         static v8::Local<v8::Object> CreateExtendedJSWrapper(v8::Isolate* isolate, ObjectManager* objectManager, const std::string& proxyClassName);
 
+        /*
+         * Java-born instances of an ES-derived proxy (clazz.newInstance(),
+         * framework inflation, etc.) are adopted into a real construct of the
+         * ES class so fields and the constructor body run. super() binds the
+         * existing Java object and does not allocate again.
+         */
+        static bool TryConstructESDerivedInstance(v8::Isolate* isolate, const std::string& proxyClassName, int javaObjectID, v8::Local<v8::Object>& out);
+
+        static bool TryConsumePendingESAdopt(v8::Isolate* isolate, int& javaObjectID);
+
         static v8::Local<v8::Object> GetImplementationObject(v8::Isolate* isolate, const v8::Local<v8::Object>& object);
 
         static void CreateTopLevelNamespaces(v8::Isolate* isolate, const v8::Local<v8::Object>& global);
@@ -327,6 +337,12 @@ class MetadataNode {
              * runtime's teardown walked every node to erase its entry.
              */
             robin_hood::unordered_map<MetadataNode*, v8::Persistent<v8::Function>*> CtorFunctions;
+
+            // Java object id being adopted by an in-flight ES construct
+            // (CreateJSInstanceNative → CallAsConstructor → super()).
+            // RegisterInstance consumes it so super() binds that id and does
+            // not NewObject again.
+            int PendingESAdoptObjectId = -1;
 
             ~MetadataNodeCache() {
                 delete MetadataKey;

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -59,6 +59,15 @@ class MetadataNode {
 
         static std::string GetTypeMetadataName(v8::Isolate* isolate, v8::Local<v8::Value>& value);
 
+        /*
+         * Resolves the Java class name a constructor function stands for, lazily registering a
+         * Java proxy class when the function is a plain ES `class X extends NativeType {}` that
+         * has not been registered yet. Returns an empty string when the function is not part of
+         * a native inheritance chain. Used when marshalling a constructor function to a Java
+         * `java.lang.Class` (or `java.lang.Object`) argument.
+         */
+        static std::string TryResolveClassCtorTypeName(v8::Isolate* isolate, const v8::Local<v8::Function>& func);
+
         static void onDisposeIsolate(v8::Isolate* isolate);
 
         static MetadataReader* getMetadataReader();
@@ -129,7 +138,23 @@ class MetadataNode {
 
         static TypeMetadata* GetTypeMetadata(v8::Isolate* isolate, const v8::Local<v8::Function>& value);
 
+        // Safe variant of GetTypeMetadata - returns nullptr when the function carries no type
+        // metadata (e.g. a plain ES class constructor) instead of crashing
+        static TypeMetadata* TryGetTypeMetadata(v8::Isolate* isolate, const v8::Local<v8::Function>& value);
+
         static void SetTypeMetadata(v8::Isolate* isolate, v8::Local<v8::Function> value, TypeMetadata* data);
+
+        /*
+         * Lazily registers a Java proxy class for a plain ES `class X extends NativeType {}`
+         * constructor function (no `.extend()` call, no downleveling). Walks the constructor
+         * prototype chain to the native base, collects overridden method names from every ES
+         * level's prototype and implemented interfaces from `static interfaces = [...]`, resolves
+         * the proxy class through the regular DexFactory pipeline and tags the constructor the
+         * same way `.extend()` tags its result (typemetadata + ExtendedCtorFuncCache entry).
+         * Returns nullptr when ctorFunc is not part of a native inheritance chain or the chain
+         * goes through a legacy `.extend()`-created class. Idempotent.
+         */
+        static TypeMetadata* EnsureExtendedESClass(v8::Isolate* isolate, v8::Local<v8::Function> ctorFunc);
 
         static std::string CreateFullClassName(const std::string& className, const std::string& extendNameAndLocation);
         static void MethodCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
@@ -231,12 +256,16 @@ class MetadataNode {
         };
 
         struct TypeMetadata {
-            TypeMetadata(const std::string& _name)
+            TypeMetadata(const std::string& _name, bool _isESDerived = false)
                 :
-                name(_name) {
+                name(_name), isESDerived(_isESDerived) {
             }
 
             std::string name;
+
+            // true when the class was registered lazily from a plain ES
+            // `class X extends NativeType {}` constructor (see EnsureExtendedESClass)
+            bool isESDerived;
         };
 
         struct CtorCacheData {

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -440,6 +440,12 @@ void Runtime::CreateJSInstanceNative(JNIEnv* _env, jobject obj,
 
   auto proxyClassName = m_objectManager->GetClassName(javaObject);
   DEBUG_WRITE("createJSInstanceNative class %s", proxyClassName.c_str());
+
+  if (MetadataNode::TryConstructESDerivedInstance(isolate, proxyClassName,
+                                                 javaObjectID, jsInstance)) {
+    return;
+  }
+
   jsInstance = MetadataNode::CreateExtendedJSWrapper(isolate, m_objectManager,
                                                      proxyClassName);
 

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -145,6 +145,10 @@ class Runtime {
 
         int GetId();
 
+        bool IsWorker() const {
+            return !m_isMainThread;
+        }
+
         v8::Local<v8::Context> GetContext();
 
         static v8::Platform* platform;

--- a/test-app/runtime/src/main/java/com/tns/DexFactory.java
+++ b/test-app/runtime/src/main/java/com/tns/DexFactory.java
@@ -119,6 +119,14 @@ public class DexFactory {
 
         // strip the `com.tns.gen` off the base extended class name
         String desiredDexClassName = this.getClassToProxyName(fullClassName);
+        // An explicit name like com.tns.gen.ESEagerNamedObject strips to a
+        // single identifier. ProxyGenerator then treats that as a suffix and
+        // emits java.lang.Object_ESEagerNamedObject while we try to load
+        // ESEagerNamedObject. Keep the qualified name so generation and load
+        // use the same class identity.
+        if (!desiredDexClassName.contains(".")) {
+            desiredDexClassName = fullClassName;
+        }
 
         // when interfaces are extended as classes, we still want to preserve
         // just the interface name without the extra file, line, column information


### PR DESCRIPTION
Parity with https://github.com/NativeScript/ios/pull/403

Makes plain ES2015+ classes that extend native types work directly on Android, without requiring `@NativeClass` or ES5 downleveling:

```ts
class JSClass extends android.view.View {
  toString() {
    return 'hello from ES class';
  }
}
```

## Lazy registration

Construction is not the only way a class first crosses into native code. All of the following now trigger lazy registration, before any instance has ever been created:

```ts
class JSClass extends java.lang.Object {}

someNativeMethod(JSClass);   // passed as a Class (or Object) argument
JSClass.class;               // .class before any construction
JSClass.class.newInstance(); // Java reflection constructs the proxy
JSClass.STATIC_FIELD;        // inherited static field
JSClass.someStaticMethod();  // inherited static method dispatch
```

## Instance identity

`new MyClass()` and Java-born construction (`Class.newInstance()`, view inflation, framework construction) now produce the same kind of JS instance: a real construct of the ES class. Public fields, private fields (`#a`), and the constructor body run on both paths.

The constructor → `super()` loop is broken with an isolate-local adopt slot (`PendingESAdoptObjectId`):

1. Java already created object **N1**.
2. `CreateJSInstanceNative(N1)` stashes N1's id and constructs `MyClass`.
3. `super()` binds `this` to N1 and does **not** `NewObject` again.

`super(args)` stays the create-path constructor picker. Adopt ignores those args so the Java constructor that already ran stays authoritative.

```ts
class MyClass extends com.tns.tests.DummyClass {
  #a = 1;
  constructor() {
    super('from-super');
  }
  someMethod() {
    return this.#a;
  }
}

new MyClass().someMethod();                    // 1, nameField === 'from-super'
MyClass.class.newInstance().someMethod();      // 1, nameField === 'dummy' (no-arg Java ctor)
```

Not solved here (not deal-breakers):

- Constructors that require JS-only arguments cannot be invented on the native-born path (`CreateJSInstanceNative` constructs with zero args).
- JS-only methods still need to be named as Java overrides (or listed for the DexFactory scan) to be callable via `invokevirtual`.
- A constructor that throws after `super()` leaves a partial JS↔Java link; a later wrap of the same id does not construct again.
- Worker isolates: `NativeClass` and ES class registration are a no-op. Only the main isolate mints native subclasses. Legacy `.extend()` is unchanged.

## NativeClass decorator API

`@NativeClass` is no longer a no-op. Optional `android` options map to the existing statics and can eagerly name the Java proxy class:

```ts
@NativeClass({
  android: {
    interfaces: [java.lang.Runnable],
    name: 'org.nativescript.example.CustomActivity',
  },
  // accepted and ignored on this runtime
  ios: {
    name: 'MyNeatIOSClass',
    protocols: [UIDelegateAnything],
  },
})
class MyClass extends android.view.View {}
```

- All properties are optional.
- `android.interfaces` → `static interfaces`
- `android.name` → `static nativeClassName` plus eager registration via `.class`
- This runtime implements `android` only; `ios` is accepted and ignored
- `@NativeClass` and `@NativeClass({ android: { … } })` are both valid. Passing the class directly (`NativeClass(MyClass)`) applies empty options.
- On worker isolates this is a no-op.

## Tests

See [`test-app/app/src/main/assets/app/tests/testNativeESClasses.js`](https://github.com/NativeScript/android/blob/feat/native-es-classes/test-app/app/src/main/assets/app/tests/testNativeESClasses.js), including:

- lazy `.class` / Class marshalling before construction
- Java virtual dispatch into ES overrides and `super`
- multi-level ES inheritance
- `When_java_instantiates_an_es_class_the_js_constructor_and_fields_should_run`
- `When_java_instantiates_an_es_class_private_fields_should_be_readable`
- `When_java_instantiates_an_es_class_super_args_should_not_construct_again`
- `When_an_es_class_constructor_throws_both_paths_should_surface_the_error`
- `When_the_NativeClass_decorator_is_applied_it_should_apply_android_options`
- `When_NativeClass_sets_an_android_name_the_proxy_should_register_immediately`
- `When_NativeClass_runs_on_a_worker_it_should_be_a_noop`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for extending native Java classes and interfaces with modern JavaScript ES classes.
  * Added lazy native proxy registration and improved class and constructor marshalling.
  * Added support for static members, private fields, `super` calls, constructor forwarding, and Java-created ES-class instances.
  * Added the global `NativeClass` decorator with interface and explicit naming options.

* **Bug Fixes**
  * Prevented duplicate superclass construction and improved constructor error propagation.
  * Preserved compatibility with legacy `.extend()` classes while rejecting unsupported ES-class usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->