### PR TITLE
fix: preserve jsparser CommonJS package boundary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,7 +269,12 @@ task copyFilesToProjectTemeplate {
             into "$DIST_FRAMEWORK_PATH/build-tools"
         }
         copy {
-            from "$BUILD_TOOLS_PATH/jsparser/build/js_parser.js"
+            from("$BUILD_TOOLS_PATH/jsparser/build") {
+                include "js_parser.js"
+            }
+            from("$BUILD_TOOLS_PATH/jsparser") {
+                include "package.json"
+            }
             into "$DIST_FRAMEWORK_PATH/build-tools/jsparser"
         }
         copy {
@@ -343,6 +348,20 @@ task copyProjectTemplate(type: Copy) {
     into "$DIST_FRAMEWORK_PATH"
 }
 
+task verifyJsParserPackage {
+    doLast {
+        def packageFile = new File("$DIST_FRAMEWORK_PATH/build-tools/jsparser/package.json")
+        if (!packageFile.exists()) {
+            throw new GradleException("The packaged JavaScript parser is missing its package.json boundary.")
+        }
+
+        def packageJson = new JsonSlurper().parseText(packageFile.text)
+        if (packageJson.type != "commonjs") {
+            throw new GradleException("The packaged JavaScript parser must run as CommonJS.")
+        }
+    }
+}
+
 task copyPackageJson(type: Copy) {
     from "$rootDir/package.json"
     into "$DIST_PATH"
@@ -394,7 +413,8 @@ if (generateRegularRuntimePackage) {
 }
 
 copyFilesToProjectTemeplate.dependsOn(buildJsParser)
-copyProjectTemplate.dependsOn(copyFilesToProjectTemeplate)
+verifyJsParserPackage.dependsOn(copyFilesToProjectTemeplate)
+copyProjectTemplate.dependsOn(verifyJsParserPackage)
 copyPackageJson.dependsOn(copyProjectTemplate)
 setPackageVersionInPackageJsonFile.dependsOn(copyPackageJson)
 copyReadme.dependsOn(setPackageVersionInPackageJsonFile)

--- a/test-app/build-tools/jsparser/package.json
+++ b/test-app/build-tools/jsparser/package.json
@@ -1,6 +1,7 @@
 {
   "name": "js-parser",
   "version": "1.0.0",
+  "type": "commonjs",
   "description": "javascript static analysis tool",
   "main": "js_parser.js",
   "scripts": {


### PR DESCRIPTION
## Problem

The Android runtime package copies `js_parser.js` into an app's generated platform directory without its package boundary. When the app (or an ancestor workspace) declares `"type": "module"`, Node treats that bundled CommonJS parser as ESM and the static binding generator fails with `ReferenceError: require is not defined in ES module scope`.

## Fix

- Declare the parser package as CommonJS explicitly.
- Copy its `package.json` alongside `js_parser.js` in the runtime package.
- Verify the packaged parser boundary during the Gradle packaging graph.

## Verification

- `./gradlew help --no-daemon --console=plain`
- Built, installed, and exercised an API 35 NativeScript Android app under a `type: module` package boundary. The static binding generator completed and the native app launched successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distribution packaging for the JavaScript parser by including its package metadata.
  * Added validation to ensure the packaged parser uses the correct CommonJS module format.
  * Updated build verification to catch packaging issues before project templates are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->