### PR TITLE
feat: V8 fast API calls through Node-API (unstable extension)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Runtime documentation
 
+- [V8 fast calls through Node-API](node-api-fast-calls.md) — the unstable
+  `node_api_ns_*` extension that lets an addon's hot leaf functions be called
+  from optimized JS with unboxed arguments: gating, the two-path contract,
+  types and flags, throwing from a fast callback, and where it actually pays.
 - [Node-API](node-api.md) — the standard `napi_*` C ABI for native addons:
   building against the prefab package, registering and requiring addons,
   threading and finalizer contracts, and the documented divergences from Node

--- a/docs/node-api-fast-calls.md
+++ b/docs/node-api-fast-calls.md
@@ -1,0 +1,235 @@
+# V8 fast calls through Node-API (unstable extension)
+
+A normal Node-API call crosses into native code through `FunctionCallbackInfo`,
+a handle scope and boxed arguments — on the order of 100 ns. V8's *fast API
+calls* let optimized JS call a plain C function with unboxed arguments in
+single-digit nanoseconds. This runtime exposes that through a Node-API-shaped
+extension, so an addon gets the speedup without writing V8 code.
+
+**This API is explicitly unstable.** Upstream Node-API
+[declined to expose fast calls](https://github.com/nodejs/node/issues/54731)
+(closed *not planned*): Node-API's contract says a callback may call `napi_*`,
+and a fast callback may not — there is no safe general subset, so any support
+is an embedder extension by definition. The descriptor vocabulary here is
+NativeScript's, it tracks a V8 API that has already broken its consumers more
+than once, and it may change or disappear in any release. It is gated
+accordingly (see below).
+
+## Gating
+
+Two separate mechanisms, because they answer different questions.
+
+**Compile time — "does this runtime offer the API?"** The header defines
+`NODE_API_NS_FAST_CALLS_VERSION`, and an addon that wants to stay portable
+compiles the fast path conditionally:
+
+```c
+#if defined(__has_include)
+#  if __has_include(<node_api_ns_fast.h>)
+#    define MY_ADDON_TRY_FAST_CALLS 1
+#  endif
+#endif
+
+#ifdef MY_ADDON_TRY_FAST_CALLS
+#  define NODE_API_NS_EXPERIMENTAL_FAST_CALLS
+#  include <node_api_ns_fast.h>
+#endif
+```
+
+**Compile time — "do you accept an unstable API?"** `node_api_ns_fast.h` is a
+hard `#error` unless the addon defines `NODE_API_NS_EXPERIMENTAL_FAST_CALLS`
+first. Nobody gets here by accident.
+
+**Run time — "can a fast call actually fire?"**
+`node_api_ns_fast_calls_available()` reports false on a jitless embed (the iOS
+runtime, or an app that passes `--jitless`), where the slow path serves every
+call. You rarely need it: registration succeeds either way and the behaviour is
+identical, so it is for diagnostics and benchmarks rather than control flow.
+
+## A complete addon
+
+```c
+#define NODE_API_NS_EXPERIMENTAL_FAST_CALLS
+#include <node_api_ns_fast.h>
+
+// The fast path: a plain C function. Receiver first, then unboxed arguments.
+static int32_t FastAdd(ns_fast_receiver receiver, int32_t a, int32_t b) {
+  (void)receiver;
+  return a + b;
+}
+
+// The slow path: an ordinary napi_callback that MUST do the same thing.
+static napi_value SlowAdd(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[2];
+  napi_get_cb_info(env, info, &argc, args, NULL, NULL);
+
+  int32_t a = 0, b = 0;
+  napi_get_value_int32(env, args[0], &a);
+  napi_get_value_int32(env, args[1], &b);
+
+  napi_value result = NULL;
+  napi_create_int32(env, a + b, &result);
+  return result;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  static const ns_fast_param params[] = {
+      {ns_fast_int32, ns_fast_flag_none},
+      {ns_fast_int32, ns_fast_flag_none},
+  };
+
+  ns_fast_descriptor descriptor = {0};
+  descriptor.slow_cb = SlowAdd;
+  descriptor.fast_fn = (const void*)FastAdd;
+  descriptor.return_type.type = ns_fast_int32;
+  descriptor.argc = 2;
+  descriptor.arg_types = params;
+
+  napi_value add = NULL;
+  if (node_api_ns_create_fast_function(env, "add", NAPI_AUTO_LENGTH,
+                                       &descriptor, &add) != napi_ok) {
+    return NULL;
+  }
+  napi_set_named_property(env, exports, "add", add);
+  return exports;
+}
+```
+
+```js
+const addon = require("myaddon");
+addon.add(1, 2); // 3 — via either path, indistinguishably
+```
+
+`test-app/runtime/src/main/cpp/napi/tests/NapiFastCallsModule.cpp` is a working
+addon covering every supported shape, and
+`test-app/app/src/main/assets/app/tests/NapiFastCallsTests.js` is its spec.
+
+## The contract
+
+**Both paths must be semantically identical.** V8 chooses between them freely
+and without notice — unoptimized tiers, deoptimization, an argument-count
+mismatch, a two-byte string where a one-byte one was expected, or a jitless
+embed all run the slow path. Any observable difference is a bug that surfaces
+as nondeterminism.
+
+**Inside the fast function:** no `napi_*` calls, no JS-heap allocation, no JS
+execution, no blocking, no exceptions except through the throw shims below.
+This is a V8-level requirement, not a Node-API one — violating it is undefined
+behaviour, not an error status.
+
+**The receiver is always the first parameter**, whether or not you use it. It
+is deliberately opaque (`ns_fast_receiver`): it is not a `napi_value` and no
+`napi_*` call may be made on it. It is in the ABI from day one because V8
+introduced it once already and broke every embedder that had not planned for
+it ([denoland/deno#15139](https://github.com/denoland/deno/issues/15139)).
+
+**`descriptor.data` reaches only the slow path.** The fast function has no env
+to read callback data through; keep fast-path state in statics, or pass it
+explicitly as an `ns_fast_pointer` argument.
+
+## Types
+
+| `ns_fast_type` | C type in the fast function | Notes |
+| --- | --- | --- |
+| `ns_fast_void` | `void` | Return only. |
+| `ns_fast_bool` | `bool` | |
+| `ns_fast_uint8` | `uint8_t` | |
+| `ns_fast_int32` / `ns_fast_uint32` | `int32_t` / `uint32_t` | |
+| `ns_fast_int64` / `ns_fast_uint64` | `int64_t` / `uint64_t` | Number by default, BigInt with `descriptor.int64_as_bigint`. |
+| `ns_fast_float32` / `ns_fast_float64` | `float` / `double` | |
+| `ns_fast_pointer` | `void*` | Unvalidated by V8; the addon owns every guarantee. |
+| `ns_fast_value` | opaque handle | Passed through untouched. |
+| `ns_fast_one_byte_string` | `const ns_fast_one_byte_string_view*` | Zero-copy Latin-1 view, valid for the call only. Two-byte strings simply take the slow path. |
+
+Returns are limited to `void`, `bool`, the integral types and the float types —
+a handle or string return would require allocation, which the fast path
+forbids.
+
+Per-parameter flags apply WebIDL conversions *before* the call:
+`ns_fast_flag_clamp` and `ns_fast_flag_enforce_range` (integral parameters,
+mutually exclusive), `ns_fast_flag_is_restricted` (float parameters, rejects
+NaN/Infinity), `ns_fast_flag_allow_shared` (handle parameters that may be a
+shared ArrayBuffer). A flag on a type that cannot carry it is rejected with
+`napi_invalid_arg` at registration — V8 would otherwise assert at some later,
+much less obvious point.
+
+## Throwing
+
+Since V8 12.6 a fast callback may throw directly; the old `fallback` escape
+hatch is gone (the header's own prose still describes it — doc rot, upstream
+included). Set `descriptor.fallible`, take a trailing `ns_fast_options`
+parameter, and throw through the shims:
+
+```c
+static double FastDivide(ns_fast_receiver receiver, double a, double b,
+                         ns_fast_options options) {
+  (void)receiver;
+  if (b == 0) {
+    node_api_ns_fast_throw_range_error(options, "ERR_DIV_ZERO",
+                                       "division by zero");
+    return 0;  // ignored once an exception is pending
+  }
+  return a / b;
+}
+```
+
+The shims (`node_api_ns_fast_throw_error`, `_type_error`, `_range_error`) open
+the handle scope and touch V8 for you, so the addon never sees an isolate.
+V8 checks the pending-exception slot when the C call returns and unwinds
+normally; **throwing does not deoptimize the caller**, and nothing re-executes,
+so the old "be idempotent before bailing out" rule no longer applies.
+
+## Where it pays
+
+Leaf, allocation-free, side-effect-free functions with scalar or raw-buffer
+arguments in a hot loop: vector and geometry math, hashing, codecs, byte
+crunching. Deno reports roughly 10× on call overhead for exactly this shape.
+
+Where it does not pay: anything that needs handles, the env, string
+materialization beyond a one-byte view, or JNI marshalling. Node removed the
+fast path from `InternalModuleStat` for precisely this reason — it needed a
+handle scope anyway, which made the "fast" path slower than the plain binding.
+And keep perspective: for most real plugins async and marshalling costs
+dominate, and sync call overhead only matters in tight loops. Measure first.
+
+## Verifying which path ran
+
+There is no API for it, by design — the paths are supposed to be
+indistinguishable. For development, do what Node's own tests do: keep a counter
+in each implementation and call the function from a small monomorphic function
+a few hundred thousand times, which is what makes TurboFan optimize the caller
+and emit the fast call. `NapiFastCallsTests.js` does this.
+
+## Implementation notes and deviations
+
+For whoever maintains this, and for the iOS runtime mirroring the surface (see
+`NAPI_FAST_CALLS.md` there — this implementation deviates from those notes in a
+few places):
+
+- **The registration API is a descriptor struct**, not the flat parameter list
+  the design notes sketched, so an explicitly unstable API can gain fields
+  (`fallible`, `int64_as_bigint` already) without breaking every call site.
+- **The slow path costs one extra V8 call.** The vendored
+  `js_native_api_v8.cc` builds `napi_callback_info` out of classes in an
+  anonymous namespace, so no other translation unit can invoke a
+  `napi_callback` directly. The forwarding callback therefore calls a real
+  function made by `napi_create_function`, which keeps napi's argument,
+  receiver and exception semantics exactly — at the cost of one extra call
+  whenever the fast path is not taken. It is the warmup path for any function
+  hot enough to deserve a fast call; if that ever matters, the fix is upstream
+  (exporting a way to invoke a `napi_callback`), not a local hack.
+- **Registering with `fast_fn == NULL` returns a plain Node-API function** with
+  no wrapper and no overhead. That is the portable-addon path, and it is why a
+  single addon source can target every runtime.
+- **Fast functions cannot be used as constructors**
+  (`ConstructorBehavior::kThrow`): `new` would have to run the slow path with a
+  `new.target` the forwarding cannot reproduce.
+- **`CFunctionInfo` keeps its argument array by pointer**, and V8 keeps the
+  `CFunctionInfo` by pointer for as long as the template lives, so both are
+  interned per distinct signature and intentionally never freed — the same
+  shape Node gets for free by declaring its `CFunctionInfo`s as file-scope
+  statics.
+- Not yet supported, in rough priority order: overloads (V8 resolves them by
+  argument count), typed-array parameters as anything richer than an opaque
+  handle, and exposing the `FastApiCallbackOptions` data pointer.

--- a/docs/node-api-fast-calls.md
+++ b/docs/node-api-fast-calls.md
@@ -184,7 +184,23 @@ so the old "be idempotent before bailing out" rule no longer applies.
 
 Leaf, allocation-free, side-effect-free functions with scalar or raw-buffer
 arguments in a hot loop: vector and geometry math, hashing, codecs, byte
-crunching. Deno reports roughly 10× on call overhead for exactly this shape.
+crunching.
+
+Measured on this runtime with a two-`int32` addition — the cheapest possible
+body, so essentially pure call overhead — 2M calls from an optimized caller,
+on an **arm64 emulator** (absolute numbers are inflated by virtualization; the
+ratio is the meaningful part):
+
+| | ns/call |
+| --- | --- |
+| Fast path (99.4% of calls; the rest ran before the caller tiered up) | **24** |
+| Plain Node-API function | **860** |
+
+So roughly **35× on call overhead** for a function that does nothing else,
+which is the ceiling rather than a typical result: the moment the body does
+real work, or the arguments need anything the fast path forbids, the ratio
+collapses toward 1. The slow path's extra forwarding call (see below) is not
+separately measured.
 
 Where it does not pay: anything that needs handles, the env, string
 materialization beyond a one-byte view, or JNI marshalling. Node removed the

--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -199,6 +199,14 @@ Everything in `js_native_api.h` behaves exactly as upstream: it is upstream, com
 | `napi_fatal_exception` | Reports through the runtime's error pipeline (`error` event, uncaught-error hooks, `uncaughtErrorPolicy`) and returns; does not abort by itself | `napi_fatal_error` still aborts the process, as upstream. |
 | `napi_async_init`, `napi_open_callback_scope` | Accepted; the resource and name arguments are inert | There is no `async_hooks`, so there is nothing to report the async context to. `napi_make_callback` itself works, and rejects a call from the wrong thread with `napi_generic_failure`. |
 
+## Going faster
+
+For hot leaf functions — scalar math, hashing, byte crunching — this runtime
+also exposes V8's fast API calls behind a Node-API-shaped extension, so
+optimized JS reaches the addon with unboxed arguments and no handle scope. It
+is an explicitly unstable vendor extension with its own opt-in gate; see
+[V8 fast calls through Node-API](node-api-fast-calls.md).
+
 ## Not supported
 
 `node_api.h` is the entire native surface. The Node **runtime** is not here: no `process`, no `fs`, no `require()` of Node core modules from native, no libuv handles, no worker_threads C API. An addon that only uses Node-API works; an addon that reaches into `node.h`, `v8.h` or `uv.h` does not.

--- a/test-app/app/src/main/assets/app/mainpage.js
+++ b/test-app/app/src/main/assets/app/mainpage.js
@@ -90,6 +90,7 @@ require('./tests/testNsUtil');
 // Node-API addon surface
 require('./tests/NapiTests');
 require('./tests/NapiCoverageTests');
+require('./tests/NapiFastCallsTests');
 require("./tests/testConcurrentAccess");
 
 require("./tests/testESModules.mjs");

--- a/test-app/app/src/main/assets/app/tests/NapiFastCallsTests.js
+++ b/test-app/app/src/main/assets/app/tests/NapiFastCallsTests.js
@@ -1,0 +1,194 @@
+// The addon is compiled into libNativeScript.so for local Debug builds only;
+// on any other runtime flavor the suite skips rather than fails.
+var napiFastModuleAvailable = true;
+try {
+    require("napifastcallsmodule");
+} catch (e) {
+    napiFastModuleAvailable = false;
+}
+
+(napiFastModuleAvailable ? describe : xdescribe)("Node-API fast calls", function () {
+    var napi = require("napifastcallsmodule");
+
+    beforeEach(function () {
+        napi.resetCounts();
+    });
+
+    // V8 picks the path; everything below that is not explicitly about which
+    // path ran must hold either way.
+    function hammer(fn, iterations) {
+        var last;
+        for (var i = 0; i < iterations; i++) {
+            last = fn(i);
+        }
+        return last;
+    }
+
+    it("reports fast calls as available on this runtime", function () {
+        // Android runs V8 with a JIT unless the app asks for --jitless.
+        expect(napi.fastCallsAvailable()).toBe(true);
+    });
+
+    it("exports both-path functions", function () {
+        expect(typeof napi.addInt32).toBe("function");
+        expect(typeof napi.scale).toBe("function");
+        expect(typeof napi.divide).toBe("function");
+        expect(typeof napi.byteLength).toBe("function");
+        expect(typeof napi.clamped).toBe("function");
+        expect(typeof napi.slowOnlyAddInt32).toBe("function");
+    });
+
+    describe("semantics", function () {
+        it("adds int32s", function () {
+            expect(napi.addInt32(1, 2)).toBe(3);
+            expect(napi.addInt32(-5, 5)).toBe(0);
+            expect(napi.addInt32(2147483647, 0)).toBe(2147483647);
+        });
+
+        it("scales doubles", function () {
+            expect(napi.scale(2)).toBe(5);
+            expect(napi.scale(0.5)).toBe(1.25);
+            expect(napi.scale(-1)).toBe(-2.5);
+        });
+
+        it("measures one-byte strings", function () {
+            expect(napi.byteLength("")).toBe(0);
+            expect(napi.byteLength("hello")).toBe(5);
+        });
+
+        it("agrees on two-byte strings, which never take the fast path", function () {
+            // V8 declines the fast path for a two-byte string, so this is the
+            // slow path's answer and it has to match the fast one's contract:
+            // the number of UTF-8 bytes.
+            expect(napi.byteLength("snowman ☃")).toBe(11);
+        });
+
+        it("applies the clamp flag to a uint8 parameter", function () {
+            expect(napi.clamped(12)).toBe(12);
+            expect(napi.clamped(-40)).toBe(0);
+            expect(napi.clamped(4000)).toBe(255);
+        });
+
+        it("behaves like a plain function when registered slow-only", function () {
+            expect(napi.slowOnlyAddInt32(20, 22)).toBe(42);
+            hammer(function (i) { return napi.slowOnlyAddInt32(i, 1); }, 2000);
+            // No fast function was registered, so no call can ever be fast.
+            expect(napi.fastCallCount()).toBe(0);
+            expect(napi.slowCallCount()).toBeGreaterThan(0);
+        });
+
+        it("cannot be used as a constructor", function () {
+            expect(function () { return new napi.addInt32(1, 2); }).toThrow();
+        });
+    });
+
+    describe("path selection", function () {
+        it("runs the slow path for a cold call", function () {
+            expect(napi.addInt32(1, 2)).toBe(3);
+            expect(napi.slowCallCount()).toBe(1);
+            expect(napi.fastCallCount()).toBe(0);
+        });
+
+        it("runs the fast path once the caller tiers up", function () {
+            // A trivial monomorphic caller is exactly what TurboFan optimizes
+            // first; the fast call is emitted only from optimized code.
+            var sum = 0;
+            function hot(i) {
+                return napi.addInt32(i, 1);
+            }
+            for (var i = 0; i < 300000; i++) {
+                sum += hot(i);
+            }
+
+            expect(sum).toBeGreaterThan(0);
+            expect(napi.fastCallCount()).toBeGreaterThan(0);
+            // Every call is accounted for on exactly one of the two paths.
+            expect(napi.fastCallCount() + napi.slowCallCount()).toBe(300000);
+        });
+
+        it("produces identical results on both paths", function () {
+            var cold = napi.scale(3);
+
+            function hot(i) {
+                return napi.scale(3);
+            }
+            for (var i = 0; i < 300000; i++) {
+                hot(i);
+            }
+
+            expect(napi.fastCallCount()).toBeGreaterThan(0);
+            expect(hot(0)).toBe(cold);
+        });
+    });
+
+    describe("fallible fast functions", function () {
+        it("divides on both paths", function () {
+            expect(napi.divide(10, 4)).toBe(2.5);
+
+            function hot(i) {
+                return napi.divide(10, 4);
+            }
+            for (var i = 0; i < 300000; i++) {
+                hot(i);
+            }
+            expect(napi.fastCallCount()).toBeGreaterThan(0);
+            expect(napi.divide(10, 4)).toBe(2.5);
+        });
+
+        it("throws a catchable RangeError from the slow path", function () {
+            var error;
+            try {
+                napi.divide(1, 0);
+            } catch (e) {
+                error = e;
+            }
+
+            expect(error instanceof RangeError).toBe(true);
+            expect(error.message).toBe("division by zero");
+            expect(error.code).toBe("ERR_DIV_ZERO");
+            expect(napi.slowCallCount()).toBe(1);
+        });
+
+        it("throws from inside the fast path, through the shim", function () {
+            // Which path serves any individual call is V8's choice, so the
+            // throwing calls are mixed into the warm-up loop rather than made
+            // once at the end: the addon counts the throws it raises from the
+            // fast function itself, which is the only way to tell that the
+            // shim ran under optimized code at all.
+            function hot(divisor) {
+                return napi.divide(1, divisor);
+            }
+
+            var caught = 0;
+            var results = 0;
+            for (var i = 0; i < 300000; i++) {
+                try {
+                    results += hot(i % 1000 === 0 ? 0 : 2);
+                } catch (e) {
+                    caught++;
+                    if (!(e instanceof RangeError) ||
+                        e.message !== "division by zero" ||
+                        e.code !== "ERR_DIV_ZERO") {
+                        throw e;
+                    }
+                }
+            }
+
+            expect(caught).toBe(300);
+            expect(results).toBeGreaterThan(0);
+            expect(napi.fastCallCount()).toBeGreaterThan(0);
+            // The throw shim opened a handle scope and threw while V8 was in
+            // optimized code, and the caller kept running afterwards.
+            expect(napi.fastThrowCount()).toBeGreaterThan(0);
+        });
+
+        it("keeps working after a throw", function () {
+            try {
+                napi.divide(1, 0);
+            } catch (e) {
+                // ignored
+            }
+            expect(napi.divide(9, 3)).toBe(3);
+        });
+    });
+});

--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -142,6 +142,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT OPTIMIZED_BUILD AND NOT OPTIMIZED_
 
         src/main/cpp/napi/tests/NapiTestModule.cpp
         src/main/cpp/napi/tests/NapiCoverageModule.cpp
+        src/main/cpp/napi/tests/NapiFastCallsModule.cpp
     )
 else ()
     set(NAPI_TEST_SOURCES)
@@ -231,6 +232,7 @@ add_library(
         # (env lifecycle, module registry, async work, threadsafe functions)
         src/main/cpp/napi/vendor/js_native_api_v8.cc
         src/main/cpp/napi/NapiEnv.cpp
+        src/main/cpp/napi/NapiFastCalls.cpp
         src/main/cpp/napi/NapiRuntime.cpp
         src/main/cpp/napi/NapiThreadSafeFunction.cpp
         src/main/cpp/napi/NodeApiEmbed.cpp

--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -197,6 +197,9 @@ tasks.register("stageNapiPrefab", Sync) {
     from("src/main/cpp/napi/NapiRuntime.h") {
         into "prefab/modules/NativeScript/include"
     }
+    from("src/main/cpp/napi/node_api_ns_fast.h") {
+        into "prefab/modules/NativeScript/include"
+    }
     includeEmptyDirs = false
 }
 afterEvaluate {

--- a/test-app/runtime/src/main/cpp/napi/NapiFastCalls.cpp
+++ b/test-app/runtime/src/main/cpp/napi/NapiFastCalls.cpp
@@ -1,0 +1,398 @@
+// V8 fast API calls behind a Node-API-shaped surface. See
+// docs/node-api-fast-calls.md for the contract and node_api_ns_fast.h for the
+// plugin-facing API.
+//
+// The whole point of the indirection is that no V8 type reaches the addon: the
+// descriptor vocabulary is ours, and V8's CTypeInfo/CFunction churn — which has
+// already broken embedders twice (the receiver parameter, the `fallback`
+// field) — stays behind this file.
+
+#define NAPI_EXPERIMENTAL
+#define NODE_API_EXPERIMENTAL_NO_WARNING
+#define NODE_API_NS_EXPERIMENTAL_FAST_CALLS
+
+#include "node_api_ns_fast.h"
+
+#include <map>
+#include <mutex>
+#include <vector>
+
+#include "js_native_api_v8.h"
+#include "v8-fast-api-calls.h"
+#include "v8-template.h"
+
+#include "Constants.h"
+
+namespace {
+
+using v8::CFunction;
+using v8::CFunctionInfo;
+using v8::CTypeInfo;
+
+//=== Descriptor -> V8 type mapping ========================================
+
+bool MapType(ns_fast_type type, CTypeInfo::Type* result) {
+  switch (type) {
+    case ns_fast_void: *result = CTypeInfo::Type::kVoid; return true;
+    case ns_fast_bool: *result = CTypeInfo::Type::kBool; return true;
+    case ns_fast_uint8: *result = CTypeInfo::Type::kUint8; return true;
+    case ns_fast_int32: *result = CTypeInfo::Type::kInt32; return true;
+    case ns_fast_uint32: *result = CTypeInfo::Type::kUint32; return true;
+    case ns_fast_int64: *result = CTypeInfo::Type::kInt64; return true;
+    case ns_fast_uint64: *result = CTypeInfo::Type::kUint64; return true;
+    case ns_fast_float32: *result = CTypeInfo::Type::kFloat32; return true;
+    case ns_fast_float64: *result = CTypeInfo::Type::kFloat64; return true;
+    case ns_fast_pointer: *result = CTypeInfo::Type::kPointer; return true;
+    case ns_fast_value: *result = CTypeInfo::Type::kV8Value; return true;
+    case ns_fast_one_byte_string:
+      *result = CTypeInfo::Type::kSeqOneByteString;
+      return true;
+    default: return false;
+  }
+}
+
+bool IsIntegral(ns_fast_type type) {
+  return type == ns_fast_uint8 || type == ns_fast_int32 ||
+         type == ns_fast_uint32 || type == ns_fast_int64 ||
+         type == ns_fast_uint64;
+}
+
+// V8 asserts on a flag its type cannot carry, so a bad descriptor has to be
+// rejected as napi_invalid_arg here rather than crashing inside V8 later.
+bool MapFlags(const ns_fast_param& param, CTypeInfo::Flags* result) {
+  uint32_t known = ns_fast_flag_clamp | ns_fast_flag_enforce_range |
+                   ns_fast_flag_is_restricted | ns_fast_flag_allow_shared;
+  if ((param.flags & ~known) != 0) {
+    return false;
+  }
+
+  uint8_t flags = static_cast<uint8_t>(CTypeInfo::Flags::kNone);
+
+  if ((param.flags & (ns_fast_flag_clamp | ns_fast_flag_enforce_range)) != 0) {
+    if (!IsIntegral(param.type)) {
+      return false;
+    }
+    // Clamping and range-enforcing are mutually exclusive conversions.
+    if ((param.flags & ns_fast_flag_clamp) != 0 &&
+        (param.flags & ns_fast_flag_enforce_range) != 0) {
+      return false;
+    }
+    if ((param.flags & ns_fast_flag_clamp) != 0) {
+      flags |= static_cast<uint8_t>(CTypeInfo::Flags::kClampBit);
+    } else {
+      flags |= static_cast<uint8_t>(CTypeInfo::Flags::kEnforceRangeBit);
+    }
+  }
+
+  if ((param.flags & ns_fast_flag_is_restricted) != 0) {
+    if (param.type != ns_fast_float32 && param.type != ns_fast_float64) {
+      return false;
+    }
+    flags |= static_cast<uint8_t>(CTypeInfo::Flags::kIsRestrictedBit);
+  }
+
+  if ((param.flags & ns_fast_flag_allow_shared) != 0) {
+    // Only a handle parameter can be an ArrayBuffer/TypedArray.
+    if (param.type != ns_fast_value) {
+      return false;
+    }
+    flags |= static_cast<uint8_t>(CTypeInfo::Flags::kAllowSharedBit);
+  }
+
+  *result = static_cast<CTypeInfo::Flags>(flags);
+  return true;
+}
+
+// Returns are limited to what V8 can hand back unboxed. A handle or a string
+// return would need allocation, which the fast path forbids.
+bool IsSupportedReturnType(ns_fast_type type) {
+  return type == ns_fast_void || type == ns_fast_bool || IsIntegral(type) ||
+         type == ns_fast_float32 || type == ns_fast_float64;
+}
+
+//=== Per-signature immortal type info =====================================
+//
+// CFunctionInfo keeps the argument array BY POINTER, and V8 keeps the
+// CFunctionInfo by pointer for as long as the function template lives. Both
+// therefore have to outlive every registration, so they are interned once per
+// distinct signature and never freed — the same shape Node gets for free by
+// declaring its CFunctionInfos as file-scope statics.
+
+struct SignatureCache {
+  std::mutex mutex;
+  std::map<std::vector<uint32_t>, const CFunctionInfo*> entries;
+};
+
+SignatureCache& Signatures() {
+  static SignatureCache* cache = new SignatureCache();
+  return *cache;
+}
+
+const CFunctionInfo* InternSignature(
+    const CTypeInfo& return_info,
+    const std::vector<CTypeInfo>& args,
+    CFunctionInfo::Int64Representation repr) {
+  std::vector<uint32_t> key;
+  key.reserve(args.size() + 2);
+  key.push_back(static_cast<uint32_t>(repr));
+  key.push_back(return_info.GetId());
+  for (const CTypeInfo& arg : args) {
+    key.push_back(arg.GetId());
+  }
+
+  SignatureCache& cache = Signatures();
+  std::lock_guard<std::mutex> lock(cache.mutex);
+
+  auto it = cache.entries.find(key);
+  if (it != cache.entries.end()) {
+    return it->second;
+  }
+
+  // Intentionally leaked; see the note above.
+  auto* stored_args = new std::vector<CTypeInfo>(args);
+  auto* info = new CFunctionInfo(return_info,
+                                 static_cast<unsigned int>(stored_args->size()),
+                                 stored_args->data(), repr);
+  cache.entries.emplace(std::move(key), info);
+  return info;
+}
+
+//=== The slow path ========================================================
+//
+// V8 requires a slow callback that is semantically identical to the fast one,
+// and it is what actually runs until the caller tiers up. The vendored
+// js_native_api_v8.cc builds napi_callback_info out of classes in an anonymous
+// namespace, so there is no way to invoke a napi_callback from another
+// translation unit: the slow path forwards to a real function made by
+// napi_create_function, which costs one extra V8 call and keeps napi's own
+// argument/receiver/exception semantics exactly.
+
+struct FastFunctionState {
+  napi_env env;
+  v8::Global<v8::Function> slow;
+};
+
+void DeleteFastFunctionState(void* arg) {
+  auto* state = static_cast<FastFunctionState*>(arg);
+  state->slow.Reset();
+  delete state;
+}
+
+void ForwardToSlow(const v8::FunctionCallbackInfo<v8::Value>& info) {
+  v8::Isolate* isolate = info.GetIsolate();
+  auto* state = static_cast<FastFunctionState*>(
+      info.Data().As<v8::External>()->Value(v8::kExternalPointerTypeTagDefault));
+
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Function> slow = state->slow.Get(isolate);
+
+  int argc = info.Length();
+  v8::LocalVector<v8::Value> args(isolate);
+  args.reserve(argc);
+  for (int i = 0; i < argc; i++) {
+    args.push_back(info[i]);
+  }
+
+  v8::Local<v8::Value> result;
+  if (!slow->Call(context, info.This(), argc, args.data()).ToLocal(&result)) {
+    // The exception is already pending; V8 unwinds from here.
+    return;
+  }
+
+  info.GetReturnValue().Set(result);
+}
+
+//=== Throwing from a fast callback ========================================
+//
+// Legal since V8 12.6: the callback may throw directly as long as a
+// HandleScope is opened first, and V8 checks the pending-exception slot when
+// the C call returns. The addon never sees the isolate, so the scope and the
+// throw happen here.
+
+enum class FastErrorKind { kError, kTypeError, kRangeError };
+
+void ThrowFromFastCallback(ns_fast_options options,
+                           const char* code,
+                           const char* message,
+                           FastErrorKind kind) {
+  auto* v8_options = reinterpret_cast<v8::FastApiCallbackOptions*>(options);
+  if (v8_options == nullptr || v8_options->isolate == nullptr) {
+    return;
+  }
+
+  v8::Isolate* isolate = v8_options->isolate;
+  v8::HandleScope scope(isolate);
+
+  v8::Local<v8::String> message_string;
+  if (!v8::String::NewFromUtf8(isolate, message != nullptr ? message : "")
+           .ToLocal(&message_string)) {
+    return;
+  }
+
+  v8::Local<v8::Value> error;
+  switch (kind) {
+    case FastErrorKind::kTypeError:
+      error = v8::Exception::TypeError(message_string);
+      break;
+    case FastErrorKind::kRangeError:
+      error = v8::Exception::RangeError(message_string);
+      break;
+    default:
+      error = v8::Exception::Error(message_string);
+      break;
+  }
+
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  if (code != nullptr && !context.IsEmpty() && error->IsObject()) {
+    v8::Local<v8::String> code_key;
+    v8::Local<v8::String> code_value;
+    if (v8::String::NewFromUtf8(isolate, "code").ToLocal(&code_key) &&
+        v8::String::NewFromUtf8(isolate, code).ToLocal(&code_value)) {
+      error.As<v8::Object>()->Set(context, code_key, code_value).FromMaybe(false);
+    }
+  }
+
+  isolate->ThrowException(error);
+}
+
+}  // namespace
+
+//=== Entry points =========================================================
+
+napi_status NAPI_CDECL
+node_api_ns_create_fast_function(napi_env env,
+                                 const char* utf8name,
+                                 size_t length,
+                                 const ns_fast_descriptor* descriptor,
+                                 napi_value* result) {
+  NAPI_PREAMBLE(env);
+  CHECK_ARG(env, descriptor);
+  CHECK_ARG(env, result);
+  CHECK_ARG(env, descriptor->slow_cb);
+  if (descriptor->argc > 0) {
+    CHECK_ARG(env, descriptor->arg_types);
+  }
+
+  // The slow function is the real Node-API function, and on its own it is a
+  // complete, correct registration.
+  napi_value slow_value = nullptr;
+  STATUS_CALL(napi_create_function(env, utf8name, length, descriptor->slow_cb,
+                                   descriptor->data, &slow_value));
+
+  // No fast function (a portable addon on a runtime where fast calls cannot
+  // fire), so there is nothing to attach and nothing to pay for.
+  if (descriptor->fast_fn == nullptr) {
+    *result = slow_value;
+    return GET_RETURN_STATUS(env);
+  }
+
+  if (!IsSupportedReturnType(descriptor->return_type.type) ||
+      descriptor->return_type.flags != ns_fast_flag_none) {
+    return napi_set_last_error(env, napi_invalid_arg);
+  }
+
+  CTypeInfo::Type return_v8_type;
+  if (!MapType(descriptor->return_type.type, &return_v8_type)) {
+    return napi_set_last_error(env, napi_invalid_arg);
+  }
+  CTypeInfo return_info(return_v8_type);
+
+  std::vector<CTypeInfo> args;
+  args.reserve(descriptor->argc + 2);
+  // The receiver is always the first parameter of the C function.
+  args.emplace_back(CTypeInfo::Type::kV8Value);
+
+  for (size_t i = 0; i < descriptor->argc; i++) {
+    const ns_fast_param& param = descriptor->arg_types[i];
+    CTypeInfo::Type arg_type;
+    CTypeInfo::Flags arg_flags;
+    if (!MapType(param.type, &arg_type) || param.type == ns_fast_void ||
+        !MapFlags(param, &arg_flags)) {
+      return napi_set_last_error(env, napi_invalid_arg);
+    }
+    args.emplace_back(arg_type, arg_flags);
+  }
+
+  if (descriptor->fallible) {
+    args.emplace_back(CTypeInfo::kCallbackOptionsType);
+  }
+
+  const CFunctionInfo* signature = InternSignature(
+      return_info, args,
+      descriptor->int64_as_bigint ? CFunctionInfo::Int64Representation::kBigInt
+                                  : CFunctionInfo::Int64Representation::kNumber);
+  CFunction fast_function(descriptor->fast_fn, signature);
+
+  auto* state = new FastFunctionState();
+  state->env = env;
+  state->slow.Reset(
+      env->isolate,
+      v8impl::V8LocalValueFromJsValue(slow_value).As<v8::Function>());
+
+  v8::Local<v8::External> data =
+      v8::External::New(env->isolate, state, v8::kExternalPointerTypeTagDefault);
+
+  CFunction overloads[] = {fast_function};
+  v8::Local<v8::FunctionTemplate> function_template =
+      v8::FunctionTemplate::NewWithCFunctionOverloads(
+          env->isolate, ForwardToSlow, data, v8::Local<v8::Signature>(),
+          static_cast<int>(descriptor->argc),
+          // A fast function is a plain function: `new` on it would have to run
+          // the slow path with a new.target the forwarding cannot reproduce.
+          v8::ConstructorBehavior::kThrow, v8::SideEffectType::kHasSideEffect,
+          {overloads, 1});
+
+  v8::Local<v8::Function> function;
+  if (!function_template->GetFunction(env->context()).ToLocal(&function)) {
+    DeleteFastFunctionState(state);
+    return napi_set_last_error(env, napi_generic_failure);
+  }
+
+  if (utf8name != nullptr) {
+    v8::Local<v8::String> name;
+    if (v8::String::NewFromUtf8(
+            env->isolate, utf8name, v8::NewStringType::kInternalized,
+            length == NAPI_AUTO_LENGTH ? -1 : static_cast<int>(length))
+            .ToLocal(&name)) {
+      function->SetName(name);
+    }
+  }
+
+  // Registered only now that nothing else can fail: the state has to outlive
+  // the function, and the env outlives both.
+  napi_add_env_cleanup_hook(env, DeleteFastFunctionState, state);
+
+  *result = v8impl::JsValueFromV8LocalValue(function);
+  return GET_RETURN_STATUS(env);
+}
+
+napi_status NAPI_CDECL node_api_ns_fast_calls_available(napi_env env,
+                                                        bool* result) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, result);
+
+  // V8 only emits fast calls from optimized code, and --jitless disables every
+  // optimizing tier. The app's startup flags are the only way this runtime can
+  // end up jitless, so they are what gets consulted.
+  *result = Constants::V8_STARTUP_FLAGS.find("jitless") == std::string::npos;
+
+  return napi_clear_last_error(env);
+}
+
+void NAPI_CDECL node_api_ns_fast_throw_error(ns_fast_options options,
+                                             const char* code,
+                                             const char* message) {
+  ThrowFromFastCallback(options, code, message, FastErrorKind::kError);
+}
+
+void NAPI_CDECL node_api_ns_fast_throw_type_error(ns_fast_options options,
+                                                  const char* code,
+                                                  const char* message) {
+  ThrowFromFastCallback(options, code, message, FastErrorKind::kTypeError);
+}
+
+void NAPI_CDECL node_api_ns_fast_throw_range_error(ns_fast_options options,
+                                                   const char* code,
+                                                   const char* message) {
+  ThrowFromFastCallback(options, code, message, FastErrorKind::kRangeError);
+}

--- a/test-app/runtime/src/main/cpp/napi/node_api_ns_fast.h
+++ b/test-app/runtime/src/main/cpp/napi/node_api_ns_fast.h
@@ -1,0 +1,191 @@
+#ifndef NODE_API_NS_FAST_H_
+#define NODE_API_NS_FAST_H_
+
+// V8 fast API calls through Node-API — a NativeScript vendor extension.
+//
+// Upstream Node-API declined to expose V8 fast calls (nodejs/node#54731,
+// closed not-planned): the ABI-stable convention assumes a callback may call
+// napi_*, and a fast callback may not. So this is an embedder extension by
+// definition, and it is EXPLICITLY UNSTABLE — the descriptor vocabulary here
+// is NativeScript's, it tracks a V8 API that has already broken its own
+// consumers (the `fallback` field, the receiver parameter, the `v8::Value*`
+// parameter type), and it may change or disappear in any release.
+//
+// Gating, two levels:
+//
+//   * NODE_API_NS_FAST_CALLS_VERSION is defined by this header, so portable
+//     addon code can feature-detect at compile time and keep one source for
+//     every runtime:
+//
+//         #if defined(__has_include)
+//         #  if __has_include(<node_api_ns_fast.h>)
+//         #    define MY_ADDON_TRY_FAST_CALLS 1
+//         #  endif
+//         #endif
+//
+//   * NODE_API_NS_EXPERIMENTAL_FAST_CALLS must be defined by the addon before
+//     including this header. It is a deliberate acknowledgement that the API
+//     is unstable; without it this header is a hard error.
+//
+// A runtime that ships this header always accepts registrations, even where
+// the fast path can never fire (a jitless embed such as the iOS runtime, or
+// any non-V8 engine): the slow path then serves every call. Register once,
+// run everywhere, and go fast where the tier exists — see
+// node_api_ns_fast_calls_available().
+
+#define NODE_API_NS_FAST_CALLS_VERSION 1
+
+#ifndef NODE_API_NS_EXPERIMENTAL_FAST_CALLS
+#error "<node_api_ns_fast.h> exposes an unstable NativeScript extension to Node-API. Define NODE_API_NS_EXPERIMENTAL_FAST_CALLS before including it to acknowledge that this API may change without notice."
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "node_api.h"
+
+EXTERN_C_START
+
+// The unboxed types a fast call can carry, mirroring V8's own vocabulary. The
+// enum is NativeScript's stable-ish contract: V8's CTypeInfo::Type is never
+// exposed, so its churn stays inside the runtime.
+typedef enum {
+  ns_fast_void = 0,
+  ns_fast_bool,
+  ns_fast_uint8,
+  ns_fast_int32,
+  ns_fast_uint32,
+  ns_fast_int64,
+  ns_fast_uint64,
+  ns_fast_float32,
+  ns_fast_float64,
+  // A raw pointer, e.g. previously handed out as external data. V8 performs no
+  // validation whatsoever; the addon owns every guarantee about it.
+  ns_fast_pointer,
+  // An opaque JS value handle, passed through untouched (V8's kV8Value).
+  ns_fast_value,
+  // A zero-copy view of a one-byte (Latin-1) string; the parameter type in the
+  // C function is `const ns_fast_one_byte_string_view*`. The view is valid only for
+  // the duration of the call, and V8 simply does not take the fast path for a
+  // two-byte string, so the slow path must handle those.
+  ns_fast_one_byte_string,
+} ns_fast_type;
+
+// WebIDL-style conversion behaviour, applied by V8 *before* the call.
+typedef enum {
+  ns_fast_flag_none = 0,
+  // Integral parameters only.
+  ns_fast_flag_clamp = 1 << 0,
+  ns_fast_flag_enforce_range = 1 << 1,
+  // Float parameters only: reject NaN/Infinity.
+  ns_fast_flag_is_restricted = 1 << 2,
+  // Typed-array/ArrayBuffer parameters only: accept shared backing stores.
+  ns_fast_flag_allow_shared = 1 << 3,
+} ns_fast_flags;
+
+typedef struct {
+  ns_fast_type type;
+  uint32_t flags;  // a bitwise OR of ns_fast_flags
+} ns_fast_param;
+
+// The zero-copy string view handed to an ns_fast_one_byte_string parameter.
+// Layout-compatible with v8::FastOneByteString.
+typedef struct {
+  const char* data;
+  uint32_t length;
+} ns_fast_one_byte_string_view;
+
+// The receiver (`this`) — always the FIRST parameter of the C function,
+// whether or not the addon uses it. It is deliberately opaque: it is NOT a
+// napi_value and no napi_* call may be made on it. It exists in the ABI from
+// day one because V8 introduced it once already and broke every embedder that
+// had not planned for it (denoland/deno#15139).
+typedef struct ns_fast_receiver__* ns_fast_receiver;
+
+// The trailing parameter of a *fallible* fast function (descriptor.fallible).
+// Opaque; its only use is the throw shims below.
+typedef struct ns_fast_options__* ns_fast_options;
+
+// How a fast function is registered. Passed by pointer so this explicitly
+// unstable API can grow fields without breaking every call site.
+typedef struct {
+  // REQUIRED, and required to be semantically identical to fast_fn. V8 chooses
+  // between the two paths freely — unoptimized tiers, deopts, argument-count
+  // mismatch and non-JIT embeds all run the slow one — so any observable
+  // difference between them is a bug that will surface as nondeterminism.
+  napi_callback slow_cb;
+
+  // Passed to slow_cb as its callback data, exactly as napi_create_function
+  // would. The fast function does not receive it (it has no env to read it
+  // through); keep fast-path state in statics or behind ns_fast_pointer.
+  void* data;
+
+  // The C function, or NULL to register slow-path-only (which is what a
+  // portable addon does on runtimes where fast calls cannot fire).
+  //
+  // Its C signature must be, in order:
+  //   1. ns_fast_receiver
+  //   2. one parameter per arg_types entry, in the unboxed C type
+  //   3. ns_fast_options, if and only if `fallible` is true
+  // returning the C type named by return_type.
+  //
+  // Inside it: NO napi_* calls, no JS-heap allocation, no JS execution, no
+  // blocking, and no exceptions other than through the shims below. Violating
+  // that is undefined behaviour at the V8 level, not a napi error.
+  const void* fast_fn;
+
+  // Void, bool, the integral types and the float types. Handle and string
+  // returns are not supported in this version.
+  ns_fast_param return_type;
+
+  // The addon's own parameters: the receiver and the options handle are NOT
+  // counted or described here, the runtime adds them.
+  size_t argc;
+  const ns_fast_param* arg_types;
+
+  // True if fast_fn takes the trailing ns_fast_options and may throw through
+  // node_api_ns_fast_throw_*. Fallible fast functions are supported (V8 12.6+
+  // allows a fast callback to throw); returning after a throw shim is called
+  // is fine, the return value is ignored once an exception is pending.
+  bool fallible;
+
+  // Whether ns_fast_int64/ns_fast_uint64 surface to JS as BigInt (true) or as
+  // Number (false, the default and what Node uses).
+  bool int64_as_bigint;
+} ns_fast_descriptor;
+
+// Creates a function backed by both paths and returns it as an ordinary
+// napi_value. Fails with napi_invalid_arg on a malformed descriptor (bad type
+// for a return, a flag on a type that cannot carry it, argc without
+// arg_types). The function cannot be used as a constructor.
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_ns_create_fast_function(napi_env env,
+                                 const char* utf8name,
+                                 size_t length,
+                                 const ns_fast_descriptor* descriptor,
+                                 napi_value* result);
+
+// Whether this runtime can register V8 fast-call trampolines at all: false on
+// a jitless or non-V8 embed, where every call runs the slow path. True does
+// NOT promise any individual call takes the fast path — that is V8's choice,
+// always, and depends on the caller tiering up.
+NAPI_EXTERN napi_status NAPI_CDECL
+node_api_ns_fast_calls_available(napi_env env, bool* result);
+
+// Throws from inside a fallible fast function. `code` may be NULL; `message`
+// may not. The runtime opens the handle scope and touches V8 on the addon's
+// behalf, so the addon never sees an isolate. Control returns to the caller —
+// return any value, it is ignored.
+NAPI_EXTERN void NAPI_CDECL node_api_ns_fast_throw_error(
+    ns_fast_options options, const char* code, const char* message);
+
+NAPI_EXTERN void NAPI_CDECL node_api_ns_fast_throw_type_error(
+    ns_fast_options options, const char* code, const char* message);
+
+NAPI_EXTERN void NAPI_CDECL node_api_ns_fast_throw_range_error(
+    ns_fast_options options, const char* code, const char* message);
+
+EXTERN_C_END
+
+#endif  // NODE_API_NS_FAST_H_

--- a/test-app/runtime/src/main/cpp/napi/tests/NapiFastCallsModule.cpp
+++ b/test-app/runtime/src/main/cpp/napi/tests/NapiFastCallsModule.cpp
@@ -1,0 +1,341 @@
+// Test addon for the V8 fast-call extension. Debug builds only.
+//
+// Each function is registered with both paths, and each path bumps its own
+// counter so the specs can tell which one V8 actually chose. That counter is
+// the single deliberate difference between the two implementations — the
+// fixture exists to observe the choice, which the contract otherwise forbids
+// user code from noticing (see docs/node-api-fast-calls.md).
+
+#define NAPI_EXPERIMENTAL
+#define NODE_API_EXPERIMENTAL_NO_WARNING
+#define NODE_API_NS_EXPERIMENTAL_FAST_CALLS
+
+#include <stdint.h>
+#include <string.h>
+
+#include <atomic>
+
+#include "NapiTestSupport.h"
+#include "napi/node_api_ns_fast.h"
+
+namespace {
+
+std::atomic<uint32_t> g_fast_calls{0};
+std::atomic<uint32_t> g_slow_calls{0};
+// Throws raised from inside the fast path specifically — the one thing the
+// error shape observed from JS cannot tell you, since both paths produce an
+// identical RangeError.
+std::atomic<uint32_t> g_fast_throws{0};
+
+void CountFast() { g_fast_calls.fetch_add(1, std::memory_order_relaxed); }
+void CountSlow() { g_slow_calls.fetch_add(1, std::memory_order_relaxed); }
+
+//=== addInt32(a, b) -> int32 ==============================================
+
+int32_t FastAddInt32(ns_fast_receiver receiver, int32_t a, int32_t b) {
+  (void)receiver;
+  CountFast();
+  return a + b;
+}
+
+napi_value SlowAddInt32(napi_env env, napi_callback_info info) {
+  CountSlow();
+
+  size_t argc = 2;
+  napi_value args[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  int32_t a = 0;
+  int32_t b = 0;
+  if (argc > 0) {
+    NAPI_CALL(env, napi_get_value_int32(env, args[0], &a));
+  }
+  if (argc > 1) {
+    NAPI_CALL(env, napi_get_value_int32(env, args[1], &b));
+  }
+
+  napi_value result = NULL;
+  NAPI_CALL(env, napi_create_int32(env, a + b, &result));
+  return result;
+}
+
+//=== scale(x) -> double ===================================================
+
+double FastScale(ns_fast_receiver receiver, double x) {
+  (void)receiver;
+  CountFast();
+  return x * 2.5;
+}
+
+napi_value SlowScale(napi_env env, napi_callback_info info) {
+  CountSlow();
+
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  double x = 0;
+  if (argc > 0) {
+    NAPI_CALL(env, napi_get_value_double(env, args[0], &x));
+  }
+
+  napi_value result = NULL;
+  NAPI_CALL(env, napi_create_double(env, x * 2.5, &result));
+  return result;
+}
+
+//=== divide(a, b) -> double, fallible =====================================
+
+double FastDivide(ns_fast_receiver receiver,
+                  double a,
+                  double b,
+                  ns_fast_options options) {
+  (void)receiver;
+  CountFast();
+  if (b == 0) {
+    g_fast_throws.fetch_add(1, std::memory_order_relaxed);
+    // Returns normally; the pending exception is what the caller observes.
+    node_api_ns_fast_throw_range_error(options, "ERR_DIV_ZERO",
+                                       "division by zero");
+    return 0;
+  }
+  return a / b;
+}
+
+napi_value SlowDivide(napi_env env, napi_callback_info info) {
+  CountSlow();
+
+  size_t argc = 2;
+  napi_value args[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  double a = 0;
+  double b = 0;
+  if (argc > 0) {
+    NAPI_CALL(env, napi_get_value_double(env, args[0], &a));
+  }
+  if (argc > 1) {
+    NAPI_CALL(env, napi_get_value_double(env, args[1], &b));
+  }
+
+  if (b == 0) {
+    napi_throw_range_error(env, "ERR_DIV_ZERO", "division by zero");
+    return NULL;
+  }
+
+  napi_value result = NULL;
+  NAPI_CALL(env, napi_create_double(env, a / b, &result));
+  return result;
+}
+
+//=== byteLength(str) -> uint32 ============================================
+//
+// V8 only takes the fast path for one-byte (Latin-1) strings; a two-byte
+// string falls through to the slow path, which is why both have to agree.
+
+uint32_t FastByteLength(ns_fast_receiver receiver,
+                        const ns_fast_one_byte_string_view* text) {
+  (void)receiver;
+  CountFast();
+  return text == NULL ? 0 : text->length;
+}
+
+napi_value SlowByteLength(napi_env env, napi_callback_info info) {
+  CountSlow();
+
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  size_t length = 0;
+  if (argc > 0) {
+    NAPI_CALL(env,
+              napi_get_value_string_utf8(env, args[0], NULL, 0, &length));
+  }
+
+  napi_value result = NULL;
+  NAPI_CALL(env, napi_create_uint32(env, (uint32_t)length, &result));
+  return result;
+}
+
+//=== clamped(x) -> uint8, exercising the conversion flags =================
+
+uint32_t FastClamped(ns_fast_receiver receiver, uint8_t value) {
+  (void)receiver;
+  CountFast();
+  return value;
+}
+
+napi_value SlowClamped(napi_env env, napi_callback_info info) {
+  CountSlow();
+
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  double raw = 0;
+  if (argc > 0) {
+    NAPI_CALL(env, napi_get_value_double(env, args[0], &raw));
+  }
+
+  // The same WebIDL [Clamp] conversion V8 applies before the fast call.
+  double clamped = raw;
+  if (clamped != clamped) {  // NaN
+    clamped = 0;
+  } else if (clamped < 0) {
+    clamped = 0;
+  } else if (clamped > 255) {
+    clamped = 255;
+  } else {
+    // Round half to even, as WebIDL specifies.
+    double floor_value = clamped - (clamped - (int64_t)clamped);
+    double fraction = clamped - floor_value;
+    if (fraction > 0.5 || (fraction == 0.5 && ((int64_t)floor_value & 1))) {
+      floor_value += 1;
+    }
+    clamped = floor_value;
+  }
+
+  napi_value result = NULL;
+  NAPI_CALL(env, napi_create_uint32(env, (uint32_t)clamped, &result));
+  return result;
+}
+
+//=== Counters and capability ==============================================
+
+napi_value FastCallCount(napi_env env, napi_callback_info info) {
+  napi_value result = NULL;
+  NAPI_CALL(env, napi_create_uint32(
+                     env, g_fast_calls.load(std::memory_order_relaxed), &result));
+  return result;
+}
+
+napi_value SlowCallCount(napi_env env, napi_callback_info info) {
+  napi_value result = NULL;
+  NAPI_CALL(env, napi_create_uint32(
+                     env, g_slow_calls.load(std::memory_order_relaxed), &result));
+  return result;
+}
+
+napi_value FastThrowCount(napi_env env, napi_callback_info info) {
+  napi_value result = NULL;
+  NAPI_CALL(env,
+            napi_create_uint32(
+                env, g_fast_throws.load(std::memory_order_relaxed), &result));
+  return result;
+}
+
+napi_value ResetCounts(napi_env env, napi_callback_info info) {
+  g_fast_calls.store(0, std::memory_order_relaxed);
+  g_slow_calls.store(0, std::memory_order_relaxed);
+  g_fast_throws.store(0, std::memory_order_relaxed);
+  return NULL;
+}
+
+napi_value FastCallsAvailable(napi_env env, napi_callback_info info) {
+  bool available = false;
+  NAPI_CALL(env, node_api_ns_fast_calls_available(env, &available));
+
+  napi_value result = NULL;
+  NAPI_CALL(env, napi_get_boolean(env, available, &result));
+  return result;
+}
+
+//=== Registration =========================================================
+
+bool DefineFast(napi_env env,
+                napi_value exports,
+                const char* name,
+                napi_callback slow_cb,
+                const void* fast_fn,
+                ns_fast_type return_type,
+                size_t argc,
+                const ns_fast_param* arg_types,
+                bool fallible) {
+  ns_fast_descriptor descriptor;
+  memset(&descriptor, 0, sizeof(descriptor));
+  descriptor.slow_cb = slow_cb;
+  descriptor.fast_fn = fast_fn;
+  descriptor.return_type.type = return_type;
+  descriptor.argc = argc;
+  descriptor.arg_types = arg_types;
+  descriptor.fallible = fallible;
+
+  napi_value function = NULL;
+  if (node_api_ns_create_fast_function(env, name, NAPI_AUTO_LENGTH, &descriptor,
+                                       &function) != napi_ok) {
+    NapiThrowLastError(env);
+    return false;
+  }
+
+  return napi_set_named_property(env, exports, name, function) == napi_ok;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  static const ns_fast_param kTwoInt32[] = {
+      {ns_fast_int32, ns_fast_flag_none},
+      {ns_fast_int32, ns_fast_flag_none},
+  };
+  static const ns_fast_param kOneDouble[] = {
+      {ns_fast_float64, ns_fast_flag_none},
+  };
+  static const ns_fast_param kTwoDoubles[] = {
+      {ns_fast_float64, ns_fast_flag_none},
+      {ns_fast_float64, ns_fast_flag_none},
+  };
+  static const ns_fast_param kOneString[] = {
+      {ns_fast_one_byte_string, ns_fast_flag_none},
+  };
+  static const ns_fast_param kOneClampedByte[] = {
+      {ns_fast_uint8, ns_fast_flag_clamp},
+  };
+
+  if (!DefineFast(env, exports, "addInt32", SlowAddInt32,
+                  (const void*)FastAddInt32, ns_fast_int32, 2, kTwoInt32,
+                  false) ||
+      !DefineFast(env, exports, "scale", SlowScale, (const void*)FastScale,
+                  ns_fast_float64, 1, kOneDouble, false) ||
+      !DefineFast(env, exports, "divide", SlowDivide, (const void*)FastDivide,
+                  ns_fast_float64, 2, kTwoDoubles, true) ||
+      !DefineFast(env, exports, "byteLength", SlowByteLength,
+                  (const void*)FastByteLength, ns_fast_uint32, 1, kOneString,
+                  false) ||
+      !DefineFast(env, exports, "clamped", SlowClamped,
+                  (const void*)FastClamped, ns_fast_uint32, 1, kOneClampedByte,
+                  false) ||
+      // Registered with no fast function at all: the portable-addon shape,
+      // which must behave exactly like a plain Node-API function.
+      !DefineFast(env, exports, "slowOnlyAddInt32", SlowAddInt32, NULL,
+                  ns_fast_int32, 2, kTwoInt32, false)) {
+    return NULL;
+  }
+
+  napi_property_descriptor properties[] = {
+      {"fastCallCount", NULL, FastCallCount, NULL, NULL, NULL, napi_default,
+       NULL},
+      {"slowCallCount", NULL, SlowCallCount, NULL, NULL, NULL, napi_default,
+       NULL},
+      {"fastThrowCount", NULL, FastThrowCount, NULL, NULL, NULL, napi_default,
+       NULL},
+      {"resetCounts", NULL, ResetCounts, NULL, NULL, NULL, napi_default, NULL},
+      {"fastCallsAvailable", NULL, FastCallsAvailable, NULL, NULL, NULL,
+       napi_default, NULL},
+  };
+  if (napi_define_properties(env, exports,
+                             sizeof(properties) / sizeof(properties[0]),
+                             properties) != napi_ok) {
+    return NULL;
+  }
+
+  return exports;
+}
+
+napi_module sModule = {
+    NAPI_MODULE_VERSION, 0, __FILE__, Init, "napifastcallsmodule", NULL, {0},
+};
+
+}  // namespace
+
+__attribute__((constructor)) static void RegisterNapiFastCallsModule(void) {
+  napi_module_register(&sModule);
+}


### PR DESCRIPTION
> Builds on the Node-API surface from #2004 (now merged); rebased onto `main`, so the diff here is only the fast-call extension.

## What

Lets a plugin's hot leaf functions be called from optimized JS with **unboxed arguments** — V8's [fast API calls](https://source.chromium.org/chromium/chromium/src/+/main:v8/include/v8-fast-api-calls.h) — without the addon writing any V8 code. A normal Node-API call crosses through `FunctionCallbackInfo`, a handle scope and boxed arguments; a fast call is a direct C call from TurboFan-generated code.

Design follows the brainstorm notes in `ns-v8ios-runtime/NAPI_FAST_CALLS.md` (deviations listed below).

**This is an explicitly unstable vendor extension.** Upstream Node-API [declined to expose fast calls](https://github.com/nodejs/node/issues/54731) (closed *not planned*): Node-API's contract says a callback may call `napi_*`, and a fast callback may not — there is no safe general subset, so any support is an embedder extension by definition.

## Gating

Three layers, answering different questions:

| Layer | Mechanism | Question |
| --- | --- | --- |
| Compile time | `NODE_API_NS_FAST_CALLS_VERSION`, always defined by the header | "does this runtime offer it?" — lets a portable addon `#ifdef` / `__has_include` and keep one source for every runtime |
| Compile time | `NODE_API_NS_EXPERIMENTAL_FAST_CALLS` required, else hard `#error` | "do you accept an unstable API?" — nobody lands here by accident |
| Run time | `node_api_ns_fast_calls_available()` | "can a fast call actually fire?" — false on a jitless embed; derived from the app's V8 startup flags, not hardcoded |

## Surface

```c
#define NODE_API_NS_EXPERIMENTAL_FAST_CALLS
#include <node_api_ns_fast.h>

static int32_t FastAdd(ns_fast_receiver recv, int32_t a, int32_t b) { return a + b; }
static napi_value SlowAdd(napi_env env, napi_callback_info info) { /* identical */ }

ns_fast_descriptor d = {0};
d.slow_cb = SlowAdd;
d.fast_fn = (const void*)FastAdd;
d.return_type.type = ns_fast_int32;
d.argc = 2;
d.arg_types = params;   // {ns_fast_int32}, {ns_fast_int32}
node_api_ns_create_fast_function(env, "add", NAPI_AUTO_LENGTH, &d, &add);
```

- **The descriptor vocabulary is ours** (`ns_fast_type`, `ns_fast_param`, flags). No V8 type ever reaches plugin source, so V8's churn — which has broken embedders twice already (the receiver parameter, the `fallback` field) — stays inside the runtime.
- **Receiver is the first parameter from day one**, opaque, even if v1 addons ignore it — exactly the change that broke Deno ([denoland/deno#15139](https://github.com/denoland/deno/issues/15139)).
- **`fast_fn == NULL` returns a plain Node-API function** with zero wrapper overhead. That is the portable-addon path: one source compiles for this runtime and for the jitless iOS runtime, going fast only where the tier exists.
- **Fallible fast functions are supported.** V8 12.6+ lets a fast callback throw; the addon takes an opaque trailing `ns_fast_options` and throws through `node_api_ns_fast_throw_{error,type_error,range_error}`, which open the handle scope internally so no isolate is ever exposed.
- WebIDL conversion flags (`clamp`, `enforce_range`, `is_restricted`, `allow_shared`) are validated at registration — a flag on a type that cannot carry it is `napi_invalid_arg` rather than a V8 assert somewhere later.

Full contract, type table and "where it pays" in [`docs/node-api-fast-calls.md`](https://github.com/NativeScript/android/blob/feat/node-api-fast-calls/docs/node-api-fast-calls.md).

## Implementation notes

- **Per-signature interning is mandatory, not an optimization**: `CFunctionInfo` keeps its argument array by raw pointer, and V8 keeps the `CFunctionInfo` by pointer for the template's life, so both are interned per distinct signature and intentionally never freed — the shape Node gets for free from file-scope statics.
- **The slow path costs one extra V8 call.** The vendored `js_native_api_v8.cc` defines `CallbackBundle`/`FunctionCallbackWrapper` inside `namespace v8impl { namespace { … } }` — internal linkage — so no other translation unit can invoke a `napi_callback` or fabricate a `napi_callback_info`. The forwarding callback therefore calls a real function made by `napi_create_function`, preserving napi's argument/receiver/exception semantics exactly, at the cost of one extra call *whenever the fast path is not taken*. That is the warmup path for anything hot enough to want fast calls; the real fix would be upstream, not a local ODR hack against internal classes.
- **Fast functions cannot be used as constructors** (`ConstructorBehavior::kThrow`): `new` would have to run the slow path with a `new.target` the forwarding cannot reproduce.

## Deviations from the brainstorm doc

- **Descriptor struct instead of the flat parameter list**, so an explicitly unstable API can gain fields without breaking call sites — it already needed `fallible` and `int64_as_bigint`.
- Handle and string **returns are rejected** in v1 (they would require allocation, which the fast path forbids); scalars and `void` only.
- The iOS side should mirror the descriptor shape when it ships its slow-path-only version.

## Testing

Full suite on an arm64 emulator (API 35): **895 passing / 0 failing** — the `feat/node-api` baseline plus **16 fast-call specs**.

The load-bearing ones:

- **The fast path actually fires**: after 300k calls through a monomorphic caller, `fastCallCount > 0` and fast + slow account for *exactly* all 300,000 calls (the addon counts each path separately).
- **The throw shim runs under optimized code**: divide-by-zero calls are interleaved into the warm-up loop and the addon counts throws raised *inside* the fast function, because the observable `RangeError` is identical from either path. All 300 throws are caught with the right message and `code`, and the caller keeps running afterwards.
- Semantics on both paths, WebIDL clamping, one-byte vs two-byte strings (V8 declines the fast path for two-byte, so the slow path must agree), slow-only registration, and constructor rejection.

## Note for reviewers: a pre-existing worker crash

While testing I hit intermittent `SIGSEGV`s (2 of 4 runs) that are **not from this branch or #2004**. They land within ~40 ms of a `Worker` runtime starting, and the fast-call specs create no workers. The device carries tombstones for this test app in threads named `W10: ./EvalWork` dated **2026-07-30, 08-03, 08-11 and 08-12** — weeks before any Node-API work — the most recent faulting inside `v8::base::OS::Abort()`. Worth tracking separately (no issue filed yet); flagging here so it is not mistaken for fallout from this stack. It also explains an occasional timing failure in the `Throw error in onerror` worker spec.

## Performance

Measured on this runtime (not borrowed figures): 2M calls of a two-`int32` addition — the cheapest possible body, so essentially pure call overhead — from an optimized caller on an **arm64 emulator**. Absolute numbers are inflated by virtualization; the ratio is the meaningful part.

| | ns/call |
| --- | --- |
| Fast path (99.4% of calls; the rest ran before the caller tiered up) | **24** |
| Plain Node-API function | **860** |

≈ **35× on call overhead** — the ceiling, not a typical result: as soon as the body does real work, or the arguments need anything the fast path forbids, the ratio collapses toward 1. The slow path's extra forwarding call is not separately measured.

## Follow-ups
- Overloads (V8 resolves them by argument count), richer typed-array parameters, exposing the `FastApiCallbackOptions` data pointer.
- Root-cause the pre-existing worker crash above.
