### PR TITLE
fix: isolate/runtime lifetime — worker startup race, teardown use-after-free, and leaks

### DIFF
--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -203,6 +203,7 @@ add_library(
         src/main/cpp/Profiler.cpp
         src/main/cpp/ReadWriteLock.cpp
         src/main/cpp/Runtime.cpp
+        src/main/cpp/RuntimeState.cpp
         src/main/cpp/SimpleAllocator.cpp
         src/main/cpp/SimpleProfiler.cpp
         src/main/cpp/StructuredClone.cpp

--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -176,6 +176,7 @@ add_library(
         src/main/cpp/File.cpp
         src/main/cpp/Interop.cpp
         src/main/cpp/IsolateDisposer.cpp
+        src/main/cpp/IsolateTracked.cpp
         src/main/cpp/JEnv.cpp
         src/main/cpp/DesugaredInterfaceCompanionClassNameResolver.cpp
         src/main/cpp/JType.cpp

--- a/test-app/runtime/src/main/cpp/ArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/ArgConverter.cpp
@@ -198,7 +198,11 @@ int64_t ArgConverter::ConvertToJavaLong(Isolate* isolate, const Local<Value>& va
 
 ArgConverter::TypeLongOperationsCache* ArgConverter::GetTypeLongCache(v8::Isolate* isolate) {
     // Per runtime, so there is no shared table to race on; see RuntimeState.h.
-    return RuntimeState::For<TypeLongOperationsCache>(isolate);
+    auto* cache = RuntimeState::For<TypeLongOperationsCache>(isolate);
+    if (cache == nullptr) {
+        throw NativeScriptException("Long conversion cache requested after the runtime was torn down");
+    }
+    return cache;
 }
 
 

--- a/test-app/runtime/src/main/cpp/ArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/ArgConverter.cpp
@@ -7,6 +7,7 @@
 #include "Runtime.h"
 #include "V8GlobalHelpers.h"
 #include "NativeScriptAssert.h"
+#include "RuntimeState.h"
 #include <sstream>
 
 using namespace v8;
@@ -196,16 +197,8 @@ int64_t ArgConverter::ConvertToJavaLong(Isolate* isolate, const Local<Value>& va
 }
 
 ArgConverter::TypeLongOperationsCache* ArgConverter::GetTypeLongCache(v8::Isolate* isolate) {
-    TypeLongOperationsCache* cache;
-    auto itFound = s_type_long_operations_cache.find(isolate);
-    if (itFound == s_type_long_operations_cache.end()) {
-        cache = new TypeLongOperationsCache;
-        s_type_long_operations_cache.emplace(isolate, cache);
-    } else {
-        cache = itFound->second;
-    }
-
-    return cache;
+    // Per runtime, so there is no shared table to race on; see RuntimeState.h.
+    return RuntimeState::For<TypeLongOperationsCache>(isolate);
 }
 
 
@@ -222,12 +215,3 @@ u16string ArgConverter::ConvertToUtf16String(const v8::Local<String>& s) {
 
 
 
-void ArgConverter::onDisposeIsolate(Isolate* isolate) {
-    auto itFound = s_type_long_operations_cache.find(isolate);
-    if (itFound != s_type_long_operations_cache.end()) {
-        delete itFound->second;
-        s_type_long_operations_cache.erase(itFound);
-    }
-}
-
-robin_hood::unordered_map<Isolate*, ArgConverter::TypeLongOperationsCache*> ArgConverter::s_type_long_operations_cache;

--- a/test-app/runtime/src/main/cpp/ArgConverter.h
+++ b/test-app/runtime/src/main/cpp/ArgConverter.h
@@ -115,19 +115,26 @@ class ArgConverter {
                 return v8::String::NewFromTwoByte(isolate, ((const uint16_t*) utf16string.data())).ToLocalChecked();
         }
 
-        static void onDisposeIsolate(v8::Isolate* isolate);
+        /*
+         * Per-runtime state (RuntimeState owns one of these per runtime, so it
+         * has to be constructible from outside ArgConverter). Destroyed with
+         * the runtime, while its isolate is still alive.
+         */
+        struct TypeLongOperationsCache {
+            v8::Persistent<v8::Function>* LongNumberCtorFunc = nullptr;
+
+            v8::Persistent<v8::NumberObject>* NanNumberObject = nullptr;
+
+            ~TypeLongOperationsCache() {
+                delete LongNumberCtorFunc;
+                delete NanNumberObject;
+            }
+        };
 
     private:
 
         // TODO: plamen5kov: rewrite logic for java long number operations in javascript (java long -> javascript number operations check)
         static const long long JS_LONG_LIMIT = ((long long) 1) << 53;
-
-        struct TypeLongOperationsCache {
-            v8::Persistent<v8::Function>* LongNumberCtorFunc;
-
-            v8::Persistent<v8::NumberObject>* NanNumberObject;
-        };
-        //
 
         static TypeLongOperationsCache* GetTypeLongCache(v8::Isolate* isolate);
 
@@ -146,11 +153,6 @@ class ArgConverter {
 
         static void NativeScriptLongToStringFunctionCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-        /*
-         * "s_type_long_operations_cache" used to keep function
-         * dealing with operations concerning java long -> javascript number.
-         */
-        static robin_hood::unordered_map<v8::Isolate*, TypeLongOperationsCache*> s_type_long_operations_cache;
 };
 }
 

--- a/test-app/runtime/src/main/cpp/ErrorEvents.cpp
+++ b/test-app/runtime/src/main/cpp/ErrorEvents.cpp
@@ -11,15 +11,6 @@ using namespace tns;
 using namespace v8;
 
 /*
- * Non-throwing runtime lookup, safe from V8 callbacks that may fire while a
- * runtime is being torn down (Runtime::GetRuntime throws in that window).
- */
-static Runtime* GetRuntimeOrNull(Isolate* isolate) {
-    return static_cast<Runtime*>(
-            isolate->GetData((uint32_t) Runtime::IsolateData::RUNTIME));
-}
-
-/*
  * Native function handed to internal/error-events.js as `nativeReportFatal(error,
  * stackString)`. It runs the terminal tail (shim + log) WITHOUT re-dispatching
  * an event: reportError and listener-thrown errors have already gone through
@@ -38,7 +29,7 @@ static void NativeReportFatalCallback(const FunctionCallbackInfo<Value>& info) {
 
 void ErrorEvents::Init(Local<Context> context) {
     auto isolate = v8::Isolate::GetCurrent();
-    auto runtime = GetRuntimeOrNull(isolate);
+    auto runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr) {
         throw NativeScriptException("ErrorEvents::Init: no runtime for isolate");
     }
@@ -81,7 +72,7 @@ void ErrorEvents::Init(Local<Context> context) {
 bool ErrorEvents::DispatchError(Isolate* isolate, Local<Value> error,
                                 const string& messageString,
                                 const string& stack) {
-    auto runtime = GetRuntimeOrNull(isolate);
+    auto runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr || runtime->DispatchErrorEventFunc().IsEmpty()) {
         return false;
     }
@@ -104,7 +95,7 @@ bool ErrorEvents::DispatchError(Isolate* isolate, Local<Value> error,
 bool ErrorEvents::DispatchUnhandledRejection(Isolate* isolate,
                                              Local<Promise> promise,
                                              Local<Value> reason) {
-    auto runtime = GetRuntimeOrNull(isolate);
+    auto runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr || runtime->DispatchUnhandledRejectionFunc().IsEmpty()) {
         return false;
     }
@@ -126,7 +117,7 @@ bool ErrorEvents::DispatchNativeUncaughtError(Isolate* isolate,
                                               Local<Value> error,
                                               const string& messageString,
                                               const string& stack) {
-    auto runtime = GetRuntimeOrNull(isolate);
+    auto runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr || runtime->DispatchNativeUncaughtErrorFunc().IsEmpty()) {
         return false;
     }
@@ -149,7 +140,7 @@ bool ErrorEvents::DispatchNativeUncaughtError(Isolate* isolate,
 void ErrorEvents::DispatchRejectionHandled(Isolate* isolate,
                                            Local<Promise> promise,
                                            Local<Value> reason) {
-    auto runtime = GetRuntimeOrNull(isolate);
+    auto runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr || runtime->DispatchRejectionHandledFunc().IsEmpty()) {
         return;
     }

--- a/test-app/runtime/src/main/cpp/Events.cpp
+++ b/test-app/runtime/src/main/cpp/Events.cpp
@@ -10,8 +10,7 @@ using namespace v8;
 
 void Events::Init(Local<Context> context) {
     auto isolate = v8::Isolate::GetCurrent();
-    auto runtime = static_cast<Runtime*>(
-            isolate->GetData((uint32_t) Runtime::IsolateData::RUNTIME));
+    auto runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr) {
         throw NativeScriptException("Events::Init: no runtime for isolate");
     }

--- a/test-app/runtime/src/main/cpp/FrameCallbacks.cpp
+++ b/test-app/runtime/src/main/cpp/FrameCallbacks.cpp
@@ -258,8 +258,7 @@ void Dispatch(EntryId id, int64_t frameTimeNanos) {
     }
 
     Isolate* isolate = entry->isolate_;
-    Runtime* runtime = static_cast<Runtime*>(
-            isolate->GetData((uint32_t) Runtime::IsolateData::RUNTIME));
+    Runtime* runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr) {
         return;
     }

--- a/test-app/runtime/src/main/cpp/IsolateDisposer.cpp
+++ b/test-app/runtime/src/main/cpp/IsolateDisposer.cpp
@@ -15,10 +15,6 @@
 
 namespace tns {
     void disposeIsolate(v8::Isolate *isolate) {
-        tns::ArgConverter::onDisposeIsolate(isolate);
-        tns::MetadataNode::onDisposeIsolate(isolate);
-        tns::Console::onDisposeIsolate(isolate);
-        tns::JSONObjectHelper::onDisposeIsolate(isolate);
         tns::NsBuiltinModules::onDisposeIsolate(isolate);
         tns::BuiltinLoader::onDisposeIsolate(isolate);
         // clear all isolate bound objects

--- a/test-app/runtime/src/main/cpp/IsolateTracked.cpp
+++ b/test-app/runtime/src/main/cpp/IsolateTracked.cpp
@@ -1,0 +1,56 @@
+#include "IsolateTracked.h"
+
+#include "RuntimeState.h"
+#include "robin_hood.h"
+
+namespace tns {
+
+namespace {
+// The live instances of one runtime; see RuntimeState.h. Touched only on that
+// runtime's own thread -- both the GC finalizer and the teardown sweep run
+// there -- so it needs no synchronization.
+struct TrackedInstances {
+    robin_hood::unordered_set<IsolateTracked*> live;
+};
+}  // namespace
+
+void IsolateTracked::BindFinalizer(v8::Isolate* isolate,
+                                   const v8::Local<v8::Object>& object) {
+    v8::HandleScope scopedHandle(isolate);
+    weakHandle_.Reset(isolate, object);
+    weakHandle_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
+
+    auto* tracked = RuntimeState::For<TrackedInstances>(isolate);
+    if (tracked != nullptr) {
+        tracked->live.insert(this);
+    }
+}
+
+void IsolateTracked::Finalizer(const v8::WeakCallbackInfo<IsolateTracked>& data) {
+    IsolateTracked* self = data.GetParameter();
+
+    auto* tracked = RuntimeState::For<TrackedInstances>(data.GetIsolate());
+    if (tracked != nullptr) {
+        tracked->live.erase(self);
+    }
+
+    delete self;
+}
+
+void IsolateTracked::SweepAll(v8::Isolate* isolate) {
+    auto* tracked = RuntimeState::For<TrackedInstances>(isolate);
+    if (tracked == nullptr) {
+        return;
+    }
+
+    // Detached first: a destructor that somehow reached back into the registry
+    // must not mutate the set being walked.
+    auto survivors = std::move(tracked->live);
+    tracked->live.clear();
+
+    for (IsolateTracked* instance : survivors) {
+        delete instance;
+    }
+}
+
+}  // namespace tns

--- a/test-app/runtime/src/main/cpp/IsolateTracked.h
+++ b/test-app/runtime/src/main/cpp/IsolateTracked.h
@@ -1,0 +1,44 @@
+#ifndef TEST_APP_ISOLATETRACKED_H
+#define TEST_APP_ISOLATETRACKED_H
+
+#include "v8.h"
+
+namespace tns {
+
+/*
+ * Base for self-owned native objects whose lifetime is bound to a single JS
+ * object through a weak handle (URL, URLSearchParams, URLPattern).
+ *
+ * An instance dies in exactly two places: the GC finalizer, or SweepAll at
+ * runtime teardown. The sweep is the point of this class -- V8 does not run
+ * weak callbacks when an isolate is disposed, so every instance still alive
+ * when a runtime goes away (a worker shutting down, say) would otherwise leak
+ * its native state, and URLPattern would leak its compiled v8::Global handles
+ * with it.
+ *
+ * Never delete a bound instance directly: both deletion paths own the registry
+ * bookkeeping. Subclasses only need a destructor that releases their own
+ * state; it runs while the isolate is still alive, so it may reset v8::Global
+ * handles, but it must not create new ones.
+ */
+class IsolateTracked {
+ public:
+    virtual ~IsolateTracked() = default;
+
+    void BindFinalizer(v8::Isolate* isolate, const v8::Local<v8::Object>& object);
+
+    /*
+     * Deletes every instance the GC never got to. Runs on the runtime's own
+     * thread while the isolate is alive.
+     */
+    static void SweepAll(v8::Isolate* isolate);
+
+ private:
+    static void Finalizer(const v8::WeakCallbackInfo<IsolateTracked>& data);
+
+    v8::Global<v8::Object> weakHandle_;
+};
+
+}  // namespace tns
+
+#endif  // TEST_APP_ISOLATETRACKED_H

--- a/test-app/runtime/src/main/cpp/JEnv.cpp
+++ b/test-app/runtime/src/main/cpp/JEnv.cpp
@@ -1,10 +1,22 @@
 #include "JEnv.h"
+
+#include <shared_mutex>
 #include <assert.h>
 #include "Util.h"
 #include "NativeScriptException.h"
 #include "DesugaredInterfaceCompanionClassNameResolver.h"
 
 using namespace tns;
+
+/*
+ * The class caches are process-wide and string-keyed, holding JNI global refs,
+ * which is correct to share -- but every runtime resolves classes from its own
+ * thread and workers run concurrently. Shared for lookups, exclusive only to
+ * publish. NewGlobalRef/DeleteLocalRef stay outside the lock; if two threads
+ * resolve the same class, the first published wins and the loser releases its
+ * ref rather than leaking it.
+ */
+static std::shared_mutex classCacheMutex;
 using namespace std;
 
 JEnv::JEnv()
@@ -758,6 +770,8 @@ jclass JEnv::FindClass(const string &className) {
 
 jclass JEnv::CheckForClassInCache(const string &className) {
     jclass global_class = nullptr;
+
+    std::shared_lock<std::shared_mutex> lock(classCacheMutex);
     auto itFound = s_classCache.find(className);
 
     if (itFound != s_classCache.end()) {
@@ -769,14 +783,30 @@ jclass JEnv::CheckForClassInCache(const string &className) {
 
 jclass JEnv::InsertClassIntoCache(const string &className, jclass &tmp) {
     auto global_class = reinterpret_cast<jclass>(m_env->NewGlobalRef(tmp));
-    s_classCache.emplace(className, global_class);
     m_env->DeleteLocalRef(tmp);
+
+    jclass published = nullptr;
+    {
+        std::unique_lock<std::shared_mutex> lock(classCacheMutex);
+        auto result = s_classCache.emplace(className, global_class);
+        if (!result.second) {
+            published = result.first->second;
+        }
+    }
+
+    if (published != nullptr) {
+        // Another thread resolved the same class first; keep its ref.
+        m_env->DeleteGlobalRef(global_class);
+        return published;
+    }
 
     return global_class;
 }
 
 jthrowable JEnv::CheckForClassMissingCache(const string &className) {
     jthrowable throwable = nullptr;
+
+    std::shared_lock<std::shared_mutex> lock(classCacheMutex);
     auto itFound = s_missingClasses.find(className);
 
     if (itFound != s_missingClasses.end()) {
@@ -788,8 +818,21 @@ jthrowable JEnv::CheckForClassMissingCache(const string &className) {
 
 jthrowable JEnv::InsertClassIntoMissingCache(const string &className,const jthrowable &tmp) {
     auto throwable = reinterpret_cast<jthrowable>(m_env->NewGlobalRef(tmp));
-    s_missingClasses.emplace(className, throwable);
     m_env->DeleteLocalRef(tmp);
+
+    jthrowable published = nullptr;
+    {
+        std::unique_lock<std::shared_mutex> lock(classCacheMutex);
+        auto result = s_missingClasses.emplace(className, throwable);
+        if (!result.second) {
+            published = result.first->second;
+        }
+    }
+
+    if (published != nullptr) {
+        m_env->DeleteGlobalRef(throwable);
+        return published;
+    }
 
     return throwable;
 }

--- a/test-app/runtime/src/main/cpp/JSONObjectHelper.cpp
+++ b/test-app/runtime/src/main/cpp/JSONObjectHelper.cpp
@@ -2,6 +2,7 @@
 #include "JSONObjectHelper.h"
 #include "ArgConverter.h"
 #include "BuiltinLoader.h"
+#include "RuntimeState.h"
 #include "robin_hood.h"
 #include <sstream>
 #include <string>
@@ -9,7 +10,16 @@
 using namespace v8;
 using namespace tns;
 
-static robin_hood::unordered_map<Isolate*, Persistent<Function>*> isolateToSerializeFunc;
+namespace {
+// The compiled JS->org.json serializer, per runtime; see RuntimeState.h.
+struct SerializeFuncState {
+    Persistent<Function>* func = nullptr;
+
+    ~SerializeFuncState() {
+        delete func;
+    }
+};
+}  // namespace
 
 void JSONObjectHelper::RegisterFromFunction(Isolate *isolate, Local<Value>& jsonObject) {
     if (!jsonObject->IsFunction()) {
@@ -84,9 +94,12 @@ void JSONObjectHelper::ConvertCallbackStatic(const FunctionCallbackInfo<Value>& 
 Persistent<Function>* JSONObjectHelper::GetSerializeFunc(Local<Context> context) {
     Isolate* isolate = v8::Isolate::GetCurrent();
 
-    auto it = isolateToSerializeFunc.find(isolate);
-    if (it != isolateToSerializeFunc.end()) {
-        return it->second;
+    auto* state = RuntimeState::For<SerializeFuncState>(isolate);
+    if (state == nullptr) {
+        return nullptr;
+    }
+    if (state->func != nullptr) {
+        return state->func;
     }
 
     Local<Value> result;
@@ -95,16 +108,8 @@ Persistent<Function>* JSONObjectHelper::GetSerializeFunc(Local<Context> context)
         return nullptr;
     }
 
-    auto* serializeFunc = new Persistent<Function>(isolate, result.As<Function>());
-    isolateToSerializeFunc.emplace(isolate, serializeFunc);
+    state->func = new Persistent<Function>(isolate, result.As<Function>());
 
-    return serializeFunc;
+    return state->func;
 }
 
-void JSONObjectHelper::onDisposeIsolate(Isolate* isolate) {
-    auto it = isolateToSerializeFunc.find(isolate);
-    if (it != isolateToSerializeFunc.end()) {
-        delete it->second;
-        isolateToSerializeFunc.erase(it);
-    }
-}

--- a/test-app/runtime/src/main/cpp/JSONObjectHelper.h
+++ b/test-app/runtime/src/main/cpp/JSONObjectHelper.h
@@ -8,7 +8,6 @@ namespace tns {
 class JSONObjectHelper {
 public:
     static void RegisterFromFunction(v8::Isolate *isolate, v8::Local<v8::Value>& jsonObject);
-    static void onDisposeIsolate(v8::Isolate* isolate);
 private:
     static v8::Persistent<v8::Function>* GetSerializeFunc(v8::Local<v8::Context> context);
     static void ConvertCallbackStatic(const v8::FunctionCallbackInfo<v8::Value>& info);

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1,4 +1,5 @@
 #include "MetadataNode.h"
+#include "RuntimeState.h"
 #include "NativeScriptAssert.h"
 #include "Constants.h"
 #include "Util.h"
@@ -82,9 +83,9 @@ bool MetadataNode::TryGetPackageName(Isolate* isolate, const Local<Object>& valu
 }
 
 Local<ObjectTemplate> MetadataNode::GetOrCreateArrayObjectTemplate(Isolate* isolate) {
-    auto it = s_arrayObjectTemplates.find(isolate);
-    if (it != s_arrayObjectTemplates.end()) {
-        return it->second->Get(isolate);
+    auto cache = GetMetadataNodeCache(isolate);
+    if (cache->ArrayObjectTemplate != nullptr) {
+        return cache->ArrayObjectTemplate->Get(isolate);
     }
 
     auto arrayObjectTemplate = ObjectTemplate::New(isolate);
@@ -92,7 +93,7 @@ Local<ObjectTemplate> MetadataNode::GetOrCreateArrayObjectTemplate(Isolate* isol
     arrayObjectTemplate->SetHandler(IndexedPropertyHandlerConfiguration(
             ArrayIndexedPropertyGetterCallback, ArrayIndexedPropertySetterCallback));
 
-    s_arrayObjectTemplates.emplace(std::make_pair(isolate, new Persistent<ObjectTemplate>(isolate, arrayObjectTemplate)));
+    cache->ArrayObjectTemplate = new Persistent<ObjectTemplate>(isolate, arrayObjectTemplate);
 
     return arrayObjectTemplate;
 }
@@ -721,7 +722,7 @@ vector<MetadataNode::MethodCallbackData *> MetadataNode::SetInstanceMethodsFromS
                 callbackData->parent = *itFound;
             }
 
-            if (s_profilerEnabled) {
+            if (s_profilerEnabled.load(std::memory_order_relaxed)) {
                 Local<External> funcData = External::New(isolate, callbackData, v8::kExternalPointerTypeTagDefault);
                 Local<FunctionTemplate> funcTemplate = FunctionTemplate::New(isolate, MethodCallback, funcData);
                 auto func = funcTemplate->GetFunction(context).ToLocalChecked();
@@ -965,8 +966,9 @@ void MetadataNode::InnerTypeAccessorGetterCallback(v8::Local<v8::Name> property,
     MetadataTreeNode* curChild = static_cast<MetadataTreeNode*>(
         v8::External::Cast(*info.Data())->Value(v8::kExternalPointerTypeTagDefault));
     auto childNode = GetOrCreateInternal(curChild);
-    auto itFound = childNode->m_poCtorCachePerIsolate.find(isolate);
-    if (itFound != childNode->m_poCtorCachePerIsolate.end()) {
+    auto innerCache = GetMetadataNodeCache(isolate);
+    auto itFound = innerCache->CtorFunctions.find(childNode);
+    if (itFound != innerCache->CtorFunctions.end()) {
         info.GetReturnValue().Set(itFound->second->Get(isolate));
         return;
     }
@@ -1086,7 +1088,7 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
     node->SetStaticMembers(isolate, wrappedCtorFunc, treeNode, curPtr);
 
     // insert isolate-specific persistent function handle
-    node->m_poCtorCachePerIsolate.insert({isolate, new Persistent<Function>(isolate, wrappedCtorFunc)});
+    cache->CtorFunctions.emplace(node, new Persistent<Function>(isolate, wrappedCtorFunc));
     if (!baseCtorFunc.IsEmpty()) {
         auto currentContext = isolate->GetCurrentContext();
         wrappedCtorFunc->SetPrototype(currentContext, baseCtorFunc);
@@ -1116,8 +1118,9 @@ Local<Function> MetadataNode::GetConstructorFunction(Isolate* isolate) {
 }
 
 Persistent<Function>* MetadataNode::GetPersistentConstructorFunction(Isolate* isolate) {
-    auto itFound = m_poCtorCachePerIsolate.find(isolate);
-    if (itFound != m_poCtorCachePerIsolate.end()) {
+    auto cache = GetMetadataNodeCache(isolate);
+    auto itFound = cache->CtorFunctions.find(this);
+    if (itFound != cache->CtorFunctions.end()) {
         auto& constrFunction = itFound->second;
 
         return constrFunction;
@@ -2063,19 +2066,17 @@ void MetadataNode::CreateTopLevelNamespaces(Isolate* isolate, const Local<Object
 }
 
 MetadataNode::MetadataNodeCache* MetadataNode::GetMetadataNodeCache(Isolate* isolate) {
-    MetadataNodeCache* cache;
-    auto itFound = s_metadata_node_cache.find(isolate);
-    if (itFound == s_metadata_node_cache.end()) {
-        cache = new MetadataNodeCache;
-        s_metadata_node_cache.emplace(isolate, cache);
-    } else {
-        cache = itFound->second;
+    // Per runtime; see RuntimeState.h. Null only once the runtime has begun
+    // tearing down, which no caller here can legitimately reach.
+    auto* cache = RuntimeState::For<MetadataNodeCache>(isolate);
+    if (cache == nullptr) {
+        throw NativeScriptException("Metadata cache requested after the runtime was torn down");
     }
     return cache;
 }
 
 void MetadataNode::EnableProfiler(bool enableProfiler) {
-    s_profilerEnabled = enableProfiler;
+    s_profilerEnabled.store(enableProfiler, std::memory_order_relaxed);
 }
 
 bool MetadataNode::IsJavascriptKeyword(const std::string &word) {
@@ -2095,7 +2096,7 @@ bool MetadataNode::IsJavascriptKeyword(const std::string &word) {
 }
 
 Local<Function> MetadataNode::Wrap(Isolate* isolate, const Local<Function>& function, const string& name, const string& origin, bool isCtorFunc) {
-    if (!s_profilerEnabled || name == "<init>") {
+    if (!s_profilerEnabled.load(std::memory_order_relaxed) || name == "<init>") {
         return function;
     }
 
@@ -2305,32 +2306,6 @@ std::string MetadataNode::GetJniClassName(MetadataEntry& entry) {
     return fullClassName;
 }
 
-void MetadataNode::onDisposeIsolate(Isolate* isolate) {
-    {
-        auto it = s_metadata_node_cache.find(isolate);
-        if (it != s_metadata_node_cache.end()) {
-            delete it->second;
-            s_metadata_node_cache.erase(it);
-        }
-    }
-    {
-        auto it = s_arrayObjectTemplates.find(isolate);
-        if (it != s_arrayObjectTemplates.end()) {
-            delete it->second;
-            s_arrayObjectTemplates.erase(it);
-        }
-    }
-    {
-        for (auto it = s_treeNode2NodeCache.begin(); it != s_treeNode2NodeCache.end(); it++) {
-            auto it2 = it->second->m_poCtorCachePerIsolate.find(isolate);
-            if(it2 != it->second->m_poCtorCachePerIsolate.end()) {
-                delete it2->second;
-                it->second->m_poCtorCachePerIsolate.erase(it2);
-            }
-        }
-    }
-}
-
 MetadataReader* MetadataNode::getMetadataReader() {
     return &MetadataNode::s_metadataReader;
 }
@@ -2340,7 +2315,5 @@ MetadataReader MetadataNode::s_metadataReader;
 robin_hood::unordered_map<std::string, MetadataNode*> MetadataNode::s_name2NodeCache;
 robin_hood::unordered_map<std::string, MetadataTreeNode*> MetadataNode::s_name2TreeNodeCache;
 robin_hood::unordered_map<MetadataTreeNode*, MetadataNode*> MetadataNode::s_treeNode2NodeCache;
-robin_hood::unordered_map<Isolate*, MetadataNode::MetadataNodeCache*> MetadataNode::s_metadata_node_cache;
-bool MetadataNode::s_profilerEnabled = false;
-robin_hood::unordered_map<Isolate*, Persistent<ObjectTemplate>*> MetadataNode::s_arrayObjectTemplates;
+std::atomic<bool> MetadataNode::s_profilerEnabled{false};
 

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -307,6 +307,19 @@ class MetadataNode {
                 for (auto& entry : CtorFunctions) {
                     delete entry.second;
                 }
+                /*
+                 * Freed from the maps rather than from CtorCacheData and
+                 * ExtendedClassCacheData themselves: both are held by value and
+                 * handed out by value (GetCachedExtendedClassData returns a
+                 * copy), and the copies share these raw pointers. A destructor
+                 * on either struct would turn every copy into a double free.
+                 */
+                for (auto& entry : CtorFuncCache) {
+                    delete entry.second.ft;
+                }
+                for (auto& entry : ExtendedCtorFuncCache) {
+                    delete entry.second.extendedCtorFunction;
+                }
             }
         };
 };

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -278,9 +278,12 @@ class MetadataNode {
          * while its isolate is still alive.
          */
         struct MetadataNodeCache {
-            v8::Persistent<v8::String>* MetadataKey;
+            // Initialized rather than left indeterminate: the cache is created
+            // on first use, which may precede MetadataNode::Init populating
+            // these, and the destructor below releases them.
+            v8::Persistent<v8::String>* MetadataKey = nullptr;
 
-            v8::Persistent<v8::String>* PackageKey;
+            v8::Persistent<v8::String>* PackageKey = nullptr;
 
             robin_hood::unordered_map<MetadataTreeNode*, CtorCacheData> CtorFuncCache;
 
@@ -298,6 +301,8 @@ class MetadataNode {
             robin_hood::unordered_map<MetadataNode*, v8::Persistent<v8::Function>*> CtorFunctions;
 
             ~MetadataNodeCache() {
+                delete MetadataKey;
+                delete PackageKey;
                 delete ArrayObjectTemplate;
                 for (auto& entry : CtorFunctions) {
                     delete entry.second;

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -18,6 +18,7 @@
 //	....->InstanceProxy->EmptyInstance
 
 #include "v8.h"
+#include <atomic>
 #include "MetadataEntry.h"
 #include "MetadataTreeNode.h"
 #include "MetadataReader.h"
@@ -70,7 +71,6 @@ class MetadataNode {
 
         static bool TryGetPackageName(v8::Isolate* isolate, const v8::Local<v8::Object>& value, std::string& out);
 
-        static void onDisposeIsolate(v8::Isolate* isolate);
 
         static MetadataReader* getMetadataReader();
     private:
@@ -185,7 +185,6 @@ class MetadataNode {
                                    PrototypeTemplateFiller& protoFiller);
 
         MetadataTreeNode* m_treeNode;
-        robin_hood::unordered_map<v8::Isolate*, v8::Persistent<v8::Function>*> m_poCtorCachePerIsolate;
         std::string m_name;
         std::string m_implType;
         bool m_isArray;
@@ -195,9 +194,7 @@ class MetadataNode {
         static robin_hood::unordered_map<std::string, MetadataNode*> s_name2NodeCache;
         static robin_hood::unordered_map<std::string, MetadataTreeNode*> s_name2TreeNodeCache;
         static robin_hood::unordered_map<MetadataTreeNode*, MetadataNode*> s_treeNode2NodeCache;
-        static robin_hood::unordered_map<v8::Isolate*, MetadataNodeCache*> s_metadata_node_cache;
-        static robin_hood::unordered_map<v8::Isolate*, v8::Persistent<v8::ObjectTemplate>*> s_arrayObjectTemplates;
-        static bool s_profilerEnabled;
+        static std::atomic<bool> s_profilerEnabled;
 
         struct MethodCallbackData {
             MethodCallbackData()
@@ -275,6 +272,11 @@ class MetadataNode {
             MetadataNode* node;
         };
 
+        /*
+         * Metadata state for one runtime. Owned by RuntimeState, so it is
+         * reached without a shared container and destroyed with the runtime,
+         * while its isolate is still alive.
+         */
         struct MetadataNodeCache {
             v8::Persistent<v8::String>* MetadataKey;
 
@@ -283,6 +285,24 @@ class MetadataNode {
             robin_hood::unordered_map<MetadataTreeNode*, CtorCacheData> CtorFuncCache;
 
             robin_hood::unordered_map<std::string, MetadataNode::ExtendedClassCacheData> ExtendedCtorFuncCache;
+
+            // The array wrapper template for this runtime.
+            v8::Persistent<v8::ObjectTemplate>* ArrayObjectTemplate = nullptr;
+
+            /*
+             * This runtime's constructor function per node. The nodes
+             * themselves are shared between runtimes, so this cannot live on
+             * them -- it used to, as a map keyed by isolate, which meant every
+             * runtime's teardown walked every node to erase its entry.
+             */
+            robin_hood::unordered_map<MetadataNode*, v8::Persistent<v8::Function>*> CtorFunctions;
+
+            ~MetadataNodeCache() {
+                delete ArrayObjectTemplate;
+                for (auto& entry : CtorFunctions) {
+                    delete entry.second;
+                }
+            }
         };
 };
 }

--- a/test-app/runtime/src/main/cpp/MethodCache.cpp
+++ b/test-app/runtime/src/main/cpp/MethodCache.cpp
@@ -1,4 +1,6 @@
 #include "MethodCache.h"
+
+#include <shared_mutex>
 #include "JniLocalRef.h"
 #include "JsArgToArrayConverter.h"
 #include "MetadataNode.h"
@@ -13,6 +15,16 @@
 #include <sstream>
 
 using namespace v8;
+
+/*
+ * s_mthod_ctor_signature_cache is process-wide and string-keyed: it holds only
+ * JNI handles, so sharing it across runtimes is correct -- but every runtime
+ * resolves into it from its own thread, and workers run concurrently. Shared
+ * for lookups (the common case by far), exclusive only to publish a new entry.
+ * Never held across the JNI resolution itself: two threads may resolve the
+ * same signature, which is idempotent, and the first one published wins.
+ */
+static std::shared_mutex signatureCacheMutex;
 using namespace std;
 using namespace tns;
 
@@ -33,31 +45,34 @@ MethodCache::CacheMethodInfo MethodCache::ResolveMethodSignature(const string& c
     CacheMethodInfo method_info;
 
     auto encoded_method_signature = EncodeSignature(className, methodName, args, isStatic);
-    auto it = s_mthod_ctor_signature_cache.find(encoded_method_signature);
-
-    if (it == s_mthod_ctor_signature_cache.end()) {
-        auto signature = ResolveJavaMethod(args, className, methodName);
-
-        DEBUG_WRITE("ResolveMethodSignature %s='%s'", encoded_method_signature.c_str(), signature.c_str());
-
-        if (!signature.empty()) {
-            JEnv env;
-            auto clazz = env.FindClass(className);
-            assert(clazz != nullptr);
-            method_info.clazz = clazz;
-            method_info.signature = signature;
-            method_info.returnType = MetadataReader::ParseReturnType(method_info.signature);
-            method_info.retType = MetadataReader::GetReturnType(method_info.returnType);
-            method_info.isStatic = isStatic;
-            method_info.mid = isStatic
-                              ? env.GetStaticMethodID(clazz, methodName, signature)
-                              :
-                              env.GetMethodID(clazz, methodName, signature);
-
-            s_mthod_ctor_signature_cache.emplace(encoded_method_signature, method_info);
+    {
+        std::shared_lock<std::shared_mutex> lock(signatureCacheMutex);
+        auto it = s_mthod_ctor_signature_cache.find(encoded_method_signature);
+        if (it != s_mthod_ctor_signature_cache.end()) {
+            return it->second;
         }
-    } else {
-        method_info = (*it).second;
+    }
+
+    auto signature = ResolveJavaMethod(args, className, methodName);
+
+    DEBUG_WRITE("ResolveMethodSignature %s='%s'", encoded_method_signature.c_str(), signature.c_str());
+
+    if (!signature.empty()) {
+        JEnv env;
+        auto clazz = env.FindClass(className);
+        assert(clazz != nullptr);
+        method_info.clazz = clazz;
+        method_info.signature = signature;
+        method_info.returnType = MetadataReader::ParseReturnType(method_info.signature);
+        method_info.retType = MetadataReader::GetReturnType(method_info.returnType);
+        method_info.isStatic = isStatic;
+        method_info.mid = isStatic
+                          ? env.GetStaticMethodID(clazz, methodName, signature)
+                          :
+                          env.GetMethodID(clazz, methodName, signature);
+
+        std::unique_lock<std::shared_mutex> lock(signatureCacheMutex);
+        s_mthod_ctor_signature_cache.emplace(encoded_method_signature, method_info);
     }
 
     return method_info;
@@ -68,23 +83,26 @@ MethodCache::CacheMethodInfo MethodCache::ResolveConstructorSignature(const Args
 
     auto& args = argWrapper.args;
     auto encoded_ctor_signature = EncodeSignature(fullClassName, "<init>", args, false);
-    auto it = s_mthod_ctor_signature_cache.find(encoded_ctor_signature);
-
-    if (it == s_mthod_ctor_signature_cache.end()) {
-        auto signature = ResolveConstructor(args, javaClass, isInterface);
-
-        DEBUG_WRITE("ResolveConstructorSignature %s='%s'", encoded_ctor_signature.c_str(), signature.c_str());
-
-        if (!signature.empty()) {
-            JEnv env;
-            constructor_info.clazz = javaClass;
-            constructor_info.signature = signature;
-            constructor_info.mid = env.GetMethodID(javaClass, "<init>", signature);
-
-            s_mthod_ctor_signature_cache.emplace(encoded_ctor_signature, constructor_info);
+    {
+        std::shared_lock<std::shared_mutex> lock(signatureCacheMutex);
+        auto it = s_mthod_ctor_signature_cache.find(encoded_ctor_signature);
+        if (it != s_mthod_ctor_signature_cache.end()) {
+            return it->second;
         }
-    } else {
-        constructor_info = (*it).second;
+    }
+
+    auto signature = ResolveConstructor(args, javaClass, isInterface);
+
+    DEBUG_WRITE("ResolveConstructorSignature %s='%s'", encoded_ctor_signature.c_str(), signature.c_str());
+
+    if (!signature.empty()) {
+        JEnv env;
+        constructor_info.clazz = javaClass;
+        constructor_info.signature = signature;
+        constructor_info.mid = env.GetMethodID(javaClass, "<init>", signature);
+
+        std::unique_lock<std::shared_mutex> lock(signatureCacheMutex);
+        s_mthod_ctor_signature_cache.emplace(encoded_ctor_signature, constructor_info);
     }
 
     return constructor_info;

--- a/test-app/runtime/src/main/cpp/NativeScriptException.cpp
+++ b/test-app/runtime/src/main/cpp/NativeScriptException.cpp
@@ -281,15 +281,6 @@ void NativeScriptException::OnUncaughtError(Local<Message> message,
   e.ReThrowToJava();
 }
 
-/*
- * Non-throwing runtime lookup, safe from V8 callbacks that may fire while a
- * runtime is being torn down (Runtime::GetRuntime throws in that window).
- */
-static Runtime* GetRuntimeOrNull(Isolate* isolate) {
-  return static_cast<Runtime*>(
-      isolate->GetData((uint32_t)Runtime::IsolateData::RUNTIME));
-}
-
 static string ToDetailString(Isolate* isolate, Local<Value> value) {
   auto context = isolate->GetCurrentContext();
   Local<String> str;
@@ -326,7 +317,7 @@ static void LogLines(const string& text) {
 void NativeScriptException::OnPromiseRejected(v8::PromiseRejectMessage message) {
   auto promise = message.GetPromise();
   auto isolate = v8::Isolate::GetCurrent();
-  auto runtime = GetRuntimeOrNull(isolate);
+  auto runtime = Runtime::TryGetRuntime(isolate);
   if (runtime == nullptr || runtime->PromiseRejections() == nullptr) {
     return;
   }
@@ -363,7 +354,7 @@ void NativeScriptException::ReportUnhandledRejection(Isolate* isolate,
     return;
   }
 
-  auto runtime = GetRuntimeOrNull(isolate);
+  auto runtime = Runtime::TryGetRuntime(isolate);
   bool discard =
       runtime != nullptr && runtime->GetDiscardUncaughtJsExceptions();
   ReportFatalTail(isolate, reason, stackTrace, "Unhandled promise rejection:",
@@ -458,7 +449,7 @@ static bool IsMarkedReportedToJs(Isolate* isolate, Local<Value> error) {
 
 bool NativeScriptException::ContainUncaughtCallbackException(Isolate* isolate,
                                                              v8::TryCatch& tc) {
-  auto runtime = GetRuntimeOrNull(isolate);
+  auto runtime = Runtime::TryGetRuntime(isolate);
   if (runtime == nullptr) {
     return false;
   }

--- a/test-app/runtime/src/main/cpp/Performance.cpp
+++ b/test-app/runtime/src/main/cpp/Performance.cpp
@@ -11,15 +11,6 @@ namespace tns {
 
 namespace {
 
-/*
- * Non-throwing runtime lookup, safe from V8 callbacks that may fire while a
- * runtime is being torn down (Runtime::GetRuntime throws in that window).
- */
-Runtime* GetRuntimeOrNull(Isolate* isolate) {
-    return static_cast<Runtime*>(
-            isolate->GetData((uint32_t) Runtime::IsolateData::RUNTIME));
-}
-
 }  // namespace
 
 void Performance::Init(Local<Context> context) {
@@ -55,7 +46,7 @@ void Performance::Init(Local<Context> context) {
 }
 
 double Performance::NowMillis(Isolate* isolate) {
-    Runtime* runtime = GetRuntimeOrNull(isolate);
+    Runtime* runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr) {
         return 0.0;
     }
@@ -64,7 +55,7 @@ double Performance::NowMillis(Isolate* isolate) {
 }
 
 double Performance::TimeOriginMillis(Isolate* isolate) {
-    Runtime* runtime = GetRuntimeOrNull(isolate);
+    Runtime* runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr) {
         return 0.0;
     }
@@ -74,7 +65,7 @@ double Performance::TimeOriginMillis(Isolate* isolate) {
 
 double Performance::MonotonicNanosToTimelineMillis(Isolate* isolate,
                                                    int64_t nanos) {
-    Runtime* runtime = GetRuntimeOrNull(isolate);
+    Runtime* runtime = Runtime::TryGetRuntime(isolate);
     if (runtime == nullptr) {
         return 0.0;
     }

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -32,6 +32,7 @@
 #include "NativeScriptAssert.h"
 #include "NativeScriptException.h"
 #include "NativeScriptPlatform.h"
+#include "RuntimeState.h"
 #include "napi/NapiEnv.h"
 #include "Performance.h"
 #include "SimpleAllocator.h"
@@ -147,6 +148,7 @@ Runtime::Runtime(JNIEnv* env, jobject runtime, int id)
       m_runGC(false) {
   m_runtime = env->NewGlobalRef(runtime);
   m_objectManager = new ObjectManager(m_runtime);
+  m_state = std::make_unique<RuntimeState>();
   {
     std::lock_guard<std::mutex> lock(s_runtimeCacheMutex);
     s_id2RuntimeCache.emplace(id, this);
@@ -615,7 +617,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath,
    * Setup the V8Platform only once per process - once for the application
    * lifetime Don't execute again if main thread has already been initialized
    */
-  if (!s_mainThreadInitialized) {
+  if (!s_mainThreadInitialized.load(std::memory_order_acquire)) {
     InitializeV8();
   }
 
@@ -743,7 +745,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath,
   globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "URLPattern"),
                       URLPatternImpl::GetCtor(isolate));
 
-  if (!s_mainThreadInitialized) {
+  if (!s_mainThreadInitialized.load(std::memory_order_acquire)) {
     m_isMainThread = true;
     // __runOnMainThread closures from any runtime's thread land on this loop
     s_mainEventLoop = m_eventLoop;
@@ -847,7 +849,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath,
   m_weakRef.Init(isolate, context);
 
   // Do not set 'self' accessor to main thread JavaScript
-  if (s_mainThreadInitialized) {
+  if (s_mainThreadInitialized.load(std::memory_order_acquire)) {
     global->DefineOwnProperty(context,
                               ArgConverter::ConvertToV8String(isolate, "self"),
                               global, readOnlyFlags);
@@ -877,7 +879,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath,
 
   // Do not build metadata (which should be static for the process) for non-main
   // threads
-  if (!s_mainThreadInitialized) {
+  if (!s_mainThreadInitialized.load(std::memory_order_acquire)) {
     MetadataNode::BuildMetadata(filesPath);
   }
 
@@ -895,7 +897,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath,
   this->m_napiEnv = NapiEnv::Create(context, m_eventLoop);
   s_currentRuntime = this;
 
-  s_mainThreadInitialized = true;
+  s_mainThreadInitialized.store(true, std::memory_order_release);
 
   return isolate;
 }
@@ -958,6 +960,11 @@ void Runtime::DestroyRuntime() {
   m_dispatchErrorEventFunc.Reset();
   m_dispatchUnhandledRejectionFunc.Reset();
   m_dispatchRejectionHandledFunc.Reset();
+  // Subsystem state bound to this isolate: released here, while the isolate is
+  // still alive, because it holds v8::Persistents.
+  if (m_state != nullptr) {
+    m_state->Clear();
+  }
   m_dispatchNativeUncaughtErrorFunc.Reset();
   tns::disposeIsolate(m_isolate);
 }
@@ -974,7 +981,7 @@ jmethodID Runtime::GET_USED_MEMORY_METHOD_ID = nullptr;
 robin_hood::unordered_map<int, Runtime*> Runtime::s_id2RuntimeCache;
 robin_hood::unordered_map<Isolate*, Runtime*> Runtime::s_isolate2RuntimesCache;
 std::mutex Runtime::s_runtimeCacheMutex;
-bool Runtime::s_mainThreadInitialized = false;
+std::atomic<bool> Runtime::s_mainThreadInitialized{false};
 v8::Platform* Runtime::platform = nullptr;
 int Runtime::m_androidVersion = Runtime::GetAndroidVersion();
 std::shared_ptr<EventLoop> Runtime::s_mainEventLoop;

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -20,6 +20,7 @@
 #include "File.h"
 #include "FrameCallbacks.h"
 #include "Interop.h"
+#include "IsolateTracked.h"
 #include "IsolateDisposer.h"
 #include "JType.h"
 #include "JsArgConverter.h"
@@ -187,8 +188,7 @@ Runtime* Runtime::GetRuntime(v8::Isolate* isolate) {
    * is written once in PrepareV8Runtime before the isolate runs any JS, so
    * reading it requires no lock.
    */
-  auto runtime = static_cast<Runtime*>(
-      isolate->GetData((uint32_t)Runtime::IsolateData::RUNTIME));
+  auto runtime = TryGetRuntime(isolate);
   if (runtime != nullptr) {
     return runtime;
   }
@@ -210,9 +210,7 @@ Runtime* Runtime::GetRuntime(v8::Isolate* isolate) {
 }
 
 Runtime* Runtime::GetRuntimeFromIsolateData(v8::Isolate* isolate) {
-  void* maybeRuntime =
-      isolate->GetData((uint32_t)Runtime::IsolateData::RUNTIME);
-  auto runtime = static_cast<Runtime*>(maybeRuntime);
+  auto runtime = TryGetRuntime(isolate);
 
   if (runtime == nullptr) {
     stringstream ss;
@@ -311,8 +309,16 @@ Runtime::~Runtime() {
   if (platformInstance != nullptr && m_isolate != nullptr && m_eventLoop != nullptr) {
     platformInstance->IsolateDisposed(m_isolate, m_eventLoop);
   }
-  CallbackHandlers::RemoveIsolateEntries(m_isolate);
-  FrameCallbacks::RemoveIsolateEntries(m_isolate);
+
+  // Last: ObjectManager calls Java through this same object above, so the ref
+  // has to outlive it. Without this the com.tns.Runtime instance -- and every
+  // Java object the runtime ever strongly registered through it -- stays
+  // reachable for the life of the process.
+  if (m_runtime != nullptr) {
+    JEnv env;
+    env.DeleteGlobalRef(m_runtime);
+    m_runtime = nullptr;
+  }
 }
 
 std::string Runtime::ReadFileText(const std::string& filePath) {
@@ -960,13 +966,51 @@ void Runtime::DestroyRuntime() {
   m_dispatchErrorEventFunc.Reset();
   m_dispatchUnhandledRejectionFunc.Reset();
   m_dispatchRejectionHandledFunc.Reset();
-  // Subsystem state bound to this isolate: released here, while the isolate is
-  // still alive, because it holds v8::Persistents.
+  m_dispatchNativeUncaughtErrorFunc.Reset();
+
+  // Both hold v8::Global handles to JS callbacks, so their entries must be
+  // dropped here rather than in ~Runtime, which runs after Isolate::Dispose --
+  // resetting a Global then writes into a freed handle table. Doing it here
+  // also closes a window in which the main thread could take a Locker on this
+  // isolate (RunMainThreadEntry) after it had already been disposed.
+  CallbackHandlers::RemoveIsolateEntries(m_isolate);
+  FrameCallbacks::RemoveIsolateEntries(m_isolate);
+
+  tns::disposeIsolate(m_isolate);
+
+  // V8 does not run weak callbacks when an isolate is disposed, so anything
+  // still bound to one has to be deleted explicitly, here, while the isolate
+  // is alive and its destructors can still touch v8::Global handles.
+  IsolateTracked::SweepAll(m_isolate);
+
+  // Everything below still needs the isolate alive -- the caller disposes it
+  // only after this returns -- but runs after the hooks above so nothing they
+  // touch is pulled out from under them.
+
+  // Cached per-isolate string constants; its destructor resets 19 handles. The
+  // slot is cleared so a stray lookup during the rest of teardown reads null
+  // rather than freed memory.
+  auto* consts = static_cast<V8StringConstants::PerIsolateV8Constants*>(
+      m_isolate->GetData((uint32_t)Runtime::IsolateData::CONSTANTS));
+  delete consts;
+  m_isolate->SetData((uint32_t)Runtime::IsolateData::CONSTANTS, nullptr);
+
+  if (m_gcFunc != nullptr) {
+    m_gcFunc->Reset();
+    delete m_gcFunc;
+    m_gcFunc = nullptr;
+  }
+  if (m_context != nullptr) {
+    m_context->Reset();
+    delete m_context;
+    m_context = nullptr;
+  }
+
+  // Last, so anything above still finds its state: this state holds
+  // v8::Persistents, which have to be released while the isolate is alive.
   if (m_state != nullptr) {
     m_state->Clear();
   }
-  m_dispatchNativeUncaughtErrorFunc.Reset();
-  tns::disposeIsolate(m_isolate);
 }
 
 Local<Context> Runtime::GetContext() {

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -55,6 +55,18 @@ class Runtime {
         static Runtime* GetRuntimeFromIsolateData(v8::Isolate* isolate);
 
         /*
+         * The runtime for this isolate, or null. Unlike the accessors above it
+         * neither throws nor locks -- it only reads the isolate's own data
+         * slot -- which is what makes it usable from the places that must not
+         * throw: GC weak callbacks, teardown paths, and the error handlers
+         * that run while a runtime is going away.
+         */
+        static Runtime* TryGetRuntime(v8::Isolate* isolate) {
+            return static_cast<Runtime*>(
+                isolate->GetData((uint32_t)IsolateData::RUNTIME));
+        }
+
+        /*
          * The runtime whose home thread is the calling thread, or null. Set at
          * the end of PrepareV8Runtime; may be stale after a Runtime destroyed
          * on another thread, so consumers must validate through

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -12,6 +12,7 @@
 #include "File.h"
 #include "Timers.h"
 #include "EventLoop.h"
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <android/looper.h>
@@ -23,6 +24,7 @@ typedef struct napi_env__* napi_env;
 
 namespace tns {
 class PromiseRejectionTracker;
+class RuntimeState;
 
 class Runtime {
     public:
@@ -92,6 +94,15 @@ class Runtime {
         void Init(JNIEnv* env, jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, bool isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize, bool forceLog);
 
         v8::Isolate* GetIsolate() const;
+
+        /*
+         * Per-runtime storage for subsystem state bound to this isolate; see
+         * RuntimeState.h. Released in DestroyRuntime while the isolate is
+         * still alive, so state holding v8::Persistents can be torn down.
+         */
+        RuntimeState* GetState() const {
+            return m_state.get();
+        }
 
         jobject GetJavaRuntime() const;
 
@@ -256,6 +267,8 @@ class Runtime {
 
         std::shared_ptr<EventLoop> m_eventLoop;
 
+        std::unique_ptr<RuntimeState> m_state;
+
         napi_env m_napiEnv = nullptr;
 
         v8::Global<v8::Object> m_globalEventTarget;
@@ -303,7 +316,7 @@ class Runtime {
 
         static jmethodID GET_USED_MEMORY_METHOD_ID;
 
-        static bool s_mainThreadInitialized;
+        static std::atomic<bool> s_mainThreadInitialized;
 
         static std::shared_ptr<EventLoop> s_mainEventLoop;
 

--- a/test-app/runtime/src/main/cpp/RuntimeState.cpp
+++ b/test-app/runtime/src/main/cpp/RuntimeState.cpp
@@ -1,0 +1,13 @@
+#include "RuntimeState.h"
+
+namespace tns {
+
+size_t RuntimeState::NextSlotIndex() {
+    // Slot indices are claimed the first time a state type is used, which can
+    // happen on any runtime's thread -- two workers touching two different
+    // subsystems for the first time race here.
+    static std::atomic<size_t> next{0};
+    return next.fetch_add(1, std::memory_order_relaxed);
+}
+
+}  // namespace tns

--- a/test-app/runtime/src/main/cpp/RuntimeState.h
+++ b/test-app/runtime/src/main/cpp/RuntimeState.h
@@ -1,0 +1,109 @@
+#ifndef TEST_APP_RUNTIMESTATE_H
+#define TEST_APP_RUNTIMESTATE_H
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "Runtime.h"
+#include "v8.h"
+
+namespace tns {
+
+/*
+ * Per-runtime storage for subsystem state that belongs to a single isolate.
+ *
+ * Such state used to live in process-wide maps keyed by v8::Isolate*. Keying by
+ * isolate does not make the *container* private: runtimes start and tear down on
+ * their own threads, so one runtime inserting its entry while another erases its
+ * own corrupts the shared container. Holding the isolate's Locker does not help
+ * -- each thread holds only its own isolate's lock, so two runtimes are never
+ * excluded from each other.
+ *
+ * Hanging the state off the Runtime removes the sharing instead of guarding it:
+ * nothing is shared, so there is nothing to race on and no lock on the access
+ * path (a lookup is an isolate data-slot read plus a vector index). It also
+ * removes the per-isolate erase at teardown -- the whole bag is destroyed once,
+ * on the runtime's own thread, while the isolate is still alive, which is what
+ * v8::Persistent members require.
+ *
+ * A subsystem declares a state struct -- typically in its own .cpp, so nothing
+ * leaks into headers -- and reaches it with:
+ *
+ *     auto* state = RuntimeState::For<MyState>(isolate);
+ *     if (state == nullptr) return;  // runtime is tearing down
+ *
+ * The first call for a runtime default-constructs the state; it is destroyed
+ * with the runtime.
+ */
+class RuntimeState {
+ public:
+    /*
+     * This runtime's instance of T, created on first use, or null once the
+     * runtime has started tearing down (callers must not resurrect state that
+     * teardown has already released).
+     */
+    template <typename T>
+    static T* For(v8::Isolate* isolate);
+
+    /*
+     * Destroys every state object. Runs on the runtime's own thread from
+     * DestroyRuntime, before the isolate is disposed.
+     */
+    void Clear() {
+        disposed_ = true;
+        slots_.clear();
+    }
+
+ private:
+    // One slot index per state type, handed out on first use from any thread.
+    static size_t NextSlotIndex();
+
+    template <typename T>
+    static size_t SlotIndexFor() {
+        static const size_t index = NextSlotIndex();
+        return index;
+    }
+
+    // Type-erased so Runtime need not know any subsystem's state type; the
+    // deleter restores the type at destruction.
+    using Slot = std::unique_ptr<void, void (*)(void*)>;
+
+    template <typename T>
+    T* GetOrCreate() {
+        if (disposed_) {
+            return nullptr;
+        }
+
+        size_t index = SlotIndexFor<T>();
+        while (slots_.size() <= index) {
+            slots_.emplace_back(nullptr, [](void*) {});
+        }
+
+        Slot& slot = slots_[index];
+        if (slot == nullptr) {
+            slot = Slot(new T(), [](void* value) { delete static_cast<T*>(value); });
+        }
+
+        return static_cast<T*>(slot.get());
+    }
+
+    std::vector<Slot> slots_;
+    bool disposed_ = false;
+};
+
+template <typename T>
+T* RuntimeState::For(v8::Isolate* isolate) {
+    Runtime* runtime = Runtime::GetRuntime(isolate);
+    RuntimeState* state = runtime->GetState();
+    if (state == nullptr) {
+        return nullptr;
+    }
+
+    return state->GetOrCreate<T>();
+}
+
+}  // namespace tns
+
+#endif  // TEST_APP_RUNTIMESTATE_H

--- a/test-app/runtime/src/main/cpp/RuntimeState.h
+++ b/test-app/runtime/src/main/cpp/RuntimeState.h
@@ -95,7 +95,13 @@ class RuntimeState {
 
 template <typename T>
 T* RuntimeState::For(v8::Isolate* isolate) {
-    Runtime* runtime = Runtime::GetRuntime(isolate);
+    // TryGetRuntime, not GetRuntime: this runs from GC weak callbacks, where
+    // throwing is not an option.
+    auto* runtime = Runtime::TryGetRuntime(isolate);
+    if (runtime == nullptr) {
+        return nullptr;
+    }
+
     RuntimeState* state = runtime->GetState();
     if (state == nullptr) {
         return nullptr;

--- a/test-app/runtime/src/main/cpp/URLImpl.h
+++ b/test-app/runtime/src/main/cpp/URLImpl.h
@@ -5,13 +5,14 @@
 #pragma once
 
 #include <vector>
+#include "IsolateTracked.h"
 #include "ada/ada.h"
 #include "v8.h"
 #include "ArgConverter.h"
 
 using namespace ada;
 namespace tns {
-    class URLImpl {
+    class URLImpl : public IsolateTracked {
     public:
         URLImpl(url_aggregator url);
 
@@ -110,20 +111,8 @@ namespace tns {
 
         static void CanParse(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-        void BindFinalizer(v8::Isolate *isolate, const v8::Local<v8::Object> &object) {
-            v8::HandleScope scopedHandle(isolate);
-            weakHandle_.Reset(isolate, object);
-            weakHandle_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
-        }
-
-        static void Finalizer(const v8::WeakCallbackInfo<URLImpl> &data) {
-            auto *pThis = data.GetParameter();
-            pThis->weakHandle_.Reset();
-            delete pThis;
-        }
 
     private:
         url_aggregator url_;
-        v8::Global<v8::Object> weakHandle_;
     };
 }

--- a/test-app/runtime/src/main/cpp/URLPatternImpl.h
+++ b/test-app/runtime/src/main/cpp/URLPatternImpl.h
@@ -6,6 +6,7 @@
 #define TEST_APP_URLPATTERNIMPL_H
 
 #include "ada/ada.h"
+#include "IsolateTracked.h"
 #include "v8.h"
 #include "ArgConverter.h"
 #include "NativeScriptAssert.h"
@@ -27,7 +28,7 @@ namespace tns {
         static bool regex_match(std::string_view input, const regex_type &pattern);
     };
 
-    class URLPatternImpl {
+    class URLPatternImpl : public IsolateTracked {
     public:
 
         URLPatternImpl(url_pattern <v8_regex_provider> pattern);
@@ -72,21 +73,9 @@ namespace tns {
 
         static void Exec(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-        void BindFinalizer(v8::Isolate *isolate, const v8::Local<v8::Object> &object) {
-            v8::HandleScope scopedHandle(isolate);
-            weakHandle_.Reset(isolate, object);
-            weakHandle_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
-        }
-
-        static void Finalizer(const v8::WeakCallbackInfo<URLPatternImpl> &data) {
-            auto *pThis = data.GetParameter();
-            pThis->weakHandle_.Reset();
-            delete pThis;
-        }
 
     private:
         url_pattern <v8_regex_provider> pattern_;
-        v8::Global<v8::Object> weakHandle_;
 
         static std::optional<ada::url_pattern_init>
         ParseInput(v8::Isolate *isolate, const v8::Local<v8::Value> &input);

--- a/test-app/runtime/src/main/cpp/URLSearchParamsImpl.h
+++ b/test-app/runtime/src/main/cpp/URLSearchParamsImpl.h
@@ -4,12 +4,13 @@
 #pragma once
 
 #include "ada/ada.h"
+#include "IsolateTracked.h"
 #include "v8.h"
 #include "ArgConverter.h"
 
 namespace tns {
 
-    class URLSearchParamsImpl {
+    class URLSearchParamsImpl : public IsolateTracked {
     public:
 
         URLSearchParamsImpl(ada::url_search_params params);
@@ -49,21 +50,9 @@ namespace tns {
 
         static void Values(const v8::FunctionCallbackInfo<v8::Value> &args);
 
-        void BindFinalizer(v8::Isolate *isolate, const v8::Local<v8::Object> &object) {
-            v8::HandleScope scopedHandle(isolate);
-            weakHandle_.Reset(isolate, object);
-            weakHandle_.SetWeak(this, Finalizer, v8::WeakCallbackType::kParameter);
-        }
-
-        static void Finalizer(const v8::WeakCallbackInfo<URLSearchParamsImpl> &data) {
-            auto *pThis = data.GetParameter();
-            pThis->weakHandle_.Reset();
-            delete pThis;
-        }
 
     private:
         ada::url_search_params params_;
-        v8::Global<v8::Object> weakHandle_;
     };
 
 } // tns

--- a/test-app/runtime/src/main/cpp/V8StringConstants.h
+++ b/test-app/runtime/src/main/cpp/V8StringConstants.h
@@ -149,25 +149,37 @@ class V8StringConstants {
             };
 
             ~PerIsolateV8Constants() {
-                CLASS_IMPLEMENTATION_OBJECT_PERSISTENT->Reset();
-                DEBUG_NAME_PERSISTENT->Reset();
-                EXTEND_PERSISTENT->Reset();
-                NULL_OBJECT_PERSISTENT->Reset();
-                NULL_NODE_NAME_PERSISTENT->Reset();
-                IS_PROTOTYPE_IMPLEMENTATION_OBJECT_PERSISTENT->Reset();
-                NATIVE_EXCEPTION_PERSISTENT->Reset();
-                STACK_PERSISTENT->Reset();
-                STACK_TRACE_PERSISTENT->Reset();
-                LONG_NUMBER_PERSISTENT->Reset();
-                PROTOTYPE_PERSISTENT->Reset();
-                SUPER_PERSISTENT->Reset();
-                TARGET_PERSISTENT->Reset();
-                TO_STRING_PERSISTENT->Reset();
-                JAVA_LONG_PERSISTENT->Reset();
-                VALUE_OF_PERSISTENT->Reset();
-                VALUE_PERSISTENT->Reset();
-                UNCAUGHT_ERROR_PERSISTENT->Reset();
-                IMPLEMENTATION_OBJECT_PERSISTENT->Reset();
+                // Persistent's traits do not reset in the destructor, so each
+                // handle is reset explicitly (requires a live isolate) and then
+                // freed. Generated from the member list -- keep the two in step.
+                ResetAndDelete(CLASS_IMPLEMENTATION_OBJECT_PERSISTENT);
+                ResetAndDelete(DEBUG_NAME_PERSISTENT);
+                ResetAndDelete(DISCARDED_ERROR_PERSISTENT);
+                ResetAndDelete(EXTEND_PERSISTENT);
+                ResetAndDelete(IMPLEMENTATION_OBJECT_PERSISTENT);
+                ResetAndDelete(IS_PROTOTYPE_IMPLEMENTATION_OBJECT_PERSISTENT);
+                ResetAndDelete(JAVA_LONG_PERSISTENT);
+                ResetAndDelete(LONG_NUMBER_PERSISTENT);
+                ResetAndDelete(NATIVE_EXCEPTION_PERSISTENT);
+                ResetAndDelete(NULL_NODE_NAME_PERSISTENT);
+                ResetAndDelete(NULL_OBJECT_PERSISTENT);
+                ResetAndDelete(PROTOTYPE_PERSISTENT);
+                ResetAndDelete(STACK_PERSISTENT);
+                ResetAndDelete(STACK_TRACE_PERSISTENT);
+                ResetAndDelete(SUPER_PERSISTENT);
+                ResetAndDelete(TARGET_PERSISTENT);
+                ResetAndDelete(TO_STRING_PERSISTENT);
+                ResetAndDelete(UNCAUGHT_ERROR_PERSISTENT);
+                ResetAndDelete(VALUE_OF_PERSISTENT);
+                ResetAndDelete(VALUE_PERSISTENT);
+            }
+
+            static void ResetAndDelete(v8::Persistent<v8::String>*& handle) {
+                if (handle != nullptr) {
+                    handle->Reset();
+                    delete handle;
+                    handle = nullptr;
+                }
             }
 
             v8::Persistent<v8::String>* CLASS_IMPLEMENTATION_OBJECT_PERSISTENT;

--- a/test-app/runtime/src/main/cpp/V8StringConstants.h
+++ b/test-app/runtime/src/main/cpp/V8StringConstants.h
@@ -151,7 +151,10 @@ class V8StringConstants {
             ~PerIsolateV8Constants() {
                 // Persistent's traits do not reset in the destructor, so each
                 // handle is reset explicitly (requires a live isolate) and then
-                // freed. Generated from the member list -- keep the two in step.
+                // freed. Every member is default-initialized because not all of
+                // them are allocated by the constructor -- DEBUG_NAME_PERSISTENT
+                // never is, and the previous version of this destructor reset it
+                // unconditionally, which would have faulted had it ever run.
                 ResetAndDelete(CLASS_IMPLEMENTATION_OBJECT_PERSISTENT);
                 ResetAndDelete(DEBUG_NAME_PERSISTENT);
                 ResetAndDelete(DISCARDED_ERROR_PERSISTENT);
@@ -182,26 +185,26 @@ class V8StringConstants {
                 }
             }
 
-            v8::Persistent<v8::String>* CLASS_IMPLEMENTATION_OBJECT_PERSISTENT;
-            v8::Persistent<v8::String>* DEBUG_NAME_PERSISTENT;
-            v8::Persistent<v8::String>* EXTEND_PERSISTENT;
-            v8::Persistent<v8::String>* NULL_OBJECT_PERSISTENT;
-            v8::Persistent<v8::String>* NULL_NODE_NAME_PERSISTENT;
-            v8::Persistent<v8::String>* IS_PROTOTYPE_IMPLEMENTATION_OBJECT_PERSISTENT;
-            v8::Persistent<v8::String>* NATIVE_EXCEPTION_PERSISTENT;
-            v8::Persistent<v8::String>* STACK_PERSISTENT;
-            v8::Persistent<v8::String>* STACK_TRACE_PERSISTENT;
-            v8::Persistent<v8::String>* LONG_NUMBER_PERSISTENT;
-            v8::Persistent<v8::String>* PROTOTYPE_PERSISTENT;
-            v8::Persistent<v8::String>* SUPER_PERSISTENT;
-            v8::Persistent<v8::String>* TARGET_PERSISTENT;
-            v8::Persistent<v8::String>* TO_STRING_PERSISTENT;
-            v8::Persistent<v8::String>* JAVA_LONG_PERSISTENT;
-            v8::Persistent<v8::String>* VALUE_OF_PERSISTENT;
-            v8::Persistent<v8::String>* VALUE_PERSISTENT;
-            v8::Persistent<v8::String>* UNCAUGHT_ERROR_PERSISTENT;
-            v8::Persistent<v8::String>* DISCARDED_ERROR_PERSISTENT;
-            v8::Persistent<v8::String>* IMPLEMENTATION_OBJECT_PERSISTENT;
+            v8::Persistent<v8::String>* CLASS_IMPLEMENTATION_OBJECT_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* DEBUG_NAME_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* EXTEND_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* NULL_OBJECT_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* NULL_NODE_NAME_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* IS_PROTOTYPE_IMPLEMENTATION_OBJECT_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* NATIVE_EXCEPTION_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* STACK_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* STACK_TRACE_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* LONG_NUMBER_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* PROTOTYPE_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* SUPER_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* TARGET_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* TO_STRING_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* JAVA_LONG_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* VALUE_OF_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* VALUE_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* UNCAUGHT_ERROR_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* DISCARDED_ERROR_PERSISTENT = nullptr;
+            v8::Persistent<v8::String>* IMPLEMENTATION_OBJECT_PERSISTENT = nullptr;
         };
 
     private:

--- a/test-app/runtime/src/main/cpp/console/Console.cpp
+++ b/test-app/runtime/src/main/cpp/console/Console.cpp
@@ -19,22 +19,36 @@
 #include "BuiltinLoader.h"
 #include "Console.h"
 #include "NsBuiltinModules.h"
+#include "RuntimeState.h"
 #include "robin_hood.h"
 
 namespace tns {
 
-// internal/inspect.js, one compiled instance per isolate. Worker runtimes
-// initialize on their own threads, so every access is under the mutex.
-static std::mutex inspectMutex;
-static robin_hood::unordered_map<v8::Isolate*, v8::Persistent<v8::Function>*> isolateToInspect;
+namespace {
+/*
+ * Console state belonging to one runtime: the console.time() labels and the
+ * compiled internal/inspect.js instance for this realm. Every access is on the
+ * owning runtime's own thread, so none of it needs synchronization -- which is
+ * exactly what a process-wide map keyed by v8::Isolate* could not give, since
+ * the container was shared even though the entries were not. See RuntimeState.h.
+ */
+struct ConsoleState {
+    robin_hood::unordered_map<std::string, double> timerLabels;
+
+    v8::Persistent<v8::Function>* inspect = nullptr;
+
+    ~ConsoleState() {
+        delete inspect;
+    }
+};
+}  // namespace
 
 static v8::Local<v8::Function> getInspectFunction(v8::Isolate* isolate) {
-    std::lock_guard<std::mutex> lock(inspectMutex);
-    auto it = isolateToInspect.find(isolate);
-    if (it == isolateToInspect.end()) {
+    auto* state = tns::RuntimeState::For<ConsoleState>(isolate);
+    if (state == nullptr || state->inspect == nullptr) {
         return v8::Local<v8::Function>();
     }
-    return it->second->Get(isolate);
+    return state->inspect->Get(isolate);
 }
 
 v8::Local<v8::Object> Console::createConsole(v8::Local<v8::Context> context, ConsoleCallback callback, const int maxLogcatObjectSize, const bool forceLog) {
@@ -48,9 +62,6 @@ v8::Local<v8::Object> Console::createConsole(v8::Local<v8::Context> context, Con
 
     assert(success);
 
-    std::map<std::string, double> timersMap;
-    Console::s_isolateToConsoleTimersMap.insert(
-        std::make_pair(v8::Isolate::GetCurrent(), timersMap));
 
     bindFunctionProperty(context, console, "assert", assertCallback);
     bindFunctionProperty(context, console, "error", errorCallback);
@@ -118,10 +129,12 @@ void Console::initInspect(v8::Local<v8::Context> context) {
         return;
     }
 
-    std::lock_guard<std::mutex> lock(inspectMutex);
-    auto& slot = isolateToInspect[isolate];
-    delete slot;
-    slot = new v8::Persistent<v8::Function>(isolate, result.As<v8::Function>());
+    auto* state = tns::RuntimeState::For<ConsoleState>(isolate);
+    if (state == nullptr) {
+        return;
+    }
+    delete state->inspect;
+    state->inspect = new v8::Persistent<v8::Function>(isolate, result.As<v8::Function>());
 }
 
 v8::Local<v8::Function> Console::getInspect(v8::Local<v8::Context> context) {
@@ -525,15 +538,17 @@ void Console::timeCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
             label = ArgConverter::ConvertToString(argString);
         }
 
-        auto it = Console::s_isolateToConsoleTimersMap.find(isolate);
-        if (it == Console::s_isolateToConsoleTimersMap.end()) {
-            // throw?
-        }
-
         auto nano = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now());
         double timeStamp = nano.time_since_epoch().count();
 
-        it->second.insert(std::make_pair(label, timeStamp));
+        auto* timers = tns::RuntimeState::For<ConsoleState>(isolate);
+        if (timers == nullptr) {
+            return;
+        }
+
+        // emplace, not assignment: a second console.time() with the same label
+        // keeps the original start stamp, as before.
+        timers->timerLabels.emplace(label, timeStamp);
     } catch (NativeScriptException& e) {
         e.ReThrowToV8();
     } catch (std::exception e) {
@@ -559,15 +574,20 @@ void Console::timeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
             label = ArgConverter::ConvertToString(argString);
         }
 
-        auto it = Console::s_isolateToConsoleTimersMap.find(isolate);
-        if (it == Console::s_isolateToConsoleTimersMap.end()) {
-            // throw?
+        double startTimeStamp = 0;
+        bool started = false;
+
+        auto* timers = tns::RuntimeState::For<ConsoleState>(isolate);
+        if (timers != nullptr) {
+            auto itTimersMap = timers->timerLabels.find(label);
+            if (itTimersMap != timers->timerLabels.end()) {
+                startTimeStamp = itTimersMap->second;
+                timers->timerLabels.erase(itTimersMap);
+                started = true;
+            }
         }
 
-        std::map<std::string, double> timersMap = it->second;
-
-        auto itTimersMap = timersMap.find(label);
-        if (itTimersMap == timersMap.end()) {
+        if (!started) {
             std::string warning = std::string("No such label '" + label + "' for console.timeEnd()");
 
             __android_log_write(ANDROID_LOG_WARN, LOG_TAG, warning.c_str());
@@ -578,9 +598,6 @@ void Console::timeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
         auto nano = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now());
         double endTimeStamp = nano.time_since_epoch().count();
-        double startTimeStamp = itTimersMap->second;
-
-        it->second.erase(label);
 
         double diffMicroseconds = endTimeStamp - startTimeStamp;
         double diffMilliseconds = diffMicroseconds / 1000.0;
@@ -604,19 +621,7 @@ void Console::timeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
     }
 }
 
-void Console::onDisposeIsolate(v8::Isolate* isolate) {
-    s_isolateToConsoleTimersMap.erase(isolate);
-
-    std::lock_guard<std::mutex> lock(inspectMutex);
-    auto it = isolateToInspect.find(isolate);
-    if (it != isolateToInspect.end()) {
-        delete it->second;
-        isolateToInspect.erase(it);
-    }
-}
-
 const char* Console::LOG_TAG = "JS";
-std::map<v8::Isolate*, std::map<std::string, double>> Console::s_isolateToConsoleTimersMap;
 ConsoleCallback Console::m_callback = nullptr;
 int Console::m_maxLogcatObjectSize;
 }

--- a/test-app/runtime/src/main/cpp/console/Console.h
+++ b/test-app/runtime/src/main/cpp/console/Console.h
@@ -31,7 +31,6 @@ class Console {
         static void timeCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static void timeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 
-        static void onDisposeIsolate(v8::Isolate* isolate);
 
         // Builds this realm's inspect function if it isn't there yet. Public
         // so ns:util can re-export the same instance.
@@ -43,7 +42,6 @@ class Console {
         static int m_maxLogcatObjectSize;
         static ConsoleCallback m_callback;
         static const char* LOG_TAG;
-        static std::map<v8::Isolate*, std::map<std::string, double>> s_isolateToConsoleTimersMap;
 
         static void initInspect(v8::Local<v8::Context> context);
 

--- a/test-app/runtime/src/main/cpp/napi/NapiEnv.cpp
+++ b/test-app/runtime/src/main/cpp/napi/NapiEnv.cpp
@@ -47,8 +47,7 @@ NapiEnv* NapiEnv::ForIsolate(Isolate* isolate) {
   // Read the isolate slot directly: the Runtime::GetRuntime* accessors throw
   // NativeScriptException when the slot is unset, and a C++ exception must
   // not cross the extern "C" Node-API surface this is called under.
-  Runtime* runtime = static_cast<Runtime*>(
-      isolate->GetData((uint32_t)Runtime::IsolateData::RUNTIME));
+  Runtime* runtime = Runtime::TryGetRuntime(isolate);
   if (runtime == nullptr) {
     return nullptr;
   }


### PR DESCRIPTION
Crash and leak fixes around isolate/runtime lifetime. They share one invariant:

> **State bound to a runtime is owned by that runtime, and released on its own thread while its isolate is still alive.**

## 1. The crash this started from

The suite intermittently died with `SIGSEGV` — roughly **1 run in 5** — always in a `Worker` thread. Device tombstones for this app go back to **2026-07-26**, all in `W<n>: ./EvalWork` threads.

Reproduced and symbolized:

```
signal 11 (SIGSEGV), SEGV_MAPERR, fault addr 0x7100000000000072
tid 24248, name: W41: ./EvalWork
  #00 std::less<v8::Isolate*>::operator()
  #01-07 std::map<v8::Isolate*, std::map<std::string,double>>::insert   (__find_equal)
  #08 tns::Console::createConsole
  #09 tns::Runtime::PrepareV8Runtime
  #12 Java_com_tns_Runtime_initNativeScript
```

The fault address is not a pointer — it is freed red-black-tree node memory.

Several subsystems kept per-isolate state in **process-wide maps keyed by `v8::Isolate*`**. Keying by isolate does not make the *container* private: workers bootstrap on detached threads and `initNativeScript` holds no process-wide lock, so one runtime inserts its entry while another erases its own, and the container is corrupted mid-operation. **The isolate `Locker` does not help** — it is per-isolate, so two runtimes never exclude each other.

## 2. The fix: own the state, don't guard the container

`RuntimeState` is a typed, per-runtime slot bag owned by `Runtime`. A subsystem declares a state struct — usually in its own `.cpp` — and reaches it with `RuntimeState::For<MyState>(isolate)`. A lookup is an isolate data-slot read plus a vector index: no lock, no hash, **no shared container to race on**. The bag is destroyed once in `DestroyRuntime`, while the isolate is alive.

Moved onto it: `Console` (timer labels + the compiled `inspect.js`), `ArgConverter` (java-long helpers), `JSONObjectHelper` (the compiled serializer), `MetadataNode` (per-isolate node cache, array template, and the constructor functions).

- **`Console` now has no global mutable state and no mutex at all.**
- **Teardown's walk over every metadata node is gone.** `MetadataNode`'s constructor functions hung off each *shared* node as a map keyed by isolate, so `onDisposeIsolate` iterated all of `s_treeNode2NodeCache` — on a dying worker's thread, while other threads inserted — to erase one entry each.
- **Four `onDisposeIsolate` hooks deleted.** Nothing is keyed by isolate any more.

## 3. Use-after-free at teardown (a crash, not a leak)

`~Runtime` called `CallbackHandlers::RemoveIsolateEntries` and `FrameCallbacks::RemoveIsolateEntries`, whose entry destructors call `v8::Global::Reset()`. `~Runtime` runs **after** `isolate->Dispose()`, so those writes land in a freed handle table.

Worse, nothing dropped those entries earlier either: between `DestroyRuntime` and `~Runtime`, the main thread could pick up a queued `__runOnMainThread` entry and take a `v8::Locker` on an **already-disposed isolate** — a main-thread crash attributed to the wrong runtime. Both calls move into `DestroyRuntime`, which fixes the write-after-free and closes the window.

## 4. Leaks

- **`URLImpl` / `URLSearchParamsImpl` / `URLPatternImpl`** each carried a copy of the same weak-handle/finalizer block and freed themselves only from the GC finalizer. **V8 does not run weak callbacks at isolate disposal**, so every instance alive when a runtime died leaked its ada state — and `URLPattern` its compiled `v8::Global` regexps. They now share an `IsolateTracked` base: registered per runtime, deleted either by the GC finalizer or by `SweepAll` at teardown. Mirrors NativeScript/ios#438, with the registry in `RuntimeState` rather than `Caches`.
- **`PerIsolateV8Constants`** was never deleted — 19 handles per runtime. Its destructor was also missing `DISCARDED_ERROR_PERSISTENT` and only `Reset` the handles rather than freeing them; both fixed, since it now actually runs.
- **`m_context` and `m_gcFunc`** — never released.
- **The `com.tns.Runtime` JNI global ref** was never deleted, pinning the Java runtime object and every Java object the runtime had strongly registered through it, for the life of the process. Released in `~Runtime` — after `ObjectManager` teardown, which calls Java through that same object, and before the worker thread detaches.
- **`TypeLongOperationsCache`** was `delete`d without a destructor, leaking two `Persistent`s per isolate.
- **`~MetadataNodeCache` did not free the constructor caches.** `CtorCacheData::ft` and `ExtendedClassCacheData::extendedCtorFunction` are owning raw pointers, so each runtime leaked a `Persistent` and its global handle per materialized class and per `.extend()`. They are freed **from the maps**, not by giving those two structs destructors: both are stored *and returned* by value (`GetCachedExtendedClassData` returns a copy) and the copies share the pointers, so a struct destructor would turn every copy into a double free. (Raised in review.)

## 5. Still-shared caches that genuinely are shared

`MethodCache::s_mthod_ctor_signature_cache` and `JEnv::s_classCache`/`s_missingClasses` are string-keyed and hold only JNI handles, so sharing them across runtimes is correct — they just were not synchronized. Both now use a `std::shared_mutex`: shared for lookups (the common case on the Java-interop hot path), exclusive only to publish. The JNI work stays **outside** the lock, so `MethodCache` resolution calling `JEnv::FindClass` does not nest them; a double-resolve is idempotent and first-publish wins, with the loser releasing its global ref instead of leaking it.

## 6. `Runtime::TryGetRuntime`

Five subsystems had each grown a private "read the isolate slot because `GetRuntime` throws" workaround — three *identical* `GetRuntimeOrNull` helpers (`Performance.cpp`, `NativeScriptException.cpp`, `ErrorEvents.cpp`, comments copy-pasted verbatim) plus inline reads in `Events.cpp` and `FrameCallbacks.cpp`. They all share `Runtime::TryGetRuntime` now — non-throwing, no lock — which is also what makes `RuntimeState`'s lookup safe to call from a GC weak callback.

## Also fixed

`console.time` / `console.timeEnd` dereferenced the iterator from a failed `find()` — both had a `// throw?` comment on the not-found branch and then used the end iterator anyway.

## Verification

The runtime installs a SIGSEGV handler that **throws a C++ exception from a signal handler** (`Runtime.cpp:65-83`), which displaces debuggerd, so faults produce no tombstone and surface as `NativeScriptException: JNI Exception occurred (SIGSEGV)` — why this read as flaky tests for weeks. (Removed separately in #2007.)

Verification therefore runs with that handler **temporarily disabled** (not part of this PR), so every fault is fatal and tombstoned:

| Build | Full-suite runs | Crashes |
| --- | --- | --- |
| Before (main) | reproduced on iteration 5 of 20; 2 of 4 in earlier ad-hoc runs | ~1 in 5 |
| First cut of the fix (mutexes on the three caches) | 20 / 20 clean | 0 |
| Per-runtime rewrite, before the teardown fixes | 13 / 13 clean (stopped early to fold in more fixes) | 0 |
| Final tree | **20 / 20 clean** | **0** |

If the fault rate were unchanged, 20 consecutive clean runs would happen about 1% of the time. Suite is **879 / 0** throughout.

Every row was measured, none extrapolated.

> The first run of the final tree failed all 20 — `PerIsolateV8Constants` declares 20 handles but its constructor allocates 19 (`DEBUG_NAME_PERSISTENT` is never assigned), and the pre-existing destructor reset it unconditionally. That destructor had simply never run before, because the object was leaked rather than deleted; deleting it made the latent fault reachable. Every member is default-initialized now. CI caught the same thing independently, as a missing results file.

## Deliberately not in this PR

- **`ObjectManager` teardown** — it has no destructor at all, and with the default `none` marking mode the paths that would drain its maps never run (three of them are declared with no definition anywhere). A worker that touched Java objects leaks up to **1000 JNI weak global refs**; ART's weak-global table is bounded, so enough worker cycles turn this into an abort rather than a leak. It needs a two-phase sweep split across `DestroyRuntime` (V8 handles) and a new `~ObjectManager` (JNI refs), on the runtime's hottest path. **Stacked PR next.**
- **Completing `~MetadataNodeCache`** (`CtorFuncCache`, `ExtendedCtorFuncCache`, and the `External`-attached PODs). `ExtendedClassCacheData` is copied by value into its map while holding a raw `Persistent*`, so adding a destructor to the struct turns every copy into a double-free — it must be freed from the map instead. Goes with the ObjectManager PR.
- **`NativeScriptException::m_javascriptException`** — the raw pointer is handed to Java as a `jlong` and reclaimed later, so fixing it changes a cross-language ownership contract.
- **`HMRSupport`'s three path-keyed global maps** — same cross-isolate shape as the ES-module registry, which #1965 is already reworking.
- **The three `MetadataNode` static node caches** and the metadata tree / `MetadataReader` buffers — genuinely process-wide, so they need a narrow lock rather than per-runtime storage, and `GetOrCreateTreeNodeByName` mutates them *while calling into Java*, which makes a coarse lock hazardous.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime cleanup and resource management during isolate shutdown.
  * Reduced the risk of stale data, memory leaks, and crashes during teardown.
  * Improved thread safety for shared caches and concurrent runtime operations.
  * Strengthened lifecycle handling for JavaScript-backed native objects and console timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->