### PR TITLE
fix: restore native tombstones and record runtime crash breadcrumbs

### DIFF
--- a/test-app/app/src/main/assets/app/tests/exceptionHandlingTests.js
+++ b/test-app/app/src/main/assets/app/tests/exceptionHandlingTests.js
@@ -319,19 +319,4 @@ describe("Tests exception handling ", function () {
 	    expect(errMsg).toContain("SyntaxError: Unexpected token 'class'");
 	    expect(errMsg).toContain("File: (file:///data/data/com.tns.testapplication/files/app/tests/syntaxErrors.js:3:4)");
 	});
-
-   // run this test only for API level bigger than 25 as we have handling there
-   if(android.os.Build.VERSION.SDK_INT > 25 && android.os.Build.CPU_ABI != "x86" && android.os.Build.CPU_ABI != "x86_64") {
-       xit("Should handle SIGABRT and throw a NativeScript exception when incorrectly calling JNI methods", function () {
-           let myClassInstance = new com.tns.tests.MyTestBaseClass3();
-           // public void callMeWithAString(java.lang.String[] stringArr, Runnable arbitraryInterface)
-           try {
-               myClassInstance.callMeWithAString("stringVal", new java.lang.Runnable({ run: () => {} }))
-           } catch (e) {
-               android.util.Log.d("~~~~~", "~~~~~~~~ " + e.toString());
-
-               expect(e.toString()).toContain("SIGABRT");
-           }
-       });
-   }
 });

--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library(
         src/main/cpp/CallbackHandlers.cpp
         src/main/cpp/ConcurrentQueue.cpp
         src/main/cpp/Constants.cpp
+        src/main/cpp/CrashBreadcrumbs.cpp
         src/main/cpp/DirectBuffer.cpp
         src/main/cpp/ErrorEvents.cpp
         src/main/cpp/EventLoop.cpp

--- a/test-app/runtime/src/main/cpp/CrashBreadcrumbs.cpp
+++ b/test-app/runtime/src/main/cpp/CrashBreadcrumbs.cpp
@@ -1,0 +1,286 @@
+#include "CrashBreadcrumbs.h"
+
+#include <android/log.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+
+namespace {
+
+constexpr size_t kMaxRuntimes = 16;
+constexpr size_t kFieldMax = 160;
+constexpr size_t kBufferMax = 8192;
+constexpr size_t kHeaderMax = 128;
+
+struct Slot {
+  bool used;
+  bool isWorker;
+  int runtimeId;
+  int tid;
+  char script[kFieldMax];
+  char module[kFieldMax];
+};
+
+Slot g_slots[kMaxRuntimes];
+std::mutex g_mutex;
+
+/*
+ * Rendered in two buffers alternately, so the signal handler never reads the
+ * one a running thread is part way through writing.
+ */
+char g_rendered[2][kBufferMax];
+size_t g_renderedLength[2];
+std::atomic<int> g_active{-1};
+
+int g_storeFd = -1;
+std::atomic_flag g_recorded = ATOMIC_FLAG_INIT;
+struct sigaction g_previous[NSIG];
+
+thread_local Slot* t_slot = nullptr;
+
+int CurrentTid() { return static_cast<int>(syscall(__NR_gettid)); }
+
+void CopyField(char* dst, const char* src) {
+  if (src == nullptr) {
+    dst[0] = '\0';
+    return;
+  }
+  size_t length = strlen(src);
+  if (length < kFieldMax) {
+    memcpy(dst, src, length + 1);
+    return;
+  }
+  // Keep the tail: the file name identifies a module, the leading directories
+  // are shared by every module in the app.
+  memcpy(dst, "...", 3);
+  memcpy(dst + 3, src + length - (kFieldMax - 4), kFieldMax - 4);
+  dst[kFieldMax - 1] = '\0';
+}
+
+void Append(char* out, size_t& length, const char* format, ...)
+    __attribute__((format(printf, 3, 4)));
+
+void Append(char* out, size_t& length, const char* format, ...) {
+  if (length >= kBufferMax) {
+    return;
+  }
+  va_list args;
+  va_start(args, format);
+  int written = vsnprintf(out + length, kBufferMax - length, format, args);
+  va_end(args);
+  if (written > 0) {
+    length += static_cast<size_t>(written);
+    if (length > kBufferMax - 1) {
+      length = kBufferMax - 1;
+    }
+  }
+}
+
+void RenderLocked() {
+  int next = g_active.load(std::memory_order_relaxed) == 0 ? 1 : 0;
+  char* out = g_rendered[next];
+  size_t length = 0;
+
+  Append(out, length, "NativeScript runtime state (pid %d):\n", getpid());
+  for (const Slot& slot : g_slots) {
+    if (!slot.used) {
+      continue;
+    }
+    Append(out, length, "  runtime=%d tid=%d %s", slot.runtimeId, slot.tid,
+           slot.isWorker ? "worker" : "main");
+    if (slot.script[0] != '\0') {
+      Append(out, length, " script=%s", slot.script);
+    }
+    Append(out, length, " module=%s\n",
+           slot.module[0] != '\0' ? slot.module : "<none>");
+  }
+
+  g_renderedLength[next] = length;
+  g_active.store(next, std::memory_order_release);
+}
+
+Slot* FindLocked(int runtimeId) {
+  for (Slot& slot : g_slots) {
+    if (slot.used && slot.runtimeId == runtimeId) {
+      return &slot;
+    }
+  }
+  return nullptr;
+}
+
+/* Async-signal-safe integer formatting; snprintf is not usable here. */
+void AppendRaw(char* out, size_t capacity, size_t& length, const char* text) {
+  while (*text != '\0' && length < capacity) {
+    out[length++] = *text++;
+  }
+}
+
+void AppendRawInt(char* out, size_t capacity, size_t& length, int value) {
+  char digits[16];
+  size_t count = 0;
+  unsigned int magnitude = static_cast<unsigned int>(value);
+  do {
+    digits[count++] = static_cast<char>('0' + magnitude % 10);
+    magnitude /= 10;
+  } while (magnitude != 0 && count < sizeof(digits));
+  while (count > 0 && length < capacity) {
+    out[length++] = digits[--count];
+  }
+}
+
+void Handler(int signalNumber, siginfo_t* info, void* context) {
+  // Only the first thread to fault records; the rest are already doomed.
+  if (!g_recorded.test_and_set()) {
+    int fd = g_storeFd;
+    if (fd >= 0) {
+      char header[kHeaderMax];
+      size_t length = 0;
+      AppendRaw(header, sizeof(header), length, "fatal signal ");
+      AppendRawInt(header, sizeof(header), length, signalNumber);
+      AppendRaw(header, sizeof(header), length, " on tid ");
+      AppendRawInt(header, sizeof(header), length, CurrentTid());
+      AppendRaw(header, sizeof(header), length, "\n");
+
+      ssize_t written = pwrite(fd, header, length, 0);
+      int active = g_active.load(std::memory_order_acquire);
+      if (written > 0 && active >= 0) {
+        pwrite(fd, g_rendered[active], g_renderedLength[active], written);
+      }
+    }
+  }
+
+  /*
+   * Hand the signal to whoever owned it before us -- on Android that is
+   * debuggerd, which writes the tombstone.
+   *
+   * A signal the kernel raised for a real fault arrives again on its own once
+   * this returns and the faulting instruction re-executes, so debuggerd is
+   * entered with the kernel's original siginfo instead of anything
+   * synthesised here. One that was delivered by abort() or kill() (si_code
+   * <= 0) will not come back, so it has to be re-raised explicitly.
+   */
+  sigaction(signalNumber, &g_previous[signalNumber], nullptr);
+  if (info == nullptr || info->si_code <= 0) {
+    raise(signalNumber);
+  }
+}
+
+}  // namespace
+
+namespace tns {
+
+void CrashBreadcrumbs::Install() {
+  static std::once_flag once;
+  std::call_once(once, [] {
+    struct sigaction action = {};
+    action.sa_sigaction = Handler;
+    // SA_ONSTACK matters for a stack-overflow SIGSEGV, which has no room left
+    // on the faulting stack to run a handler. bionic already gives every
+    // thread an alternate signal stack, so the flag is all that is needed.
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&action.sa_mask);
+    for (int signalNumber : {SIGSEGV, SIGABRT, SIGBUS, SIGILL, SIGFPE}) {
+      sigaction(signalNumber, &action, &g_previous[signalNumber]);
+    }
+  });
+}
+
+void CrashBreadcrumbs::OpenStore(const std::string& filesRoot) {
+  static std::once_flag once;
+  std::call_once(once, [&filesRoot] {
+    std::string path = filesRoot + "/.ns-crash-breadcrumb";
+    int fd = open(path.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, 0600);
+    if (fd < 0) {
+      return;
+    }
+
+    char previous[kBufferMax + kHeaderMax];
+    ssize_t length = read(fd, previous, sizeof(previous) - 1);
+    if (length > 0) {
+      previous[length] = '\0';
+      // Deliberately not ANDROID_LOG_FATAL: liblog feeds a fatal record to
+      // android_set_abort_message, and bionic keeps the first message it is
+      // given for the life of the process. Claiming that slot here would
+      // describe the *previous* process in this one's tombstone, and would
+      // shut out the abort message libc or ART writes for the real fault.
+      __android_log_print(
+          ANDROID_LOG_ERROR, "TNS.Native",
+          "The previous process was killed by a fatal signal. Runtime state "
+          "recorded at that moment (match tid against the tombstone in "
+          "/data/tombstones):\n%s",
+          previous);
+      ftruncate(fd, 0);
+    }
+
+    g_storeFd = fd;
+  });
+}
+
+void CrashBreadcrumbs::RegisterRuntime(int runtimeId) {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  Slot* slot = FindLocked(runtimeId);
+  if (slot == nullptr) {
+    for (Slot& candidate : g_slots) {
+      if (!candidate.used) {
+        slot = &candidate;
+        break;
+      }
+    }
+  }
+  if (slot == nullptr) {
+    // Table full. Keep the runtimes already tracked rather than evicting one.
+    return;
+  }
+
+  slot->used = true;
+  slot->isWorker = false;
+  slot->runtimeId = runtimeId;
+  slot->tid = CurrentTid();
+  slot->script[0] = '\0';
+  slot->module[0] = '\0';
+  t_slot = slot;
+  RenderLocked();
+}
+
+void CrashBreadcrumbs::UnregisterRuntime(int runtimeId) {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  Slot* slot = FindLocked(runtimeId);
+  if (slot == nullptr) {
+    return;
+  }
+  if (t_slot == slot) {
+    t_slot = nullptr;
+  }
+  slot->used = false;
+  RenderLocked();
+}
+
+void CrashBreadcrumbs::SetWorkerScript(int runtimeId, const char* script) {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  Slot* slot = FindLocked(runtimeId);
+  if (slot == nullptr) {
+    return;
+  }
+  slot->isWorker = true;
+  CopyField(slot->script, script);
+  RenderLocked();
+}
+
+void CrashBreadcrumbs::SetCurrentModule(const char* modulePath) {
+  Slot* slot = t_slot;
+  if (slot == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(g_mutex);
+  CopyField(slot->module, modulePath);
+  RenderLocked();
+}
+
+}  // namespace tns

--- a/test-app/runtime/src/main/cpp/CrashBreadcrumbs.cpp
+++ b/test-app/runtime/src/main/cpp/CrashBreadcrumbs.cpp
@@ -39,7 +39,7 @@ char g_rendered[2][kBufferMax];
 size_t g_renderedLength[2];
 std::atomic<int> g_active{-1};
 
-int g_storeFd = -1;
+std::atomic<int> g_storeFd{-1};
 std::atomic_flag g_recorded = ATOMIC_FLAG_INIT;
 struct sigaction g_previous[NSIG];
 
@@ -84,6 +84,11 @@ void Append(char* out, size_t& length, const char* format, ...) {
 }
 
 void RenderLocked() {
+  // Once a crash is recorded the handler may be reading either buffer; a
+  // second flip after that point would rewrite the one it is copying out.
+  if (g_recorded.test(std::memory_order_acquire)) {
+    return;
+  }
   int next = g_active.load(std::memory_order_relaxed) == 0 ? 1 : 0;
   char* out = g_rendered[next];
   size_t length = 0;
@@ -138,7 +143,7 @@ void AppendRawInt(char* out, size_t capacity, size_t& length, int value) {
 void Handler(int signalNumber, siginfo_t* info, void* context) {
   // Only the first thread to fault records; the rest are already doomed.
   if (!g_recorded.test_and_set()) {
-    int fd = g_storeFd;
+    int fd = g_storeFd.load(std::memory_order_acquire);
     if (fd >= 0) {
       char header[kHeaderMax];
       size_t length = 0;
@@ -219,7 +224,7 @@ void CrashBreadcrumbs::OpenStore(const std::string& filesRoot) {
       ftruncate(fd, 0);
     }
 
-    g_storeFd = fd;
+    g_storeFd.store(fd, std::memory_order_release);
   });
 }
 
@@ -273,13 +278,25 @@ void CrashBreadcrumbs::SetWorkerScript(int runtimeId, const char* script) {
   RenderLocked();
 }
 
-void CrashBreadcrumbs::SetCurrentModule(const char* modulePath) {
+CrashBreadcrumbs::ModuleScope::ModuleScope(const char* modulePath) {
   Slot* slot = t_slot;
   if (slot == nullptr) {
     return;
   }
   std::lock_guard<std::mutex> lock(g_mutex);
+  previous_ = slot->module;
+  restore_ = true;
   CopyField(slot->module, modulePath);
+  RenderLocked();
+}
+
+CrashBreadcrumbs::ModuleScope::~ModuleScope() {
+  Slot* slot = t_slot;
+  if (!restore_ || slot == nullptr) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(g_mutex);
+  CopyField(slot->module, previous_.c_str());
   RenderLocked();
 }
 

--- a/test-app/runtime/src/main/cpp/CrashBreadcrumbs.h
+++ b/test-app/runtime/src/main/cpp/CrashBreadcrumbs.h
@@ -1,0 +1,45 @@
+#ifndef CRASHBREADCRUMBS_H_
+#define CRASHBREADCRUMBS_H_
+
+#include <string>
+
+namespace tns {
+
+/*
+ * Records what each runtime thread was doing, so a process killed by a fatal
+ * signal leaves behind more than a native backtrace.
+ *
+ * The state is rendered into a plain byte buffer as it changes, on ordinary
+ * threads. At crash time the only work left is a write(2) of that buffer,
+ * which is one of the few calls POSIX permits from a signal handler --
+ * anything that allocates, takes a lock or formats has already happened.
+ */
+class CrashBreadcrumbs {
+ public:
+  /*
+   * Installs SIGSEGV/SIGABRT/SIGBUS/SIGILL/SIGFPE handlers that record the
+   * breadcrumb and then hand the signal back to the handler installed before
+   * them, so debuggerd still writes the tombstone. Idempotent.
+   */
+  static void Install();
+
+  /*
+   * Points the store at the app's files directory and reports whatever a
+   * previous process left behind. Idempotent, so every runtime may call it.
+   */
+  static void OpenStore(const std::string& filesRoot);
+
+  /* Binds the calling thread to a runtime for that runtime's lifetime. */
+  static void RegisterRuntime(int runtimeId);
+  static void UnregisterRuntime(int runtimeId);
+
+  /* Marks a registered runtime as a worker started from `script`. */
+  static void SetWorkerScript(int runtimeId, const char* script);
+
+  /* Records the module the calling runtime is about to execute. */
+  static void SetCurrentModule(const char* modulePath);
+};
+
+}  // namespace tns
+
+#endif /* CRASHBREADCRUMBS_H_ */

--- a/test-app/runtime/src/main/cpp/CrashBreadcrumbs.h
+++ b/test-app/runtime/src/main/cpp/CrashBreadcrumbs.h
@@ -36,8 +36,22 @@ class CrashBreadcrumbs {
   /* Marks a registered runtime as a worker started from `script`. */
   static void SetWorkerScript(int runtimeId, const char* script);
 
-  /* Records the module the calling runtime is about to execute. */
-  static void SetCurrentModule(const char* modulePath);
+  /*
+   * Records the module the calling runtime is executing for the lifetime of
+   * the scope. Module loads nest (`require` inside a module body), so the
+   * enclosing module is restored on destruction, on throw paths included.
+   */
+  class ModuleScope {
+   public:
+    explicit ModuleScope(const char* modulePath);
+    ~ModuleScope();
+    ModuleScope(const ModuleScope&) = delete;
+    ModuleScope& operator=(const ModuleScope&) = delete;
+
+   private:
+    std::string previous_;
+    bool restore_ = false;
+  };
 };
 
 }  // namespace tns

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -364,7 +364,7 @@ Local<Object> ModuleInternal::LoadImpl(Isolate* isolate, const string& moduleNam
 Local<Object> ModuleInternal::LoadModule(Isolate* isolate, const string& modulePath, const string& moduleCacheKey) {
     string frameName("LoadModule " + modulePath);
     tns::instrumentation::Frame frame(frameName);
-    CrashBreadcrumbs::SetCurrentModule(modulePath.c_str());
+    CrashBreadcrumbs::ModuleScope moduleBreadcrumb(modulePath.c_str());
     Local<Object> result;
 
     auto context = isolate->GetCurrentContext();

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -13,6 +13,7 @@
 #include "V8GlobalHelpers.h"
 #include "NativeScriptAssert.h"
 #include "Constants.h"
+#include "CrashBreadcrumbs.h"
 #include "NativeScriptException.h"
 #include "NsBuiltinModules.h"
 #include "napi/NapiModules.h"
@@ -363,6 +364,7 @@ Local<Object> ModuleInternal::LoadImpl(Isolate* isolate, const string& moduleNam
 Local<Object> ModuleInternal::LoadModule(Isolate* isolate, const string& modulePath, const string& moduleCacheKey) {
     string frameName("LoadModule " + modulePath);
     tns::instrumentation::Frame frame(frameName);
+    CrashBreadcrumbs::SetCurrentModule(modulePath.c_str());
     Local<Object> result;
 
     auto context = isolate->GetCurrentContext();

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -5,7 +5,6 @@
 #include <unistd.h>
 
 #include <chrono>
-#include <csignal>
 #include <mutex>
 #include <sstream>
 #include <thread>
@@ -15,6 +14,7 @@
 #include "BuiltinLoader.h"
 #include "CallbackHandlers.h"
 #include "Constants.h"
+#include "CrashBreadcrumbs.h"
 #include "ErrorEvents.h"
 #include "Events.h"
 #include "File.h"
@@ -62,26 +62,6 @@ using namespace tns;
 bool tns::LogEnabled = true;
 SimpleAllocator g_allocator;
 
-void SIG_handler(int sigNumber) {
-  stringstream msg;
-  msg << "JNI Exception occurred (";
-  switch (sigNumber) {
-    case SIGABRT:
-      msg << "SIGABRT";
-      break;
-    case SIGSEGV:
-      msg << "SIGSEGV";
-      break;
-    default:
-      // Shouldn't happen, but for completeness
-      msg << "Signal #" << sigNumber;
-      break;
-  }
-  msg << ").\n=======\nCheck the 'adb logcat' for additional information about "
-         "the error.\n=======\n";
-  throw NativeScriptException(msg.str());
-}
-
 void LogAndAbortUncaught() {
   try {
     throw;  // rethrow the current unknown
@@ -113,15 +93,8 @@ void Runtime::Init(JavaVM* vm, void* reserved) {
     JEnv::Init(s_jvm);
   }
 
-  // handle SIGABRT/SIGSEGV only on API level > 20 as the handling is not so
-  // efficient in older versions
-  if (m_androidVersion > 20) {
-    struct sigaction action = {};
-    action.sa_handler = SIG_handler;
-    sigemptyset(&action.sa_mask);
-    sigaction(SIGABRT, &action, NULL);
-    sigaction(SIGSEGV, &action, NULL);
-  }
+  CrashBreadcrumbs::Install();
+
   // Set terminate handler for uncaught exceptions
   std::set_terminate(LogAndAbortUncaught);
 }
@@ -256,6 +229,11 @@ void Runtime::Init(JNIEnv* env, jstring filesPath, jstring nativeLibDir,
   auto nativeLibDirStr = ArgConverter::jstringToString(nativeLibDir);
   auto packageNameStr = ArgConverter::jstringToString(packageName);
   auto callingDirStr = ArgConverter::jstringToString(callingDir);
+
+  // Runs on this runtime's own thread, for the main runtime and for workers
+  // alike, so the calling thread is the one the breadcrumb should name.
+  CrashBreadcrumbs::OpenStore(filesRoot);
+  CrashBreadcrumbs::RegisterRuntime(m_id);
 
   Constants::APP_ROOT_FOLDER_PATH = filesRoot + "/app/";
   // read config options passed from Java
@@ -928,6 +906,7 @@ double Runtime::PerformanceNowMillis() {
 }
 
 void Runtime::DestroyRuntime() {
+  CrashBreadcrumbs::UnregisterRuntime(m_id);
   {
     std::lock_guard<std::mutex> lock(s_runtimeCacheMutex);
     s_id2RuntimeCache.erase(m_id);

--- a/test-app/runtime/src/main/cpp/WorkerWrapper.cpp
+++ b/test-app/runtime/src/main/cpp/WorkerWrapper.cpp
@@ -7,6 +7,7 @@
 
 #include "ArgConverter.h"
 #include "CallbackHandlers.h"
+#include "CrashBreadcrumbs.h"
 #include "JEnv.h"
 #include "JniLocalRef.h"
 #include "NativeScriptAssert.h"
@@ -353,6 +354,7 @@ void WorkerWrapper::BackgroundLooper(std::shared_ptr<WorkerWrapper> self) {
             runtimeId = env.CallStaticIntMethod(RUNTIME_CLASS, INIT_WORKER_RUNTIME_METHOD_ID,
                                                 workerId_, (jstring) callingDir);
             runtime_ = Runtime::GetRuntime(runtimeId);
+            CrashBreadcrumbs::SetWorkerScript(runtimeId, workerPath_.c_str());
 
             {
                 std::lock_guard<std::mutex> lock(looperMutex_);


### PR DESCRIPTION
## Problem

`SIG_handler` was installed for SIGABRT and SIGSEGV and **threw a `NativeScriptException` from inside the signal handler**. That is undefined behaviour: the unwinder cannot cross the kernel-built signal frame, so on arm64 the throw reached `std::terminate` → `LogAndAbortUncaught` → `_Exit(EXIT_FAILURE)` and the process died anyway. Installing `sa_handler` for SIGSEGV also displaced debuggerd, so **no tombstone was written** — no backtrace, no registers, no fault address.

A crash produced exactly this, and nothing else:

```
TNS.Native: Uncaught NativeScriptException: Exception Message: JNI Exception occurred (SIGSEGV).
TNS.Native: =======
TNS.Native: Check the 'adb logcat' for additional information about the error.
TNS.Native: =======
```

So the handler bought nothing: it destroyed the diagnostics *and* still crashed. This is why a genuine worker data race read as flaky tests for weeks (#2006).

## What changed

A diagnostic-only handler that never throws. It writes a pre-rendered breadcrumb with a single `write(2)` and hands the signal back to whoever owned it before, so **debuggerd still writes the tombstone** with the kernel's original `siginfo`.

- State is rendered into a plain byte buffer on ordinary threads whenever it changes, double-buffered so the handler never reads a half-written one. The handler does two `pwrite(2)`s to a pre-opened fd and chains — no allocation, no lock, no JNI, no V8, no logging.
- Installed `SA_SIGINFO | SA_ONSTACK`. No alt stack is allocated: bionic already gives every thread one, and `SA_ONSTACK` is what makes a stack-overflow SIGSEGV survivable.
- Chaining restores the previous disposition and *returns*, letting the faulting instruction re-fault so debuggerd sees the kernel's original siginfo rather than a synthesized one. Signals with `si_code <= 0` (abort/kill) cannot re-fault and are re-raised instead.
- `std::set_terminate(LogAndAbortUncaught)` is unchanged — that one is the legitimate handler for genuine uncaught C++ exceptions and already `_Exit()`s.

**Cost:** a mutex + `snprintf` over ≤16 slots per runtime create/destroy, worker start, and module load. Module load already does file I/O and compilation, so this sits far below its noise floor. ~31 KB of static buffers and one fd. Nothing on any hot path; zero steady-state cost.

## Design decision: not `android_set_abort_message`

`android_set_abort_message` was the obvious candidate and was tested first. It **does** reach SIGSEGV tombstones, not just SIGABRT (confirmed on API 35) — but bionic is **first-write-wins**: a probe set three messages and the tombstone showed the first.

That rules it out. A breadcrumb has to update as the runtime moves, and a write-once slot freezes at startup state. Worse, claiming that slot means libc's fortify/assert messages and ART's Java-crash messages can no longer be recorded — we would be *destroying* diagnostics to add our own.

That same finding caught a bug in the first cut of this change: the breadcrumb was reported with `ANDROID_LOG_FATAL`, and liblog feeds fatal records to `android_set_abort_message`, so it silently squatted the slot and surfaced as the `Abort message:` of the *next* process's tombstone. It now logs at `ERROR`, with the constraint documented in the code.

## Before / after

**Before:** the four logcat lines above, no tombstone. (Known prior behaviour on `main`, reported from a real crash — not a measurement re-taken for this PR.)

**After**, induced SIGSEGV on a worker thread — full tombstone, correct fault address, symbolized backtrace:

```
pid: 15027, tid: 15180, name: W54: ./eventLoo  >>> com.tns.testapplication <<<
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000000000000
Cause: null pointer dereference
backtrace:
  #00 ... libNativeScript.so (tns::ModuleInternal::LoadModule(...)+372)
  #01 ... libNativeScript.so (tns::ModuleInternal::LoadImpl(...)+2404)
  #02 ... libNativeScript.so (tns::ModuleInternal::RequireCallbackImpl(...)+4900)
  #03 ... libNativeScript.so (tns::ModuleInternal::RequireCallback(...)+456)
  #04 ... libNativeScript.so (Builtins_CallApiCallbackGeneric+104)
```

plus the breadcrumb, reported on next launch:

```
fatal signal 11 on tid 15180
NativeScript runtime state (pid 15027):
  runtime=0  tid=15027 main   module=.../app/shared/Require/ResolveCanonicalPath/second.js
  runtime=23 tid=15107 worker script=./EvalWorker.js          module=.../app/shared/Workers/EvalWorker.js
  runtime=48 tid=15180 worker script=./eventLoopEchoWorker.js module=.../app/tests/eventLoopEchoWorker.js
```

tid 15180 matches the tombstone's crashing thread, whose name the tombstone truncates to `W54: ./eventLoo` — the breadcrumb supplies the full worker script and the module it was in.

**SIGABRT** verified separately: `signal 6 (SIGABRT), code -6 (SI_TKILL)`, backtrace through `abort` → `LoadModule`, breadcrumb pid/tid matching the tombstone exactly.

## Behaviour change, and why there is no opt-out

Fatal signals now surface as real native crashes instead of being converted into JS exceptions, so apps that were "surviving" these will now report them (Play Console / Crashlytics included). That is the point.

No opt-out flag is offered deliberately: the old path never actually kept the app running on arm64 — the throw could not unwind out of the signal frame, so it always reached `_Exit`. There is no "limps on" behaviour to preserve, only "dies opaquely, without a tombstone". An opt-out would be a supported switch that re-enables undefined behaviour and re-disables tombstones. If a specific app regresses, the fault it was hiding is the thing to fix.

The disabled `exceptionHandlingTests` spec asserting that a JNI misuse yields a catchable `"SIGABRT"` exception is removed along with the behaviour it documented.

## Testing

**878 tests / 0 failures / 0 errors / 4 skipped** on the final commit-clean APK. No tombstone during the run and the breadcrumb file was 0 bytes afterwards — no false positives.

The 879 → 878 delta is exactly the deleted `xit` spec: disabled specs still count toward jasmine's total (skipped went 5 → 4). No test regressed.

## Not verified

- The "before" snippet is the known prior behaviour, not a measurement re-taken on `main` for this PR.
- Everything was verified on **one arm64 API 35 emulator**. `android_set_abort_message`'s first-write-wins behaviour and debuggerd's abort-message printing could differ on older releases — neither is load-bearing for the shipped design, but the tombstone-chaining is, and that is proven only on API 35.
- **WASM trap handler interaction.** V8 installs its own SIGSEGV handler for WASM traps. This is safe by construction — `Install()` runs at `JNI_OnLoad`, before V8 init, so V8's handler sits ahead of ours and recoverable traps never reach us — and the WASM specs pass, but a deliberate WASM out-of-bounds trap was not constructed to prove it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added crash breadcrumbs capturing runtime, worker script, module, signal, and thread information.
  * Crash context is persisted and recovered across launches to improve diagnostics after unexpected failures.

* **Bug Fixes**
  * Improved fatal-crash handling while preserving existing signal behavior.
  * Removed obsolete platform- and architecture-specific gating for the skipped crash test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->