### PR TITLE
Route Java to JS calls to the runtime that created the binding

### DIFF
--- a/test-app/app/src/main/assets/app/tests/testsForRuntimeBindingGenerator.js
+++ b/test-app/app/src/main/assets/app/tests/testsForRuntimeBindingGenerator.js
@@ -109,9 +109,9 @@ describe("Tests for runtime binding generator", function () {
 
         var interfaces = clazz.getInterfaces();
 
-        var expectedInterfaces = ["java.util.jar.Pack200$Packer", "java.util.Formattable", "java.util.Observer", "java.util.jar.Pack200$Unpacker", "com.tns.NativeScriptHashCodeProvider"];
+        var expectedInterfaces = ["java.util.jar.Pack200$Packer", "java.util.Formattable", "java.util.Observer", "java.util.jar.Pack200$Unpacker", "com.tns.NativeScriptHashCodeProvider", "com.tns.NativeScriptRuntimeBound"];
 
-        expect(interfaces.length).toBe(5);
+        expect(interfaces.length).toBe(6);
 
         for(var i = 0; i < interfaces.length; i++) {
             var interfaceName = interfaces[i].getName().toString();
@@ -168,9 +168,9 @@ describe("Tests for runtime binding generator", function () {
 
             var interfaces = clazz.getInterfaces();
 
-            var expectedInterfaces = ["java.util.jar.Pack200$Packer", "java.util.Formattable", "java.util.Observer", "java.util.jar.Pack200$Unpacker", "com.tns.NativeScriptHashCodeProvider"];
+            var expectedInterfaces = ["java.util.jar.Pack200$Packer", "java.util.Formattable", "java.util.Observer", "java.util.jar.Pack200$Unpacker", "com.tns.NativeScriptHashCodeProvider", "com.tns.NativeScriptRuntimeBound"];
 
-            expect(interfaces.length).toBe(5);
+            expect(interfaces.length).toBe(6);
 
             for(var i = 0; i < interfaces.length; i++) {
                 var interfaceName = interfaces[i].getName().toString();

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
@@ -448,6 +448,8 @@ public class Generator {
             String normalizedClassName = BcelNamingUtil.resolveClassName(clazz.getClassName());
             fieldsWriter.writeStaticThizField(normalizedClassName);
         }
+
+        fieldsWriter.writeRuntimeIdField();
     }
 
     private void writeConstructorsToWriter(Writer writer, JavaClass clazz, DataRow dataRow, String generatedClassName, GenericHierarchyView genericHierarchyView) {
@@ -523,6 +525,7 @@ public class Generator {
 
         methodsWriter.writeInternalRuntimeHashCodeMethod();
         methodsWriter.writeInternalRuntimeEqualsMethod();
+        methodsWriter.writeInternalRuntimeIdAccessorMethods();
     }
 
     /**

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/FieldsWriter.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/FieldsWriter.java
@@ -2,4 +2,5 @@ package org.nativescript.staticbindinggenerator.generating.writing;
 
 public interface FieldsWriter extends JavaCodeWriter {
     void writeStaticThizField(String className);
+    void writeRuntimeIdField();
 }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/MethodsWriter.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/MethodsWriter.java
@@ -8,5 +8,6 @@ public interface MethodsWriter extends JavaCodeWriter {
     void writeGetInstanceMethod(String className);
     void writeInternalRuntimeEqualsMethod();
     void writeInternalRuntimeHashCodeMethod();
+    void writeInternalRuntimeIdAccessorMethods();
     void writeInternalServiceOnCreateMethod();
 }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/ClassWriterImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/ClassWriterImpl.java
@@ -11,6 +11,7 @@ public class ClassWriterImpl implements ClassWriter {
     private static final String PUBLIC_CLASS_KEYWORD = "public class";
     private static final String JAVASCRIPT_IMPLEMENTATION_FILE_NAME_PATTERN = "@com.tns.JavaScriptImplementation(javaScriptFile = \"./%s\")";
     private static final String NATIVESCRIPT_HASHCODE_PROVIDER_INTERFACE_NAME = "com.tns.NativeScriptHashCodeProvider";
+    private static final String NATIVESCRIPT_RUNTIME_BOUND_INTERFACE_NAME = "com.tns.NativeScriptRuntimeBound";
     private static final String NOT_EXTENDING_ANY_CLASS_MESSAGE = "Not extending any class!";
 
     private final Writer writer;
@@ -42,6 +43,9 @@ public class ClassWriterImpl implements ClassWriter {
         writer.write(IMPLEMENTS_KEYWORD);
         writer.write(SPACE_LITERAL);
         writer.write(NATIVESCRIPT_HASHCODE_PROVIDER_INTERFACE_NAME);
+        writer.write(COMMA_LITERAL);
+        writer.write(SPACE_LITERAL);
+        writer.write(NATIVESCRIPT_RUNTIME_BOUND_INTERFACE_NAME);
 
         if (!isEmpty(implementedInterfacesNames) && !isEmpty(implementedInterfacesNames.get(0))) {
             writer.write(COMMA_LITERAL);

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/FieldsWriterImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/FieldsWriterImpl.java
@@ -7,11 +7,19 @@ public class FieldsWriterImpl implements FieldsWriter {
 
 
     private static final String THIZ_KEYWORD = "thiz";
+    private static final String RUNTIME_ID_FIELD_DECLARATION = "private int runtimeId__ns = com.tns.NativeScriptRuntimeBound.INVALID_RUNTIME_ID;";
 
     private final Writer writer;
 
     public FieldsWriterImpl(final Writer writer) {
         this.writer = writer;
+    }
+
+    @Override
+    public void writeRuntimeIdField() {
+        writer.write(TABULATION_LITERAL);
+        writer.writeln(RUNTIME_ID_FIELD_DECLARATION);
+        writer.writeln();
     }
 
     @Override

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/MethodsWriterImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/MethodsWriterImpl.java
@@ -47,6 +47,10 @@ public class MethodsWriterImpl implements MethodsWriter {
 
     private static final String INTERNAL_RUNTIME_EQUALS_METHOD_SIGNATURE = "public boolean equals__super(java.lang.Object other)";
     private static final String INTERNAL_RUNTIME_HASHCODE_METHOD_SIGNATURE = "public int hashCode__super()";
+    private static final String INTERNAL_RUNTIME_GET_RUNTIME_ID_METHOD_SIGNATURE = "public int getRuntimeId__ns()";
+    private static final String INTERNAL_RUNTIME_GET_RUNTIME_ID_RETURN_STATEMENT = "return runtimeId__ns;";
+    private static final String INTERNAL_RUNTIME_SET_RUNTIME_ID_METHOD_SIGNATURE = "public void setRuntimeId__ns(int runtimeId)";
+    private static final String INTERNAL_RUNTIME_SET_RUNTIME_ID_ASSIGNMENT = "runtimeId__ns = runtimeId;";
     private static final String INTERNAL_SERVICES_ONCREATE_METHOD_SIGNATURE = "public void " + ON_CREATE_METHOD_NAME + "()";
 
     private static final String RETURN_KEYWORD = "return";
@@ -369,7 +373,7 @@ public class MethodsWriterImpl implements MethodsWriter {
         if (shouldSuppressCallJsMethodExceptions) {
             writer.write(CLOSING_CURLY_BRACKET_LITERAL);
             writer.write(GENERIC_CATCH_BLOCK_BEGINNING);
-            writer.writeln("\t\t\tcom.tns.Runtime.passSuppressedExceptionToJs(throwable, \"" + methodName + "\");");
+            writer.writeln("\t\t\tcom.tns.Runtime.passSuppressedExceptionToJs(this, throwable, \"" + methodName + "\");");
             writer.writeln(ANDROID_LOG_METHOD_CALL_STATEMENT);
 
             if (!returnType.equals(Type.VOID)) {
@@ -396,6 +400,12 @@ public class MethodsWriterImpl implements MethodsWriter {
     @Override
     public void writeInternalRuntimeHashCodeMethod() {
         writeInternalRuntimeMethod(INTERNAL_RUNTIME_HASHCODE_METHOD_SIGNATURE, INTERNAL_RUNTIME_HASHCODE_METHOD_RETURN_STATEMENT);
+    }
+
+    @Override
+    public void writeInternalRuntimeIdAccessorMethods() {
+        writeInternalRuntimeMethod(INTERNAL_RUNTIME_GET_RUNTIME_ID_METHOD_SIGNATURE, INTERNAL_RUNTIME_GET_RUNTIME_ID_RETURN_STATEMENT);
+        writeInternalRuntimeMethod(INTERNAL_RUNTIME_SET_RUNTIME_ID_METHOD_SIGNATURE, INTERNAL_RUNTIME_SET_RUNTIME_ID_ASSIGNMENT);
     }
 
     private void writeInternalRuntimeMethod(String signature, String returnStatement) {

--- a/test-app/build-tools/static-binding-generator/src/test/java/android/util/Log.java
+++ b/test-app/build-tools/static-binding-generator/src/test/java/android/util/Log.java
@@ -1,0 +1,11 @@
+package android.util;
+
+/**
+ * Stub for compiling generated bindings in tests: the exception-suppressing
+ * variant emits a call to android.util.Log, which is not on the test classpath.
+ */
+public class Log {
+    public static int w(String tag, String msg) {
+        return 0;
+    }
+}

--- a/test-app/build-tools/static-binding-generator/src/test/java/com/tns/NativeScriptRuntimeBound.java
+++ b/test-app/build-tools/static-binding-generator/src/test/java/com/tns/NativeScriptRuntimeBound.java
@@ -1,0 +1,9 @@
+package com.tns;
+
+public interface NativeScriptRuntimeBound {
+    int INVALID_RUNTIME_ID = -1;
+
+    int getRuntimeId__ns();
+
+    void setRuntimeId__ns(int runtimeId);
+}

--- a/test-app/build-tools/static-binding-generator/src/test/java/com/tns/Runtime.java
+++ b/test-app/build-tools/static-binding-generator/src/test/java/com/tns/Runtime.java
@@ -5,4 +5,5 @@ public class Runtime {
     public static Object callJSMethod(Object javaObject, String methodName, Class<?> retType, Object... args) {
         return null;
     }
+    public static void passSuppressedExceptionToJs(Object instance, Throwable ex, String methodName) {}
 }

--- a/test-app/build-tools/static-binding-generator/src/test/java/org/nativescript/staticbindinggenerator/test/GeneratorTest.java
+++ b/test-app/build-tools/static-binding-generator/src/test/java/org/nativescript/staticbindinggenerator/test/GeneratorTest.java
@@ -53,7 +53,50 @@ public class GeneratorTest {
         Class<?> helloClass = InMemoryJavaCompiler.compile(binding.getClassname(), sourceCode.toString(), options);
 
         Assert.assertNotNull(helloClass);
-        Assert.assertEquals(3, helloClass.getDeclaredMethods().length);
+        Assert.assertEquals(5, helloClass.getDeclaredMethods().length);
+    }
+
+    @Test
+    public void testCanCompileBindingWithSuppressedCallJsMethodExceptions() throws Exception {
+        List<String> lines = Utils.getDataRowsFromResource("datarow-named-extend.txt");
+        DataRow dataRow = new DataRow(lines.get(0));
+
+        File outputDir = null;
+        List<DataRow> libs = new ArrayList<>();
+        Generator generator = new Generator(outputDir, libs, true);
+        Binding binding = generator.generateBinding(dataRow);
+        Assert.assertNotNull(binding);
+
+        String sourceCode = binding.getContent();
+        Assert.assertTrue(sourceCode.contains("com.tns.Runtime.passSuppressedExceptionToJs(this,"));
+
+        Iterable<String> options = new ArrayList<String>(Arrays.asList("-cp", dependenciesDir));
+        Class<?> helloClass = InMemoryJavaCompiler.compile(binding.getClassname(), sourceCode, options);
+
+        Assert.assertNotNull(helloClass);
+    }
+
+    @Test
+    public void testBindingCarriesItsOwningRuntimeId() throws Exception {
+        List<String> lines = Utils.getDataRowsFromResource("datarow-named-extend.txt");
+        DataRow dataRow = new DataRow(lines.get(0));
+
+        File outputDir = null;
+        List<DataRow> libs = new ArrayList<>();
+        Generator generator = new Generator(outputDir, libs);
+        Binding binding = generator.generateBinding(dataRow);
+        Assert.assertNotNull(binding);
+
+        Iterable<String> options = new ArrayList<String>(Arrays.asList("-cp", dependenciesDir));
+        Class<?> boundClass = InMemoryJavaCompiler.compile(binding.getClassname(), binding.getContent(), options);
+
+        Assert.assertTrue(com.tns.NativeScriptRuntimeBound.class.isAssignableFrom(boundClass));
+
+        com.tns.NativeScriptRuntimeBound instance = (com.tns.NativeScriptRuntimeBound) boundClass.newInstance();
+        Assert.assertEquals(com.tns.NativeScriptRuntimeBound.INVALID_RUNTIME_ID, instance.getRuntimeId__ns());
+
+        instance.setRuntimeId__ns(7);
+        Assert.assertEquals(7, instance.getRuntimeId__ns());
     }
 
     @Test
@@ -79,7 +122,7 @@ public class GeneratorTest {
         Class<?> helloClass = InMemoryJavaCompiler.compile("com.tns.gen.com.example.MyInterface", sourceCode.toString(), options);
 
         Assert.assertNotNull(helloClass);
-        Assert.assertEquals(3, helloClass.getDeclaredMethods().length);  // 3 methods (includes 'hashCode__super' and 'equals__super')
+        Assert.assertEquals(5, helloClass.getDeclaredMethods().length);  // 5 methods (includes 'hashCode__super', 'equals__super', 'getRuntimeId__ns' and 'setRuntimeId__ns')
     }
 
     @Test
@@ -100,7 +143,7 @@ public class GeneratorTest {
         Class<?> ComplexClass = InMemoryJavaCompiler.compile(binding.getClassname(), sourceCode.toString(), options);
 
         Assert.assertNotNull(ComplexClass);
-        Assert.assertEquals(3, ComplexClass.getInterfaces().length); // 2 + 1 (hashcodeprovider)
+        Assert.assertEquals(4, ComplexClass.getInterfaces().length); // 2 + hashcodeprovider + runtimebound
     }
 
     @Test
@@ -127,7 +170,7 @@ public class GeneratorTest {
         Class<?> ComplexClass = InMemoryJavaCompiler.compile(binding.getClassname(), sourceCode.toString(), options);
 
         Assert.assertNotNull(ComplexClass);
-        Assert.assertEquals(4, ComplexClass.getDeclaredMethods().length); // 1 + constructor + (equals + hashcode)
+        Assert.assertEquals(6, ComplexClass.getDeclaredMethods().length); // 1 + constructor + (equals + hashcode) + (getRuntimeId__ns + setRuntimeId__ns)
     }
 
     @Test

--- a/test-app/runtime-binding-generator/src/main/java/com/tns/NativeScriptRuntimeBound.java
+++ b/test-app/runtime-binding-generator/src/main/java/com/tns/NativeScriptRuntimeBound.java
@@ -1,0 +1,24 @@
+package com.tns;
+
+/**
+ * Implemented by generated binding classes so that a Java-&gt;JS call can be routed
+ * to the runtime that created the instance rather than inferred from the calling
+ * thread.
+ *
+ * The runtime id is written once, by the runtime that registers the instance, and
+ * is never reassigned: an instance may later be wrapped by other runtimes (each
+ * keeps its own object-id map), but only the creating runtime holds the JS
+ * implementation the generated overrides dispatch to.
+ */
+public interface NativeScriptRuntimeBound {
+    /**
+     * Not 0: that is a real runtime id (the main runtime's), and JsV8InspectorClient
+     * hard-codes it as such. Implementations must therefore seed the backing field
+     * rather than rely on its natural zero default.
+     */
+    int INVALID_RUNTIME_ID = -1;
+
+    int getRuntimeId__ns();
+
+    void setRuntimeId__ns(int runtimeId);
+}

--- a/test-app/runtime-binding-generator/src/main/java/com/tns/bindings/Dump.java
+++ b/test-app/runtime-binding-generator/src/main/java/com/tns/bindings/Dump.java
@@ -23,6 +23,7 @@ public class Dump {
     static final String runtimeClass = LCOM_TNS_RUNTIME;
     static final String callJSMethodName = "callJSMethod";
     static final String initInstanceMethodName = "initInstance";
+    static final String RUNTIME_ID_FIELD_NAME = "runtimeId__ns";
 
     static final StringBuffer methodDescriptorBuilder = new StringBuffer();
 
@@ -449,6 +450,8 @@ public class Dump {
             mv.visitMethodInsn(org.ow2.asmdex.Opcodes.INSN_INVOKE_DIRECT_RANGE, objectClass, "<init>", ctorSignature, args);
         }
 
+        generateRuntimeIdInitialization(mv, thisRegister, tnsClassSignature);
+
         if (!isApplicationClass(classTo)) {
             generateInitializedBlock(mv, thisRegister, classSignature, tnsClassSignature);
         }
@@ -473,6 +476,20 @@ public class Dump {
                            { 3, 1, 2, 0 }); //invoke callJSMethod(this, "init", true, params)
     }
 
+    /*
+     * Seeds runtimeId__ns with NativeScriptRuntimeBound.INVALID_RUNTIME_ID, which a
+     * dex field's zero default does not give us - 0 is the main runtime's id. Runs
+     * as early as a constructor can touch the instance, which still leaves the
+     * superclass constructor above it reading 0; a proxied method called from there
+     * resolves to the main runtime, finds no object id registered, and reports that
+     * instead. It cannot run earlier: the verifier rejects field access on an
+     * uninitialized reference.
+     */
+    private void generateRuntimeIdInitialization(MethodVisitor mv, int thisRegister, String tnsClassSignature) {
+        mv.visitVarInsn(org.ow2.asmdex.Opcodes.INSN_CONST_4, thisRegister - 1, -1);
+        mv.visitFieldInsn(org.ow2.asmdex.Opcodes.INSN_IPUT, tnsClassSignature, RUNTIME_ID_FIELD_NAME, "I", thisRegister - 1, thisRegister);
+    }
+
     private void generateInitializedBlock(MethodVisitor mv, int thisRegister, String classSignature, String tnsClassSignature) {
         mv.visitFieldInsn(org.ow2.asmdex.Opcodes.INSN_IGET_BOOLEAN, tnsClassSignature, "__initialized", "Z", thisRegister - 2, thisRegister); //put __initialized in local var 1
         Label label = new Label();
@@ -493,6 +510,28 @@ public class Dump {
 
         generateEqualsSuper(cv);
         generateHashCodeSuper(cv);
+        generateGetRuntimeId(cv, tnsClassSignature);
+        generateSetRuntimeId(cv, tnsClassSignature);
+    }
+
+    // 2 registers, 1 parameter: 'this' takes the last one, v0 is left as scratch
+    private void generateGetRuntimeId(ClassVisitor cv, String tnsClassSignature) {
+        MethodVisitor mv = cv.visitMethod(org.ow2.asmdex.Opcodes.ACC_PUBLIC, "getRuntimeId__ns", "I", null, null);
+        mv.visitCode();
+        mv.visitMaxs(2, 0);
+        mv.visitFieldInsn(org.ow2.asmdex.Opcodes.INSN_IGET, tnsClassSignature, RUNTIME_ID_FIELD_NAME, "I", 0, 1);
+        mv.visitIntInsn(org.ow2.asmdex.Opcodes.INSN_RETURN, 0);
+        mv.visitEnd();
+    }
+
+    // 2 registers, 2 parameters: v0 is 'this' and v1 the id, leaving no scratch
+    private void generateSetRuntimeId(ClassVisitor cv, String tnsClassSignature) {
+        MethodVisitor mv = cv.visitMethod(org.ow2.asmdex.Opcodes.ACC_PUBLIC, "setRuntimeId__ns", "VI", null, null);
+        mv.visitCode();
+        mv.visitMaxs(2, 0);
+        mv.visitFieldInsn(org.ow2.asmdex.Opcodes.INSN_IPUT, tnsClassSignature, RUNTIME_ID_FIELD_NAME, "I", 1, 0);
+        mv.visitInsn(org.ow2.asmdex.Opcodes.INSN_RETURN_VOID);
+        mv.visitEnd();
     }
 
     private void generateEqualsSuper(ClassVisitor cv) {
@@ -804,10 +843,14 @@ public class Dump {
     private void generateFields(ClassVisitor cv) {
         FieldVisitor fv = cv.visitField(org.ow2.asmdex.Opcodes.ACC_PRIVATE, "__initialized", "Z", null, null);
         fv.visitEnd();
+
+        // seeded per constructor, see generateRuntimeIdInitialization
+        fv = cv.visitField(org.ow2.asmdex.Opcodes.ACC_PRIVATE, RUNTIME_ID_FIELD_NAME, "I", null, null);
+        fv.visitEnd();
     }
 
-    static final String[] classImplentedInterfaces = new String[] { "Lcom/tns/NativeScriptHashCodeProvider;" };
-    static final String[] interfaceImplementedInterfaces = new String[] { "Lcom/tns/NativeScriptHashCodeProvider;", "" };
+    static final String[] classImplentedInterfaces = new String[] { "Lcom/tns/NativeScriptHashCodeProvider;", "Lcom/tns/NativeScriptRuntimeBound;" };
+    static final String[] interfaceImplementedInterfaces = new String[] { "Lcom/tns/NativeScriptHashCodeProvider;", "Lcom/tns/NativeScriptRuntimeBound;", "" };
 
     private ClassVisitor generateClass(ApplicationWriter aw, ClassDescriptor classTo, String classSignature, String tnsClassSignature, HashSet<ClassDescriptor> implementedInterfaces, AnnotationDescriptor[] annotations) {
         ClassVisitor cv;
@@ -817,7 +860,7 @@ public class Dump {
         ArrayList<String> interfacesToImplement = new ArrayList(Arrays.asList(classImplentedInterfaces));
 
         if (classTo.isInterface()) {
-            interfaceImplementedInterfaces[1] = classSignature; //new String[] { "Lcom/tns/NativeScriptHashCodeProvider;", classSignature };
+            interfaceImplementedInterfaces[interfaceImplementedInterfaces.length - 1] = classSignature;
             for (String interfaceToImpl : interfaceImplementedInterfaces) {
                 if (!interfacesToImplement.contains(interfaceToImpl)) {
                     interfacesToImplement.add(interfaceToImpl);

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -124,12 +124,51 @@ public class Runtime {
         passExceptionToJsNative(getRuntimeId(), ex, ex.getMessage(), Runtime.getStackTraceErrorMessage(ex), Runtime.getJSStackTrace(ex), true);
     }
 
+    /**
+     * Retained for bindings generated before the instance-carrying overload; the
+     * calling thread's runtime is only a guess at where the exception belongs.
+     */
     public static void passSuppressedExceptionToJs(Throwable ex, String methodName) {
-        com.tns.Runtime runtime = com.tns.Runtime.getCurrentRuntime();
-        if (runtime != null) {
-            String errorMessage = "Error on \"" + Thread.currentThread().getName() + "\" thread for " + methodName + "\n";
-            runtime.passDiscardedExceptionToJs(ex, "");
+        passSuppressedExceptionToJs(null, ex, methodName);
+    }
+
+    public static void passSuppressedExceptionToJs(Object instance, Throwable ex, String methodName) {
+        com.tns.Runtime runtime = null;
+
+        if (instance != null) {
+            int owningRuntimeId = getOwningRuntimeId(instance);
+            if (owningRuntimeId != NativeScriptRuntimeBound.INVALID_RUNTIME_ID) {
+                runtime = runtimeCache.get(owningRuntimeId);
+            }
         }
+
+        if (runtime == null) {
+            runtime = com.tns.Runtime.getCurrentRuntime();
+        }
+
+        if (runtime != null) {
+            runtime.postDiscardedExceptionToJs(ex);
+        }
+    }
+
+    /*
+     * Reports on the owning runtime's thread without waiting: the caller has
+     * already swallowed the exception and has no result to collect. A runtime
+     * whose looper is gone simply drops the report - throwing out of an
+     * error-reporting path would replace a suppressed exception with a live one.
+     */
+    private void postDiscardedExceptionToJs(final Throwable ex) {
+        if (config.appConfig.getEnableMultithreadedJavascript() || threadScheduler.getThread().equals(Thread.currentThread())) {
+            passDiscardedExceptionToJs(ex, "");
+            return;
+        }
+
+        threadScheduler.post(new Runnable() {
+            @Override
+            public void run() {
+                passDiscardedExceptionToJs(ex, "");
+            }
+        });
     }
 
     private boolean initialized;
@@ -371,6 +410,35 @@ public class Runtime {
             return staticConfiguration.appConfig.getRemoteModuleAllowlistArray();
         }
         return new String[0];
+    }
+
+    /*
+     * Records which runtime a binding instance belongs to. Called once, from
+     * initInstance, by the runtime that registers the instance; later
+     * registrations in other runtimes (getOrCreateJavaObjectID when the instance
+     * crosses into another isolate) must not overwrite it, because only the
+     * creating runtime holds the JS implementation behind the generated overrides.
+     */
+    private static void recordOwningRuntime(Object instance, int runtimeId) {
+        if (instance instanceof NativeScriptRuntimeBound) {
+            NativeScriptRuntimeBound bound = (NativeScriptRuntimeBound) instance;
+            if (bound.getRuntimeId__ns() == NativeScriptRuntimeBound.INVALID_RUNTIME_ID) {
+                bound.setRuntimeId__ns(runtimeId);
+            }
+        }
+    }
+
+    /*
+     * The id of the runtime that created the instance, or INVALID_RUNTIME_ID for
+     * anything that does not carry one - bindings built by a generator older than
+     * this interface, and plain objects handed to callJSMethod directly. Note that
+     * a returned id may name a runtime that has since been torn down; callers
+     * decide how to report that.
+     */
+    private static int getOwningRuntimeId(Object javaObject) {
+        return (javaObject instanceof NativeScriptRuntimeBound)
+                ? ((NativeScriptRuntimeBound) javaObject).getRuntimeId__ns()
+                : NativeScriptRuntimeBound.INVALID_RUNTIME_ID;
     }
 
     private static Runtime getObjectRuntime(Object object) {
@@ -790,6 +858,14 @@ public class Runtime {
         try {
             Runtime runtime = Runtime.getCurrentRuntime();
 
+            if (runtime == null) {
+                throw new NativeScriptException("Cannot initialize an instance of " + instance.getClass().getName()
+                        + ": no NativeScript runtime is bound to thread \"" + Thread.currentThread().getName()
+                        + "\". Construct it on the runtime's own thread, or from JS.");
+            }
+
+            recordOwningRuntime(instance, runtime.getRuntimeId());
+
             int objectId = runtime.currentObjectId;
 
             if (objectId != -1) {
@@ -1152,15 +1228,35 @@ public class Runtime {
     }
 
     public static Object callJSMethod(Object javaObject, String methodName, Class<?> retType, boolean isConstructor, long delay, Object... args) throws NativeScriptException {
-        Runtime runtime = Runtime.getCurrentRuntime();
+        int owningRuntimeId = getOwningRuntimeId(javaObject);
+        Runtime runtime;
 
-        // if we're not in a runtime or the runtime we're in does not have the object, try to find the right one (this might happen if a worker fires a JS method on an object created in the main thread or another worker)
-        if (runtime == null || runtime.getJavaObjectID(javaObject) == null) {
-            runtime = getObjectRuntime(javaObject);
-        }
+        if (owningRuntimeId != NativeScriptRuntimeBound.INVALID_RUNTIME_ID) {
+            runtime = runtimeCache.get(owningRuntimeId);
 
-        if (runtime == null) {
-            throw new NativeScriptException("Cannot find runtime for instance=" + ((javaObject == null) ? "null" : javaObject));
+            if (runtime == null) {
+                // Naming the class rather than the instance: toString() may be one
+                // of the JS overrides, and calling it here would re-enter the
+                // runtime we just failed to reach.
+                return discardCall(methodName, retType, "an instance of " + javaObject.getClass().getName()
+                        + " outlived the runtime that created it (id=" + owningRuntimeId + ")");
+            }
+        } else {
+            // Nothing recorded the owner: fall back to the calling thread's
+            // runtime, then to whichever runtime holds the object. A wrapper in
+            // some runtime's map is only evidence that the object crossed into
+            // it, so this can pick a runtime that never implemented the method.
+            // Both generators stamp the id now, so this is for bindings built by
+            // an older one.
+            runtime = Runtime.getCurrentRuntime();
+
+            if (runtime == null || runtime.getJavaObjectID(javaObject) == null) {
+                runtime = getObjectRuntime(javaObject);
+            }
+
+            if (runtime == null) {
+                throw new NativeScriptException("Cannot find runtime for instance=" + ((javaObject == null) ? "null" : javaObject));
+            }
         }
 
         return runtime.callJSMethodImpl(javaObject, methodName, retType, isConstructor, delay, args);
@@ -1347,6 +1443,10 @@ public class Runtime {
                         ret = e;
                     }
                 }
+            } else {
+                // arr[0] stays null and primitive returns are defaulted below
+                logDiscardedCall(methodName, "runtime id=" + getRuntimeId() + " (workerId=" + workerId
+                        + ") is no longer accepting work");
             }
 
             ret = arr[0];
@@ -1360,6 +1460,25 @@ public class Runtime {
         }
 
         return ret;
+    }
+
+    private static void logDiscardedCall(String methodName, String reason) {
+        android.util.Log.w("Warning", "NativeScript discarding call to \"" + methodName + "\": " + reason);
+    }
+
+    /*
+     * A call with nowhere left to run is dropped rather than thrown. These arrive
+     * on Android callbacks - lifecycle, listeners, draw - where an exception would
+     * take down the process because a worker ended, so the loss is contained to
+     * the one call and reported through the log instead. Primitive returns still
+     * need a value the generated cast can unbox.
+     */
+    private static Object discardCall(String methodName, Class<?> retType, String reason) {
+        logDiscardedCall(methodName, reason);
+
+        return (retType != null && retType.isPrimitive() && retType != void.class)
+                ? defaultPrimitiveValue(retType)
+                : null;
     }
 
     private static Object defaultPrimitiveValue(Class<?> type) {


### PR DESCRIPTION
### Description

**Draft — opening this for design discussion before polishing.**

SBG generates real Java classes for JS code, but those classes carry no record of *which* runtime is using them. `com.tns.Runtime` therefore has to re-derive the target of every Java→JS call from the calling thread. Today that means, in order:

1. the `currentRuntime` thread-local,
2. the currently-entered V8 isolate (`getCurrentRuntimeId()`), which yields nothing on a plain Java callback thread (Binder, foreign `Handler`, executor),
3. `getObjectRuntime()` — a linear scan of every live runtime, probing each one's own object→id map until one contains the instance.

Three problems fall out of that.

**Ownership is inferred from the wrong signal.** The routing check is "does this runtime have an id for the object". But a wrapper only records that the instance *crossed into* that isolate, not that the isolate implements it. An instance created by one runtime and later passed into another exists in both maps, so a call can dispatch into an isolate that holds a wrapper but not the user's JS implementation.

**The owner scan is a data race.** With `enableMultithreadedJavascript` off (the default), `strongJavaObjectToID`/`weakJavaObjectToID` are plain `HashMap`/`NativeScriptHashMap`. `getObjectRuntime` reads *other* runtimes' maps from a foreign thread while their owning threads mutate them on every JS object creation and GC pass.

**Failures are undiagnosable.** `dispatchCallJSMethodNative` discarded the result of `threadScheduler.post()`: a post to a quitting worker looper returned `null` (or a zeroed primitive) to the caller with no log at all. `initInstance` dereferenced a possibly-null runtime, so constructing a binding off a runtime thread produced a bare NPE.

### What this changes

**Both** generators now emit `com.tns.NativeScriptRuntimeBound`, so every binding carries the id of the runtime that registered it:

- the **static** binding generator, in Java source;
- the **runtime** binding generator (`Dump.java`), which dexes the proxies behind `new java.lang.Runnable({...})` — the more common of the two — in asmdex, alongside the `__initialized` field and `equals__super` it already emits.

`initInstance` stamps the id **once**. Later registrations by other runtimes (`getOrCreateJavaObjectID`, when the instance crosses isolates) must not overwrite it, since only the creating runtime holds the JS implementation behind the generated overrides. Runtime ids are monotonic and never reused, so a stale id can never collide with a newer runtime.

`INVALID_RUNTIME_ID` is `-1`, so both generators seed the field rather than rely on its zero default — 0 is a real runtime id (the main runtime's). The dex proxies seed it as early as a constructor may touch the instance; it can't be earlier, since the verifier rejects field access on an uninitialized reference. A proxied method invoked from *within* a superclass constructor therefore still reads 0, resolves to the main runtime, finds no object id registered for the instance and reports that — where before the change the same call reported that no runtime held the instance. Both are errors; only the wording moves.

Bindings built by an older generator carry no id and keep the previous thread-based resolution, unchanged.

> **Side finding, not fixed here.** I first tried making `INVALID_RUNTIME_ID` 0 and starting runtime ids at 1, which would have removed the seeding entirely. That crashes the app at startup with `Cannot find runtime for id:0`, because `JsV8InspectorClient.cpp:853` does `Runtime::GetRuntime(0)` — the inspector hard-codes the assumption that the main runtime is id 0. Worth knowing about independently of this PR; it means runtime id 0 is load-bearing and undocumented.

A call with nowhere left to run is **dropped and logged**, not thrown. These arrive on Android callbacks — lifecycle, listeners, draw — so throwing would take down the process because a worker ended; the loss stays contained to the one call. Primitive returns reuse the existing default-value substitution so the generated cast can still unbox. That covers a call against a terminated owner (previously: scan and dispatch to whichever runtime happened to hold a wrapper) and a failed `post()` to a quitting looper (previously: already `null`, now at least logged).

`initInstance` is the one case that still throws. It dereferenced a null runtime, so constructing a binding off a runtime thread produced a bare NPE — already a crash, so this isn't a new one. Dropping there would leave an unregistered instance whose every later call fails anyway, further from the cause.

`passSuppressedExceptionToJs` routed by calling thread, so an exception suppressed on behalf of another runtime was reported to the wrong one — and the message it built was never actually passed to `passDiscardedExceptionToJs`. It now takes the instance, resolves the same owner, and reports on that runtime's own thread without blocking. The two-argument overload stays for already-generated bindings.

### Points I'd like review on

- **One inherited asymmetry.** A call whose owner has *terminated* is dropped, but the pre-existing "no runtime holds this object at all" path still throws `Cannot find runtime for instance=...` — untouched here, since it's long-standing behavior and a different condition (never a live binding, versus a lifecycle race a worker ending can legitimately cause). Happy to make it drop too if you'd rather it be uniform.
- **Hand-written asmdex** in `Dump.java` is the part most worth a careful read — mistakes there surface as dex verification failures at runtime, not compile errors. The two accessors mirror the register conventions of the existing `equals__super`/`hashCode__super` templates (parameters occupy the last registers), and the whole emulator suite exercises them, since essentially every listener in the specs is one of these proxies.
- **Dex cost**: two methods and one int field per generated binding class. Real but modest; flagging it for method-count budgets.
- **Runtime id numbering is unchanged**, deliberately — see the side finding above.
- **Native side is unchanged.** `Java_com_tns_Runtime_callJSMethodNative` still returns `nullptr` silently when `TryGetRuntime(runtimeId)` misses. The Java guard now covers the realistic window; what remains is a narrow TOCTOU race between the Java check and the JNI call. Throwing from there needs care (`ReThrowToJava` calls `Isolate::GetCurrent()`, which is exactly what is unavailable when the runtime is gone), so I left it out rather than guess.
- A call to an object owned by a terminated worker currently no-ops with a log. The other option is falling back to main, which I avoided: main holds a wrapper but not the worker's JS implementation, so it would run the wrong code rather than none.

### Related Pull Requests

None yet — iOS has the same static-binding shape and would want a matching change if this direction is accepted.

### Does your pull request have unit tests?

Yes, plus manual verification:

- `testsForRuntimeBindingGenerator.js` asserts the exact interface list of a runtime-generated proxy; updated for the added interface.
- `GeneratorTest` gains coverage that a generated binding implements `NativeScriptRuntimeBound`, defaults to `INVALID_RUNTIME_ID`, and round-trips the stamp; and that the exception-suppressing variant compiles and emits `passSuppressedExceptionToJs(this, ...)`. That path had no compile coverage before — it needed an `android.util.Log` test stub, added here.
- Existing SBG suites pass (19 tests).
- `:runtime:testDebugUnitTest` passes.
- Regenerated the test app's bindings end-to-end and compiled the whole app against them.
- Full Jasmine suite on an API 35 emulator, re-run after the drop-don't-throw revision: **124 suites, 879 tests, 0 failures, 0 errors, 4 skipped**. (`runtestsAndVerifyResults` itself aborts at `deletePreviousResultXml` on Play-image AVDs, which refuse `adb root`, so this was run by installing the debug APK and pulling the results XML via `run-as`.)
