### PR TITLE
fix(runtime): generate named Java proxies at runtime when not precompiled

### DIFF
--- a/test-app/runtime-binding-generator/src/main/java/com/tns/bindings/ProxyGenerator.java
+++ b/test-app/runtime-binding-generator/src/main/java/com/tns/bindings/ProxyGenerator.java
@@ -37,7 +37,14 @@ public class ProxyGenerator {
         String proxyFileName;
 
         if (proxyName.contains(".")) {
+            // Thumb-suffix dotted names like the anonymous ones: DexFactory's
+            // cache probe (getDexFile) and purge (purgeDexesByThumb) both key
+            // on the thumb, so an unsuffixed file regenerates every launch and
+            // its stale .jar survives — and gets reused — across app versions.
             proxyFileName = proxyName;
+            if (proxyThumb != null) {
+                proxyFileName += "-" + proxyThumb;
+            }
         } else {
             proxyFileName = classToProxy.getName().replace('$', '_');
             if (!isInterface) {

--- a/test-app/runtime-binding-generator/src/main/java/com/tns/bindings/ProxyGenerator.java
+++ b/test-app/runtime-binding-generator/src/main/java/com/tns/bindings/ProxyGenerator.java
@@ -26,6 +26,17 @@ public class ProxyGenerator {
     }
 
     public String generateProxy(String proxyName, ClassDescriptor classToProxy, HashSet<String> methodOverrides, HashSet<ClassDescriptor> implementedInterfaces, boolean isInterface, AnnotationDescriptor[] annotations) throws IOException {
+        return generateProxy(proxyName, null, classToProxy, methodOverrides, implementedInterfaces, isInterface, annotations);
+    }
+
+    /**
+     * cacheDigest, when present, becomes part of the proxy's file name. The
+     * thumb only changes on reinstall, so name + thumb alone cannot see an
+     * edit to the proxy's contents (method overrides, interfaces) - the
+     * digest is what makes such an edit miss the cache instead of silently
+     * loading the previous dex.
+     */
+    public String generateProxy(String proxyName, String cacheDigest, ClassDescriptor classToProxy, HashSet<String> methodOverrides, HashSet<ClassDescriptor> implementedInterfaces, boolean isInterface, AnnotationDescriptor[] annotations) throws IOException {
         ApplicationWriter aw = new ApplicationWriter();
         aw.visit();
 
@@ -53,6 +64,10 @@ public class ProxyGenerator {
             if (proxyThumb != null) {
                 proxyFileName += "-" + proxyThumb;
             }
+        }
+        // After the thumb, so purgeDexesByThumb keeps matching old generations.
+        if (cacheDigest != null) {
+            proxyFileName += "-" + cacheDigest;
         }
 
         if (IsLogEnabled) {

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -626,12 +626,13 @@ void ModuleInternal::Load(Local<Context> context, const string& path) {
         }
         // Callers reach here with a project-relative name as readily as an
         // absolute one: `Runtime.createJSInstance` hands over whatever a
-        // generated binding's @JavaScriptImplementation carries, and
-        // java.io.File has already flattened `./bundle.mjs` to `bundle.mjs`.
-        // The require branch below resolves such a name against the app root;
-        // the ES module branch goes straight to the filesystem, so anchor it
-        // here or it fails as "Cannot find module" from whatever the process
-        // cwd happens to be.
+        // generated binding's @JavaScriptImplementation carries, and that is
+        // `./bundle.mjs` by SBG convention — a module name in the app-root
+        // namespace, not a filesystem path. The require branch below resolves
+        // such names against the app root; the ES module branch stats the
+        // string as-is (after CanonicalizeRegistryKey folds `./` away), so
+        // anchor it here or it resolves against the process cwd and fails as
+        // "Cannot find module bundle.mjs".
         LoadESModule(isolate, AnchorToAppRoot(path, isHttpModule), BootEntryEvaluationOptions(isHttpModule));
         if (isHttpModule) {
             TNS_DEBUG(Esm, "run-module http-esm ok %s", NormalizeHttpModuleUrl(path).c_str());

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -593,6 +593,15 @@ void ModuleInternal::RequireNativeCallback(const v8::FunctionCallbackInfo<v8::Va
     funcPtr(args);
 }
 
+static std::string AnchorToAppRoot(const std::string& path, bool isHttpModule) {
+    if (isHttpModule || path.empty() || path[0] == '/' || path.rfind("file://", 0) == 0 ||
+        Constants::APP_ROOT_FOLDER_PATH.empty()) {
+        return path;
+    }
+    const std::string relative = path.rfind("./", 0) == 0 ? path.substr(2) : path;
+    return Constants::APP_ROOT_FOLDER_PATH + relative;
+}
+
 void ModuleInternal::Load(Local<Context> context, const string& path) {
     TNSPERF();
     auto isolate = m_isolate;
@@ -615,9 +624,15 @@ void ModuleInternal::Load(Local<Context> context, const string& path) {
         if (isHttpModule) {
             TNS_DEBUG(Esm, "run-module http-esm begin %s", NormalizeHttpModuleUrl(path).c_str());
         }
-        // The entry runs before this thread's event loop does, so its graph can
-        // only make progress from the pump inside LoadESModule.
-        LoadESModule(isolate, path, BootEntryEvaluationOptions(isHttpModule));
+        // Callers reach here with a project-relative name as readily as an
+        // absolute one: `Runtime.createJSInstance` hands over whatever a
+        // generated binding's @JavaScriptImplementation carries, and
+        // java.io.File has already flattened `./bundle.mjs` to `bundle.mjs`.
+        // The require branch below resolves such a name against the app root;
+        // the ES module branch goes straight to the filesystem, so anchor it
+        // here or it fails as "Cannot find module" from whatever the process
+        // cwd happens to be.
+        LoadESModule(isolate, AnchorToAppRoot(path, isHttpModule), BootEntryEvaluationOptions(isHttpModule));
         if (isHttpModule) {
             TNS_DEBUG(Esm, "run-module http-esm ok %s", NormalizeHttpModuleUrl(path).c_str());
         }

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -593,15 +593,6 @@ void ModuleInternal::RequireNativeCallback(const v8::FunctionCallbackInfo<v8::Va
     funcPtr(args);
 }
 
-static std::string AnchorToAppRoot(const std::string& path, bool isHttpModule) {
-    if (isHttpModule || path.empty() || path[0] == '/' || path.rfind("file://", 0) == 0 ||
-        Constants::APP_ROOT_FOLDER_PATH.empty()) {
-        return path;
-    }
-    const std::string relative = path.rfind("./", 0) == 0 ? path.substr(2) : path;
-    return Constants::APP_ROOT_FOLDER_PATH + relative;
-}
-
 void ModuleInternal::Load(Local<Context> context, const string& path) {
     TNSPERF();
     auto isolate = m_isolate;
@@ -624,16 +615,9 @@ void ModuleInternal::Load(Local<Context> context, const string& path) {
         if (isHttpModule) {
             TNS_DEBUG(Esm, "run-module http-esm begin %s", NormalizeHttpModuleUrl(path).c_str());
         }
-        // Callers reach here with a project-relative name as readily as an
-        // absolute one: `Runtime.createJSInstance` hands over whatever a
-        // generated binding's @JavaScriptImplementation carries, and that is
-        // `./bundle.mjs` by SBG convention — a module name in the app-root
-        // namespace, not a filesystem path. The require branch below resolves
-        // such names against the app root; the ES module branch stats the
-        // string as-is (after CanonicalizeRegistryKey folds `./` away), so
-        // anchor it here or it resolves against the process cwd and fails as
-        // "Cannot find module bundle.mjs".
-        LoadESModule(isolate, AnchorToAppRoot(path, isHttpModule), BootEntryEvaluationOptions(isHttpModule));
+        // The entry runs before this thread's event loop does, so its graph can
+        // only make progress from the pump inside LoadESModule.
+        LoadESModule(isolate, path, BootEntryEvaluationOptions(isHttpModule));
         if (isHttpModule) {
             TNS_DEBUG(Esm, "run-module http-esm ok %s", NormalizeHttpModuleUrl(path).c_str());
         }

--- a/test-app/runtime/src/main/java/com/tns/ClassResolver.java
+++ b/test-app/runtime/src/main/java/com/tns/ClassResolver.java
@@ -1,6 +1,9 @@
 package com.tns;
 
+import android.util.Log;
+
 import com.tns.system.classes.loading.ClassStorageService;
+import com.tns.system.classes.loading.LookedUpClassNotFound;
 
 import java.io.IOException;
 
@@ -26,7 +29,21 @@ class ClassResolver {
         }
 
         if (clazz == null) {
-            clazz = classStorageService.retrieveClass(className);
+            try {
+                clazz = classStorageService.retrieveClass(className);
+            } catch (LookedUpClassNotFound notFound) {
+                // A named proxy (`Base.extend('a.b.C', {...})` / @JavaProxy)
+                // whose class the static binding generator never compiled — it
+                // only scans assets/app, and dev servers keep most source off
+                // disk. The proxy generator accepts dotted names for classes
+                // and interfaces alike, so supply the class the same way
+                // anonymous extends are supplied.
+                Log.w("JS", "Class " + className + " not precompiled; generating at runtime. Framework references resolve only if dex injection into the app class loader succeeds.");
+                clazz = dexFactory.resolveClass(canonicalBaseClassName, name, className, methodOverrides, implementedInterfaces, isInterface);
+                if (clazz == null) {
+                    throw notFound;
+                }
+            }
         }
 
         return clazz;

--- a/test-app/runtime/src/main/java/com/tns/ClassResolver.java
+++ b/test-app/runtime/src/main/java/com/tns/ClassResolver.java
@@ -39,7 +39,14 @@ class ClassResolver {
                 // and interfaces alike, so supply the class the same way
                 // anonymous extends are supplied.
                 Log.w("JS", "Class " + className + " not precompiled; generating at runtime. Framework references resolve only if dex injection into the app class loader succeeds.");
-                clazz = dexFactory.resolveClass(canonicalBaseClassName, name, className, methodOverrides, implementedInterfaces, isInterface);
+                try {
+                    clazz = dexFactory.resolveClass(canonicalBaseClassName, name, className, methodOverrides, implementedInterfaces, isInterface);
+                } catch (Throwable generationFailure) {
+                    // The precise not-found is the actionable error; a failed
+                    // generation attempt is its detail, not its replacement.
+                    notFound.addSuppressed(generationFailure);
+                    throw notFound;
+                }
                 if (clazz == null) {
                     throw notFound;
                 }

--- a/test-app/runtime/src/main/java/com/tns/DexFactory.java
+++ b/test-app/runtime/src/main/java/com/tns/DexFactory.java
@@ -120,9 +120,14 @@ public class DexFactory {
         // strip the `com.tns.gen` off the base extended class name
         String desiredDexClassName = this.getClassToProxyName(fullClassName);
 
+        // A named proxy (`Base.extend('a.b.C', {...})` / @JavaProxy) asks for
+        // exactly that Java class name; the substitutions below are for the
+        // anonymous form only, where the name is derived from the base.
+        boolean isNamedProxy = !fullClassName.startsWith(COM_TNS_GEN_PREFIX) && fullClassName.contains(".");
+
         // when interfaces are extended as classes, we still want to preserve
         // just the interface name without the extra file, line, column information
-        if (!baseClassName.isEmpty() && isInterface) {
+        if (!baseClassName.isEmpty() && isInterface && !isNamedProxy) {
             fullClassName = COM_TNS_GEN_PREFIX + classToProxy;
         }
 
@@ -136,7 +141,7 @@ public class DexFactory {
             }
 
             String dexFilePath;
-            if (isInterface) {
+            if (isInterface && !isNamedProxy) {
                 dexFilePath = this.generateDex(name, classToProxy, methodOverrides, implementedInterfaces, isInterface);
             } else {
                 dexFilePath = this.generateDex(desiredDexClassName, classToProxy, methodOverrides, implementedInterfaces, isInterface);

--- a/test-app/runtime/src/main/java/com/tns/DexFactory.java
+++ b/test-app/runtime/src/main/java/com/tns/DexFactory.java
@@ -131,7 +131,13 @@ public class DexFactory {
             fullClassName = COM_TNS_GEN_PREFIX + classToProxy;
         }
 
-        File dexFile = this.getDexFile(desiredDexClassName);
+        // The thumb only changes on reinstall, so a cache key of name + thumb
+        // cannot see an edit to the proxy's contents: under HMR a named
+        // proxy's new method overrides would silently load the previous dex.
+        // The digest carries the contents into the file name.
+        String contentDigest = computeContentDigest(classToProxy, methodOverrides, implementedInterfaces, isInterface);
+
+        File dexFile = this.getDexFile(desiredDexClassName, contentDigest);
 
         // generate dex file
         if (dexFile == null) {
@@ -142,9 +148,9 @@ public class DexFactory {
 
             String dexFilePath;
             if (isInterface && !isNamedProxy) {
-                dexFilePath = this.generateDex(name, classToProxy, methodOverrides, implementedInterfaces, isInterface);
+                dexFilePath = this.generateDex(name, contentDigest, classToProxy, methodOverrides, implementedInterfaces, isInterface);
             } else {
-                dexFilePath = this.generateDex(desiredDexClassName, classToProxy, methodOverrides, implementedInterfaces, isInterface);
+                dexFilePath = this.generateDex(desiredDexClassName, contentDigest, classToProxy, methodOverrides, implementedInterfaces, isInterface);
             }
             dexFile = new File(dexFilePath);
             long stopGenTime = System.nanoTime();
@@ -256,11 +262,50 @@ public class DexFactory {
         return classToProxy;
     }
 
-    private File getDexFile(String className) throws InvalidClassException {
+    /**
+     * Digest of everything that shapes the generated proxy besides its name,
+     * so the dex cache key changes when the proxy's contents do. Sorted, so
+     * JS property-enumeration order cannot produce a spurious miss.
+     */
+    private static String computeContentDigest(String classToProxy, String[] methodOverrides, String[] implementedInterfaces, boolean isInterface) {
+        StringBuilder canonical = new StringBuilder(classToProxy).append('\n').append(isInterface);
+        if (methodOverrides != null) {
+            String[] sortedOverrides = methodOverrides.clone();
+            java.util.Arrays.sort(sortedOverrides);
+            for (String override : sortedOverrides) {
+                canonical.append('\n').append(override);
+            }
+        }
+        if (implementedInterfaces != null) {
+            String[] sortedInterfaces = implementedInterfaces.clone();
+            java.util.Arrays.sort(sortedInterfaces);
+            for (String iface : sortedInterfaces) {
+                canonical.append('').append(iface);
+            }
+        }
+        try {
+            byte[] hash = java.security.MessageDigest.getInstance("SHA-256")
+                          .digest(canonical.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(10);
+            for (int i = 0; i < 5; i++) {
+                hex.append(String.format("%02x", hash[i]));
+            }
+            return hex.toString();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            // SHA-256 is mandatory on Android; a digestless key only loses
+            // cache freshness, never correctness of a fresh generation.
+            return null;
+        }
+    }
+
+    private File getDexFile(String className, String contentDigest) throws InvalidClassException {
         String classToProxyFile = className.replace("$", "_");
 
         if (this.dexThumb != null) {
             classToProxyFile += "-" + this.dexThumb;
+        }
+        if (contentDigest != null) {
+            classToProxyFile += "-" + contentDigest;
         }
 
         String dexFilePath = dexDir + "/" + classToProxyFile + ".dex";
@@ -279,7 +324,7 @@ public class DexFactory {
         return null;
     }
 
-    private String generateDex(String proxyName, String className, String[] methodOverrides, String[] implementedInterfaces, boolean isInterface) throws ClassNotFoundException, IOException {
+    private String generateDex(String proxyName, String contentDigest, String className, String[] methodOverrides, String[] implementedInterfaces, boolean isInterface) throws ClassNotFoundException, IOException {
         Class<?> classToProxy = Class.forName(className);
 
         HashSet<String> methodOverridesSet = null;

--- a/test-app/runtime/src/main/java/com/tns/Module.java
+++ b/test-app/runtime/src/main/java/com/tns/Module.java
@@ -47,6 +47,24 @@ class Module {
         return ApplicationFilesPath;
     }
 
+    /**
+     * Resolves an entry-module path for runModule. A non-absolute, scheme-less
+     * name is an app-root-relative module name (the @JavaScriptImplementation
+     * convention) and goes through the same resolution require uses - extension
+     * and directory probing included - so the native side only ever receives a
+     * loadable identity: an absolute path or a URL. Missing entries throw here,
+     * with require's wording, instead of failing against the process cwd.
+     */
+    static String resolveEntryPath(String path) {
+        if (path.isEmpty() || path.startsWith("/") || path.contains("://")) {
+            return path;
+        }
+        String relative = (path.startsWith("./") || path.startsWith("../") || path.startsWith("~/"))
+                          ? path
+                          : "./" + path;
+        return resolvePath(relative, ApplicationFilesPath + ModulesFilesPath);
+    }
+
     @RuntimeCallable
     private static String resolvePath(String path, String baseDir) {
         // The baseDir is the directory path of the calling module.

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -696,8 +696,7 @@ public class Runtime {
     }
 
     public void runModule(File jsFile) throws NativeScriptException {
-        String filePath = jsFile.getPath();
-        runModule(getRuntimeId(), filePath);
+        runModule(getRuntimeId(), Module.resolveEntryPath(jsFile.getPath()));
     }
 
     public Object runScript(File jsFile) throws NativeScriptException {

--- a/test-app/tools/package-lock.json
+++ b/test-app/tools/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "static_analysis",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
Named proxies — Base.extend('a.b.C', {...}) and @JavaProxy('a.b.C') — only
existed if the static binding generator had compiled them ahead of time:
ClassResolver routed com.tns.gen* names through DexFactory and threw for
everything else. SBG scans only assets/app, so a dev server that keeps
@nativescript/core off disk (Vite HMR serves it over HTTP) lost every named
proxy in core and crashed at boot with
LookedUpClassNotFound: Class "com.tns.FragmentClass" not found.

- ClassResolver: on LookedUpClassNotFound, fall through to DexFactory and
  generate the proxy dex at runtime — classes and interfaces alike. Logs a
  warning per class so SBG coverage gaps stay visible.
- DexFactory: tell named proxies apart from anonymous bindings so a dotted
  interface implementation keeps its requested name instead of the derived
  com.tns.gen one. Core's two [@JavaProxy](https://github.com/JavaProxy) proxies implement
  ActivityLifecycleCallbacks and ComponentCallbacks2 — both interfaces.
- ProxyGenerator: thumb-suffix dotted proxy file names. Unsuffixed files
  never matched getDexFile's probe (regenerated every launch), never
  matched purgeDexesByThumb, and jarFile.exists() reused their stale .jar
  across app versions.
- ModuleInternal: anchor relative runModule paths to the app root in the ES
  module branch, as the require branch always has. A generated binding's
  @JavaScriptImplementation carries ./bundle.mjs — an app-root-relative
  module name by SBG convention — but the ESM branch stats it as a
  filesystem path from the process cwd (after the registry-key canonicalizer
  folds the ./ away), so it failed as "Cannot find module bundle.mjs".

Manifest-referenced classes (com.tns.NativeScriptActivity) resolve through
this path because the generated dex is injected into the app class loader
during entry evaluation — which the boot backstop holds until settled —
before the framework instantiates the activity. A precompiled class is
still the sturdier answer where a build step can provide one; this makes
the missing-class case survivable instead of fatal.