### PR TITLE
feat: close the remaining gaps against the merged iOS loader PR

### DIFF
--- a/test-app/app/src/main/assets/app/esm/scoped/inside/dynamic.mjs
+++ b/test-app/app/src/main/assets/app/esm/scoped/inside/dynamic.mjs
@@ -1,0 +1,6 @@
+// Dynamic import must consult the same scope as a static import from this
+// file: the host names the referrer by script origin, and that origin must
+// canonicalize to the registry key the scope prefixes match against.
+export function load() {
+    return import("ns-scoped-leaf");
+}

--- a/test-app/app/src/main/assets/app/tests/esmEntryNeverSettlesWorker.mjs
+++ b/test-app/app/src/main/assets/app/tests/esmEntryNeverSettlesWorker.mjs
@@ -1,0 +1,10 @@
+// An ES module worker entry that never finishes evaluating. The parent is told
+// the entry body started before the park, so its terminate() lands inside the
+// entry's bounded evaluation pump rather than after it.
+postMessage("never-settles:started");
+
+await new Promise(function () {});
+
+globalThis.onmessage = function () {
+    postMessage("never-settles:unreachable");
+};

--- a/test-app/app/src/main/assets/app/tests/testEsmHttpLoader.js
+++ b/test-app/app/src/main/assets/app/tests/testEsmHttpLoader.js
@@ -356,6 +356,29 @@ describe("HTTP ESM Loader", function () {
                     reportRejection(error, done);
                 });
             });
+
+            it("applies the referrer's scope to dynamic import()", function (done) {
+                // The host names a dynamic import's referrer by script origin
+                // (a file:// URL), not by registry key; the origin must land on
+                // the same canonical key the scope prefixes match, or scoped
+                // lookups silently fall through to top-level imports.
+                var insideScope = appRoot + "/esm/scoped/inside/";
+                var scopes = {};
+                scopes[insideScope] = { "ns-scoped-leaf": origin + "/esm/graph-leaf.mjs?k=in" };
+                setMap({
+                    imports: { "ns-scoped-leaf": origin + "/esm/graph-leaf.mjs?k=top" },
+                    scopes: scopes,
+                });
+
+                import("~/esm/scoped/inside/dynamic.mjs").then(function (mod) {
+                    return mod.load();
+                }).then(function (leafMod) {
+                    expect(leafMod.name).toBe("in");
+                    done();
+                }).catch(function (error) {
+                    reportRejection(error, done);
+                });
+            });
         });
 
         // An imperative API rejects bad input loudly, the way WebIDL does on the

--- a/test-app/app/src/main/assets/app/tests/testWorkerEsmEntry.js
+++ b/test-app/app/src/main/assets/app/tests/testWorkerEsmEntry.js
@@ -90,6 +90,58 @@ describe("worker ES module entries", function () {
         worker.postMessage("ping");
     });
 
+    // The worker isolate is published before its entry runs, so terminate()
+    // can interrupt an entry that is still evaluating - here one parked on a
+    // promise that never settles, inside the pump that waits for it.
+    it("survives terminate() while an entry is parked in top-level await", function (done) {
+        var ITERATIONS = 3;
+        var FALLBACK_TERMINATE = 700;
+        var SETTLE_AFTER = 700;
+        var errors = [];
+
+        function iteration(remaining) {
+            if (remaining === 0) {
+                expect(errors).toEqual([]);
+                // A worker spawned after the terminated ones still works.
+                var next = new Worker("~/tests/esmEntrySyncWorker.mjs");
+                next.onmessage = function (msg) {
+                    expect(msg.data).toBe("esm-entry:ping");
+                    next.terminate();
+                    done();
+                };
+                next.postMessage("ping");
+                return;
+            }
+
+            var worker = new Worker("./esmEntryNeverSettlesWorker.mjs");
+            var terminated = false;
+
+            function terminateOnce() {
+                if (terminated) {
+                    return;
+                }
+                terminated = true;
+                worker.terminate();
+                setTimeout(function () {
+                    iteration(remaining - 1);
+                }, SETTLE_AFTER);
+            }
+
+            worker.onerror = function (e) {
+                errors.push(String((e && e.message) || e));
+            };
+            worker.onmessage = function (msg) {
+                expect(msg.data).toBe("never-settles:started");
+                terminateOnce();
+            };
+            // The evaluation pump is bounded, so a start message that never
+            // arrives must not push the terminate past the window it targets.
+            setTimeout(terminateOnce, FALLBACK_TERMINATE);
+        }
+
+        iteration(ITERATIONS);
+    });
+
     // WHATWG parity: the worker's message queue is enabled when its entry
     // script finishes evaluating, and from then on messages dispatch whether
     // or not a handler exists. A handler registered later (from a timer)

--- a/test-app/app/src/main/assets/app/tests/testWorkerEsmEntry.js
+++ b/test-app/app/src/main/assets/app/tests/testWorkerEsmEntry.js
@@ -61,6 +61,20 @@ describe("worker ES module entries", function () {
         worker.postMessage("ping");
     });
 
+    // An http(s) worker specifier bypasses the filesystem check entirely: the
+    // entry is fetched, compiled and registered under its canonical URL key on
+    // the worker's own thread, which is also the key the settle gate probes.
+    it("runs a worker whose entry is an http URL", function (done) {
+        var origin = "http://127.0.0.1:" + com.tns.tests.ModuleTestServer.ensureStarted();
+        var worker = new Worker(origin + "/esm/worker-entry.mjs");
+        worker.onmessage = function (msg) {
+            expect(msg.data).toBe("http-worker-entry:ping");
+            worker.terminate();
+            done();
+        };
+        worker.postMessage("ping");
+    });
+
     // Extension resolution tries `.js` before `.mjs`, and no `.js` sibling
     // exists, so the ES module entry is what answers. Its top-level await also
     // parks past the yield window, so the message posted here proves the

--- a/test-app/app/src/main/java/com/tns/tests/ModuleTestServer.java
+++ b/test-app/app/src/main/java/com/tns/tests/ModuleTestServer.java
@@ -196,6 +196,23 @@ public final class ModuleTestServer {
             return;
         }
 
+        if ("/esm/worker-entry.mjs".equals(path)) {
+            // A worker entry served over HTTP, importing one relative dependency
+            // so the entry exercises the graph walk and not just the root fetch.
+            String body = "import { WORKER_TAG } from \"./worker-entry-dep.mjs\";\n"
+                    + "globalThis.onmessage = function (msg) {\n"
+                    + "    postMessage(WORKER_TAG + \":\" + msg.data);\n"
+                    + "};\n";
+            respond(socket, "200 OK", JS_MIME, body.getBytes(UTF8));
+            return;
+        }
+
+        if ("/esm/worker-entry-dep.mjs".equals(path)) {
+            String body = "export const WORKER_TAG = \"http-worker-entry\";\n";
+            respond(socket, "200 OK", JS_MIME, body.getBytes(UTF8));
+            return;
+        }
+
         if ("/esm/syntax-error.mjs".equals(path)) {
             // Deliberately unparseable: pins that the loader surfaces V8's real
             // compile error instead of a generic failure.

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -15,7 +15,9 @@
 #include <fstream>
 #include <cstdio>
 #include <chrono>
+#include "HttpLoader.h"
 #include "MethodCache.h"
+#include "ModuleInternal.h"
 #include "SimpleProfiler.h"
 #include "Runtime.h"
 #include "WorkerMessage.h"
@@ -1215,11 +1217,17 @@ void CallbackHandlers::NewThreadCallback(const v8::FunctionCallbackInfo<v8::Valu
 
         int priority = GetWorkerThreadPriority(isolate, context, args);
 
-        // TODO: Validate worker path and call worker.onerror if the script does not exist
+        // An http(s) entry has no filesystem form to validate or to resolve
+        // against the caller's directory: it is already absolute, and the
+        // module loader's HTTP branch fetches it on the worker's own thread
+        // under the same security gate every other remote load passes. The
+        // URL is what the worker registers its entry under, so it is also what
+        // the settle gate probes — it must reach the wrapper unrewritten.
+        const bool isHttpEntry = ModuleInternal::IsHttpModulePath(workerPath);
 
         // Resolve tilde paths before creating the worker
         std::string resolvedPath = workerPath;
-        if (!workerPath.empty() && workerPath[0] == '~') {
+        if (!isHttpEntry && !workerPath.empty() && workerPath[0] == '~') {
             // Convert ~/path to ApplicationPath/path
             std::string tail = workerPath.size() >= 2 && workerPath[1] == '/' ? workerPath.substr(2) : workerPath.substr(1);
             resolvedPath = Constants::APP_ROOT_FOLDER_PATH + tail;
@@ -1232,7 +1240,9 @@ void CallbackHandlers::NewThreadCallback(const v8::FunctionCallbackInfo<v8::Valu
          * app-root-relative resolution, mirroring the iOS runtime.
          */
         std::string currentDir = Constants::APP_ROOT_FOLDER_PATH;
-        auto stack = StackTrace::CurrentStackTrace(isolate, 1, StackTrace::kScriptName);
+        auto stack = isHttpEntry
+                             ? Local<StackTrace>()
+                             : StackTrace::CurrentStackTrace(isolate, 1, StackTrace::kScriptName);
         if (!stack.IsEmpty() && stack->GetFrameCount() > 0) {
             auto currentExecutingScriptName = stack->GetFrame(isolate, 0)->GetScriptName();
             auto currentExecutingScriptNameStr = ArgConverter::ConvertToString(
@@ -1248,22 +1258,30 @@ void CallbackHandlers::NewThreadCallback(const v8::FunctionCallbackInfo<v8::Valu
             }
         }
 
-        // Will throw if the path is invalid or the file doesn't exist. The
-        // worker runs on its own thread, with its own working directory and
-        // module registry, so it gets the canonical path resolved here rather
-        // than the spec: nothing on the other side can redo this resolution,
-        // and the entry's registry key must be the file that was validated.
+        // The worker runs on its own thread, with its own working directory
+        // and module registry, so it gets the entry resolved here rather than
+        // the spec: nothing on the other side can redo this resolution, and
+        // the entry's registry key must be what was resolved here.
         std::string entryPath;
-        try {
-            entryPath = ModuleInternal::CheckFileExists(isolate, resolvedPath, currentDir);
-        } catch (NativeScriptException& e) {
-            if (currentDir == Constants::APP_ROOT_FOLDER_PATH) {
-                throw;
+        if (isHttpEntry) {
+            // Repaired, not canonicalized: the canonical key depends on the
+            // worker's own canonicalization vocabulary, which is installed on
+            // its isolate, and both the loader and the settle gate derive it
+            // there from this URL.
+            entryPath = NormalizeHttpModuleUrl(resolvedPath);
+        } else {
+            // Throws if the path is invalid or the file doesn't exist.
+            try {
+                entryPath = ModuleInternal::CheckFileExists(isolate, resolvedPath, currentDir);
+            } catch (NativeScriptException& e) {
+                if (currentDir == Constants::APP_ROOT_FOLDER_PATH) {
+                    throw;
+                }
+                // not found next to the caller - retry against the app root
+                entryPath = ModuleInternal::CheckFileExists(isolate, resolvedPath,
+                                                            Constants::APP_ROOT_FOLDER_PATH);
+                currentDir = Constants::APP_ROOT_FOLDER_PATH;
             }
-            // not found next to the caller - retry against the app root
-            entryPath = ModuleInternal::CheckFileExists(isolate, resolvedPath,
-                                                        Constants::APP_ROOT_FOLDER_PATH);
-            currentDir = Constants::APP_ROOT_FOLDER_PATH;
         }
 
         auto workerId = WorkerWrapper::NextWorkerId();

--- a/test-app/runtime/src/main/cpp/EventLoop.cpp
+++ b/test-app/runtime/src/main/cpp/EventLoop.cpp
@@ -739,7 +739,11 @@ EventLoop::PumpResult EventLoop::PumpUntil(double deadlineSeconds,
         if (settled()) {
             return PumpResult::kSettled;
         }
-        if (isolate_->IsExecutionTerminating()) {
+        // Both probes: IsExecutionTerminating is true only while JS frames
+        // unwind with the termination exception active, so a pump parked with
+        // nothing queued would never observe TerminateExecution through it.
+        if (terminationRequested_.load(std::memory_order_acquire) ||
+            isolate_->IsExecutionTerminating()) {
             return PumpResult::kTerminated;
         }
         if (IsStopped()) {

--- a/test-app/runtime/src/main/cpp/EventLoop.cpp
+++ b/test-app/runtime/src/main/cpp/EventLoop.cpp
@@ -736,15 +736,17 @@ EventLoop::PumpResult EventLoop::PumpUntil(double deadlineSeconds,
     const auto deadline = std::chrono::steady_clock::now() +
                           std::chrono::duration<double>(deadlineSeconds);
     for (;;) {
-        if (settled()) {
-            return PumpResult::kSettled;
-        }
         // Both probes: IsExecutionTerminating is true only while JS frames
         // unwind with the termination exception active, so a pump parked with
         // nothing queued would never observe TerminateExecution through it.
+        // Termination outranks settlement: consuming a settled result means
+        // running more JS, which a terminating isolate must not do.
         if (terminationRequested_.load(std::memory_order_acquire) ||
             isolate_->IsExecutionTerminating()) {
             return PumpResult::kTerminated;
+        }
+        if (settled()) {
+            return PumpResult::kSettled;
         }
         if (IsStopped()) {
             // a stopped loop drops every post, so nothing can settle anymore
@@ -771,7 +773,9 @@ EventLoop::PumpResult EventLoop::PumpUntil(double deadlineSeconds,
             }
         }
         if (settled()) {
-            return PumpResult::kSettled;
+            // back through the loop head, where termination outranks the
+            // settlement this drain produced
+            continue;
         }
         if (ranLooperWork == 0) {
             WaitForInternalWork(10, /*pumpDeliverable=*/drainLooperWork);

--- a/test-app/runtime/src/main/cpp/EventLoop.h
+++ b/test-app/runtime/src/main/cpp/EventLoop.h
@@ -197,6 +197,18 @@ public:
     static bool IsInLooperCallback();
 
     /**
+     * Marks this loop's isolate as termination-requested. Callable from any
+     * thread. Pumps consult it alongside Isolate::IsExecutionTerminating,
+     * which per its contract is true only while JS frames are unwinding with
+     * the termination exception active - a pump parked with nothing queued
+     * never runs JS, so TerminateExecution alone cannot end it before the
+     * deadline.
+     */
+    void NoteTerminationRequested() {
+        terminationRequested_.store(true, std::memory_order_release);
+    }
+
+    /**
      * Blocks the calling thread until this loop's internal lane has work (the
      * eventfd or timerfd is readable) or `timeoutMs` elapses, whichever comes
      * first, without entering the looper - so it is safe where
@@ -400,6 +412,8 @@ private:
     Lane internal_;
     Lane ordered_;
     std::atomic<uint64_t> claimCells_[kClaimCells] = {};
+    // Set by NoteTerminationRequested (any thread), read by PumpUntil.
+    std::atomic_bool terminationRequested_{false};
     // ordered-lane source with its own bookkeeping (Timers); home-thread only
     OrderedTaskSource* timerSource_ = nullptr;
     // bare ordered tokens posted before the bind; flushed by Bind

--- a/test-app/runtime/src/main/cpp/HttpLoader.cpp
+++ b/test-app/runtime/src/main/cpp/HttpLoader.cpp
@@ -1,13 +1,13 @@
 #include "HttpLoader.h"
 
 #include <unistd.h>
-#include <v8.h>
 
 #include <algorithm>
 #include <atomic>
 #include <cctype>
 #include <chrono>
 #include <cstring>
+#include <deque>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -16,27 +16,20 @@
 
 #include "ArgConverter.h"
 #include "JEnv.h"
-#include "ModuleInternal.h"
+// The transport carries canonical keys rather than computing them, but
+// CanonicalizeHttpUrlKey itself reads the calling isolate's canonicalization
+// vocabulary — the one loader dependency left here.
 #include "ModuleInternalCallbacks.h"
 #include "NativeScriptException.h"
 #include "Runtime.h"
 #include "TraceLog.h"
 #include "robin_hood.h"
-#include "v8-json.h"
 
 namespace tns {
 
 static inline bool StartsWith(const std::string& s, const char* prefix) {
     size_t n = strlen(prefix);
     return s.size() >= n && s.compare(0, n, prefix) == 0;
-}
-
-static inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate, const char* str) {
-    return ArgConverter::ConvertToV8String(isolate, str ? std::string(str) : std::string());
-}
-
-static inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate, const std::string& str) {
-    return ArgConverter::ConvertToV8String(isolate, str);
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -571,7 +564,8 @@ static void ClassifyModuleResponse(const std::string& url, bool transportOk, int
     result.body = std::move(body);
 }
 
-bool HttpFetchModule(const std::string& url, ModuleFetchResult& result) {
+bool HttpFetchModule(const std::string& url, const std::string& canonicalKey,
+                     ModuleFetchResult& result) {
     result = ModuleFetchResult();
 
     // Security gate: the single point of enforcement for all HTTP module
@@ -587,11 +581,6 @@ bool HttpFetchModule(const std::string& url, ModuleFetchResult& result) {
     const bool urlLogEnabled = LogCategoryEnabled(LogCategory::Fetch);
     const auto netStart = urlLogEnabled ? std::chrono::steady_clock::now()
                                         : std::chrono::steady_clock::time_point{};
-
-    // Canonicalize here, on the caller's isolate thread: the vocabulary the
-    // key depends on belongs to that isolate, and the transport below must
-    // never reach for it.
-    const std::string canonicalKey = CanonicalizeHttpUrlKey(url);
 
     std::string body;
     std::string contentType;
@@ -888,7 +877,106 @@ static bool PerformHttpFetchOnceSync(const std::string& url, const std::string& 
     }
 }
 
-void FetchModuleBodyAsync(const std::string& url,
+// ── Bounded async fetch ──────────────────────────────────────
+//
+// One module fetch, with everything the fetch thread needs; nothing here
+// touches V8 or an isolate.
+namespace {
+
+struct ModuleFetchJob {
+    std::string url;
+    std::string canonicalKey;
+    std::function<void(ModuleFetchResult)> completion;
+};
+
+// See the cap's rationale in HttpLoader.h. 16 matches iOS's
+// HTTPMaximumConnectionsPerHost.
+constexpr size_t kMaxConcurrentModuleFetches = 16;
+
+std::mutex g_fetchQueueMutex;
+std::deque<ModuleFetchJob> g_fetchQueue;
+size_t g_fetchThreadCount = 0;
+
+void RunModuleFetchJob(const ModuleFetchJob& job) {
+    std::string body;
+    std::string contentType;
+    int status = 0;
+    const auto start = std::chrono::steady_clock::now();
+    bool bustApplied = false;
+    bool transportOk = PerformHttpFetchOnceSync(job.url, job.canonicalKey, body, contentType,
+                                                status, bustApplied);
+    if (!transportOk) {
+        // Transport error → one retry, the same single-retry policy the
+        // sync path applies.
+        TNS_DEBUG(Esm, "[http-loader][fetch-async] retrying %s after transport error",
+                       job.url.c_str());
+        usleep(120 * 1000);
+        transportOk = PerformHttpFetchOnceSync(job.url, job.canonicalKey, body, contentType, status,
+                                               bustApplied);
+    }
+
+    ModuleFetchResult result;
+    ClassifyModuleResponse(job.url, transportOk, status, contentType, body, result);
+
+    if (result.ok && bustApplied) {
+        ClearCacheBustForUrl(job.canonicalKey);
+    }
+
+    if (!result.ok) {
+        TNS_DEBUG(Esm, "[http-loader][fetch-async][reject] %s", result.failureReason.c_str());
+    } else if (LogCategoryEnabled(LogCategory::Fetch)) {
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now() - start)
+                                .count();
+        TNS_DEBUG(Fetch, "[http-loader][fetch][async] %s bytes=%lu ms=%lld", job.url.c_str(),
+                         (unsigned long)result.body.size(), (long long)ms);
+    }
+    job.completion(std::move(result));
+}
+
+// A fetch thread serves its own job and then drains the queue, so the JVM
+// attach is paid once per thread rather than once per module and the cap
+// bounds threads, not just sockets. Exiting checks the queue and decrements
+// the count in ONE critical section: a producer that queues therefore always
+// observes — and is observed by — a thread that has not yet exited, so a
+// queued job cannot be stranded behind a thread on its way out.
+void ModuleFetchThreadMain(ModuleFetchJob job) {
+    JavaVM* jvm = Runtime::GetJVM();
+    bool attachedHere = false;
+    if (jvm != nullptr) {
+        JNIEnv* raw = nullptr;
+        if (jvm->GetEnv(reinterpret_cast<void**>(&raw), JNI_VERSION_1_6) != JNI_OK) {
+            if (jvm->AttachCurrentThread(&raw, nullptr) == JNI_OK) {
+                attachedHere = true;
+            }
+        }
+    }
+    struct DetachIfAttached {
+        JavaVM* jvm;
+        bool attached;
+        ~DetachIfAttached() {
+            if (attached && jvm != nullptr) {
+                jvm->DetachCurrentThread();
+            }
+        }
+    } detachGuard{jvm, attachedHere};
+
+    for (;;) {
+        RunModuleFetchJob(job);
+
+        std::lock_guard<std::mutex> lock(g_fetchQueueMutex);
+        if (g_fetchQueue.empty()) {
+            g_fetchThreadCount--;
+            return;
+        }
+        job = std::move(g_fetchQueue.front());
+        g_fetchQueue.pop_front();
+    }
+}
+
+}  // namespace
+
+void FetchModuleBodyAsync(const std::string& url, const std::string& canonicalKey,
                           std::function<void(ModuleFetchResult result)> completion) {
     // Security gate: single point of enforcement, same as HttpFetchModule.
     if (!IsRemoteUrlAllowed(url)) {
@@ -901,420 +989,56 @@ void FetchModuleBodyAsync(const std::string& url,
         return;
     }
 
-    // Canonicalize before the hop: the vocabulary belongs to the calling
-    // isolate, and the fetch thread below has no isolate to read it from.
-    const std::string canonicalKey = CanonicalizeHttpUrlKey(url);
-
-    std::thread([url, canonicalKey, completion = std::move(completion)]() mutable {
-        JavaVM* jvm = Runtime::GetJVM();
-        bool attachedHere = false;
-        if (jvm != nullptr) {
-            JNIEnv* raw = nullptr;
-            if (jvm->GetEnv(reinterpret_cast<void**>(&raw), JNI_VERSION_1_6) != JNI_OK) {
-                if (jvm->AttachCurrentThread(&raw, nullptr) == JNI_OK) {
-                    attachedHere = true;
-                }
-            }
+    ModuleFetchJob job{url, canonicalKey, std::move(completion)};
+    {
+        std::lock_guard<std::mutex> lock(g_fetchQueueMutex);
+        if (g_fetchThreadCount >= kMaxConcurrentModuleFetches) {
+            g_fetchQueue.push_back(std::move(job));
+            return;
         }
-        struct DetachIfAttached {
-            JavaVM* jvm;
-            bool attached;
-            ~DetachIfAttached() {
-                if (attached && jvm != nullptr) {
-                    jvm->DetachCurrentThread();
-                }
-            }
-        } detachGuard{jvm, attachedHere};
+        g_fetchThreadCount++;
+    }
 
-        std::string body;
-        std::string contentType;
-        int status = 0;
-        const auto start = std::chrono::steady_clock::now();
-        bool bustApplied = false;
-        bool transportOk =
-                PerformHttpFetchOnceSync(url, canonicalKey, body, contentType, status, bustApplied);
-        if (!transportOk) {
-            // Transport error → one retry, the same single-retry policy the
-            // sync path applies.
-            TNS_DEBUG(Esm, "[http-loader][fetch-async] retrying %s after transport error",
-                           url.c_str());
-            usleep(120 * 1000);
-            transportOk = PerformHttpFetchOnceSync(url, canonicalKey, body, contentType, status,
-                                                   bustApplied);
+    // Copied, not moved: a throwing std::thread constructor leaves its
+    // decay-copies in an unspecified state, and the failure path below still
+    // has to deliver this job's completion.
+    try {
+        std::thread(ModuleFetchThreadMain, job).detach();
+        return;
+    } catch (...) {
+    }
+
+    // A counted slot with no thread behind it: anything queued against it has
+    // nothing left to drain it if this was the last one, so those jobs are
+    // failed here rather than left waiting on a thread that will never exist.
+    std::deque<ModuleFetchJob> orphaned;
+    {
+        std::lock_guard<std::mutex> lock(g_fetchQueueMutex);
+        g_fetchThreadCount--;
+        if (g_fetchThreadCount == 0) {
+            orphaned.swap(g_fetchQueue);
         }
+    }
 
-        ModuleFetchResult result;
-        ClassifyModuleResponse(url, transportOk, status, contentType, body, result);
+    // The completion contract is exactly-once, and the caller's bookkeeping
+    // (pendingFetches) is already incremented — a swallowed spawn failure
+    // wedges the graph walk short of settling forever.
+    auto failSpawn = [](const ModuleFetchJob& failedJob) {
+        ModuleFetchResult failed;
+        failed.failureReason = "Could not fetch " + failedJob.url +
+                               ": the runtime could not start a fetch thread";
+        TNS_DEBUG(Esm, "[http-loader][fetch-async][spawn-fail] %s", failedJob.url.c_str());
+        failedJob.completion(std::move(failed));
+    };
 
-        if (result.ok && bustApplied) {
-            ClearCacheBustForUrl(canonicalKey);
-        }
-
-        if (!result.ok) {
-            TNS_DEBUG(Esm, "[http-loader][fetch-async][reject] %s", result.failureReason.c_str());
-        } else if (LogCategoryEnabled(LogCategory::Fetch)) {
-            const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                    std::chrono::steady_clock::now() - start)
-                                    .count();
-            TNS_DEBUG(Fetch, "[http-loader][fetch][async] %s bytes=%lu ms=%lld", url.c_str(),
-                             (unsigned long)result.body.size(), (long long)ms);
-        }
-        completion(std::move(result));
-    }).detach();
+    failSpawn(job);
+    for (const ModuleFetchJob& orphan : orphaned) {
+        failSpawn(orphan);
+    }
 }
 
 void CleanupHttpLoaderGlobals() {
     ClearAllCacheBustMarks();
-}
-
-// ─────────────────────────────────────────────────────────────
-// ns:module binding
-
-namespace {
-
-void InstallDevFunction(v8::Isolate* isolate, v8::Local<v8::Context> context,
-                        v8::Local<v8::Object> target, const char* name,
-                        v8::FunctionCallback callback) {
-    v8::Local<v8::FunctionTemplate> fnTpl = v8::FunctionTemplate::New(isolate, callback);
-    v8::Local<v8::Function> fn = fnTpl->GetFunction(context).ToLocalChecked();
-    fn->SetName(ToV8String(isolate, name));
-    target->CreateDataProperty(context, ToV8String(isolate, name), fn).Check();
-}
-
-// The only sections configureLoader understands. An unlisted key is a typo the
-// caller hears about rather than a setting that silently does nothing.
-constexpr const char* kLoaderConfigKeys[] = {"importMap", "volatilePatterns", "canonicalization"};
-
-void ConfigureLoaderCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    v8::Isolate* isolate = info.GetIsolate();
-    v8::HandleScope scope(isolate);
-    v8::Local<v8::Context> ctx = isolate->GetCurrentContext();
-
-    try {
-        auto throwTypeError = [&](const std::string& message) {
-            isolate->ThrowException(v8::Exception::TypeError(ToV8String(isolate, message)));
-        };
-
-        if (info.Length() < 1 || !info[0]->IsObject()) {
-            throwTypeError("configureLoader expects a config object");
-            return;
-        }
-
-        v8::Local<v8::Object> config = info[0].As<v8::Object>();
-
-        // ── Validation phase ─────────────────────────────────────────────
-        // Nothing below mutates the vocabulary. The whole config is checked first
-        // so a rejected call leaves every section exactly as it was — the
-        // atomicity the import map alone used to have, now covering the entire
-        // call.
-
-        // Unknown top-level keys.
-        v8::Local<v8::Array> configKeys;
-        if (!config->GetOwnPropertyNames(ctx, v8::PropertyFilter::ONLY_ENUMERABLE,
-                                         v8::KeyConversionMode::kConvertToString)
-                     .ToLocal(&configKeys)) {
-            return;  // pending exception
-        }
-        for (uint32_t i = 0; i < configKeys->Length(); i++) {
-            v8::Local<v8::Value> keyVal;
-            if (!configKeys->Get(ctx, i).ToLocal(&keyVal)) {
-                return;
-            }
-            std::string key = ArgConverter::ToString(isolate, keyVal);
-            bool known = false;
-            for (const char* candidate : kLoaderConfigKeys) {
-                if (key == candidate) {
-                    known = true;
-                    break;
-                }
-            }
-            if (!known) {
-                throwTypeError("configureLoader: unknown option '" + key + "'");
-                return;
-            }
-        }
-
-        // Reads `obj[key]` as an array of strings into `out`. `label` names the
-        // section in any error. Returns false with an exception pending on a type
-        // failure; `present` distinguishes "absent" from "present and valid".
-        auto readStringArray = [&](v8::Local<v8::Object> obj, const char* key,
-                                   const std::string& label, std::vector<std::string>& out,
-                                   bool* present) -> bool {
-            *present = false;
-            v8::Local<v8::Value> val;
-            if (!obj->Get(ctx, ToV8String(isolate, key)).ToLocal(&val)) {
-                return false;
-            }
-            if (val->IsUndefined()) {
-                return true;
-            }
-            if (!val->IsArray()) {
-                throwTypeError("configureLoader: " + label + " must be an array of strings");
-                return false;
-            }
-            v8::Local<v8::Array> arr = val.As<v8::Array>();
-            for (uint32_t i = 0; i < arr->Length(); i++) {
-                v8::Local<v8::Value> elem;
-                if (!arr->Get(ctx, i).ToLocal(&elem)) {
-                    return false;
-                }
-                if (!elem->IsString()) {
-                    throwTypeError("configureLoader: " + label + "[" + std::to_string(i) +
-                                   "] must be a string");
-                    return false;
-                }
-                out.push_back(ArgConverter::ToString(isolate, elem));
-            }
-            *present = true;
-            return true;
-        };
-
-        // importMap: an object or a JSON string. Validated here, installed below.
-        std::string importMapJson;
-        bool haveImportMap = false;
-        v8::Local<v8::Value> importMapVal;
-        if (!config->Get(ctx, ToV8String(isolate, "importMap")).ToLocal(&importMapVal)) {
-            return;
-        }
-        if (!importMapVal->IsUndefined()) {
-            std::string jsonStr;
-            if (importMapVal->IsString()) {
-                jsonStr = ArgConverter::ToString(isolate, importMapVal);
-            } else if (importMapVal->IsObject() && !importMapVal->IsFunction()) {
-                // A function is an object to V8, and JSON::Stringify hands one back
-                // as the literal text "undefined" rather than failing — so it is
-                // excluded here and falls through to the TypeError below.
-                v8::Local<v8::String> stringified;
-                if (!v8::JSON::Stringify(ctx, importMapVal).ToLocal(&stringified)) {
-                    return;  // a throwing toJSON / getter propagates unchanged
-                }
-                std::string text = ArgConverter::ToString(isolate, stringified);
-                // The same "undefined" answer reaches a plain object whose toJSON
-                // returns undefined; leaving jsonStr empty routes it to the same
-                // TypeError.
-                if (text != "undefined") {
-                    jsonStr = std::move(text);
-                }
-            }
-            if (jsonStr.empty()) {
-                throwTypeError("configureLoader: importMap must be an object or a JSON string");
-                return;
-            }
-            std::string importMapError;
-            if (!ValidateImportMapJson(jsonStr, &importMapError)) {
-                // The previous map is still installed: a rejected update changes
-                // nothing, so a typo cannot empty a live session's vocabulary.
-                throwTypeError("configureLoader: " + importMapError);
-                return;
-            }
-            importMapJson = std::move(jsonStr);
-            haveImportMap = true;
-        }
-
-        // volatilePatterns: array of strings. Presence of the array decides, not
-        // its contents — an empty one is explicit policy meaning "nothing is
-        // volatile any more", the same rule canonicalization follows, and the only
-        // reading under which a present section replaces its state wholesale.
-        std::vector<std::string> patterns;
-        bool havePatterns = false;
-        if (!readStringArray(config, "volatilePatterns", "volatilePatterns", patterns,
-                             &havePatterns)) {
-            return;
-        }
-
-        // canonicalization: { stripParams, forPathPrefixes, preserveQueryFor } —
-        // the URL vocabulary CanonicalizeHttpUrlKey applies (see its doc block).
-        // Presence of the object marks the vocabulary as configured, replacing the
-        // built-in fallback entirely (empty arrays are honored as explicit policy).
-        CanonicalizationConfig canon;
-        bool haveCanon = false;
-        v8::Local<v8::Value> canonVal;
-        if (!config->Get(ctx, ToV8String(isolate, "canonicalization")).ToLocal(&canonVal)) {
-            return;
-        }
-        if (!canonVal->IsUndefined()) {
-            if (!canonVal->IsObject()) {
-                throwTypeError("configureLoader: canonicalization must be an object");
-                return;
-            }
-            v8::Local<v8::Object> canonObj = canonVal.As<v8::Object>();
-            bool ignored = false;
-            if (!readStringArray(canonObj, "stripParams", "canonicalization.stripParams",
-                                 canon.stripParams, &ignored) ||
-                !readStringArray(canonObj, "forPathPrefixes", "canonicalization.forPathPrefixes",
-                                 canon.devPathPrefixes, &ignored) ||
-                !readStringArray(canonObj, "preserveQueryFor", "canonicalization.preserveQueryFor",
-                                 canon.preserveQueryPrefixes, &ignored)) {
-                return;
-            }
-            haveCanon = true;
-        }
-
-        // ── Apply phase ──────────────────────────────────────────────────
-        // Everything validated; from here nothing can fail on the caller's input.
-
-        if (haveImportMap) {
-            // The re-parse inside SetImportMap is deterministic and already
-            // succeeded above, so the only failure left is the isolate shutting
-            // down.
-            std::string installError;
-            if (!SetImportMap(importMapJson, &installError)) {
-                throwTypeError("configureLoader: " + installError);
-                return;
-            }
-            TNS_DEBUG(Esm, "[ns:module configureLoader] import map set (%zu bytes)",
-                           importMapJson.size());
-        }
-
-        if (havePatterns) {
-            SetVolatilePatterns(patterns);
-            TNS_DEBUG(Esm, "[ns:module configureLoader] %zu volatile patterns set",
-                           patterns.size());
-        }
-
-        if (haveCanon) {
-            SetCanonicalizationConfig(std::move(canon));
-        }
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception& e) {
-        NativeScriptException nsEx(std::string("Error: c++ exception: ") + e.what() + "\n");
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c++ exception!"));
-        nsEx.ReThrowToV8();
-    }
-}
-
-void InvalidateModulesCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    v8::Isolate* isolate = info.GetIsolate();
-    v8::HandleScope scope(isolate);
-    v8::Local<v8::Context> ctx = isolate->GetCurrentContext();
-
-    try {
-        if (info.Length() < 1 || !info[0]->IsArray()) {
-            isolate->ThrowException(v8::Exception::TypeError(
-                    ToV8String(isolate, "invalidateModules expects an array of URL strings")));
-            return;
-        }
-
-        v8::Local<v8::Array> urlsArray = info[0].As<v8::Array>();
-        std::vector<std::string> urls;
-        urls.reserve(urlsArray->Length());
-        for (uint32_t index = 0; index < urlsArray->Length(); index++) {
-            v8::Local<v8::Value> value;
-            if (!urlsArray->Get(ctx, index).ToLocal(&value)) {
-                return;
-            }
-            if (!value->IsString()) {
-                isolate->ThrowException(v8::Exception::TypeError(ToV8String(
-                        isolate,
-                        "invalidateModules: urls[" + std::to_string(index) +
-                                "] must be a string")));
-                return;
-            }
-            urls.push_back(ArgConverter::ToString(isolate, value));
-        }
-
-        if (tns::LogCategoryEnabled(tns::LogCategory::Registry)) {
-            TNS_DEBUG(Registry, "invalidate called urls.count=%zu", urls.size());
-            size_t shown = 0;
-            for (const auto& u : urls) {
-                if (shown >= 32) break;
-                TNS_DEBUG(Registry, "invalidate url[%zu]=%s", shown, u.c_str());
-                shown++;
-            }
-            if (urls.size() > shown) {
-                TNS_DEBUG(Registry, "invalidate (hidden %zu more URL(s))", urls.size() - shown);
-            }
-        }
-
-        tns::InvalidateModules(isolate, ctx, urls);
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception& e) {
-        NativeScriptException nsEx(std::string("Error: c++ exception: ") + e.what() + "\n");
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c++ exception!"));
-        nsEx.ReThrowToV8();
-    }
-}
-
-void GetLoadedModuleUrlsCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    v8::Isolate* isolate = info.GetIsolate();
-    v8::HandleScope scope(isolate);
-    v8::Local<v8::Context> ctx = isolate->GetCurrentContext();
-
-    try {
-        std::vector<std::string> urls = tns::GetLoadedModuleUrls();
-        v8::Local<v8::Array> result = v8::Array::New(isolate, static_cast<int>(urls.size()));
-
-        for (uint32_t index = 0; index < urls.size(); index++) {
-            result->Set(ctx, index, ToV8String(isolate, urls[index])).FromMaybe(false);
-        }
-
-        info.GetReturnValue().Set(result);
-    } catch (NativeScriptException& e) {
-        e.ReThrowToV8();
-    } catch (std::exception& e) {
-        NativeScriptException nsEx(std::string("Error: c++ exception: ") + e.what() + "\n");
-        nsEx.ReThrowToV8();
-    } catch (...) {
-        NativeScriptException nsEx(std::string("Error: c++ exception!"));
-        nsEx.ReThrowToV8();
-    }
-}
-
-}  // namespace
-
-bool BuildNsModuleBinding(v8::Local<v8::Context> context, v8::Local<v8::Object> binding) {
-    v8::Isolate* isolate = v8::Isolate::GetCurrent();
-
-    InstallDevFunction(isolate, context, binding, "configureLoader", ConfigureLoaderCallback);
-    InstallDevFunction(isolate, context, binding, "invalidateModules", InvalidateModulesCallback);
-    InstallDevFunction(isolate, context, binding, "getLoadedModuleUrls",
-                       GetLoadedModuleUrlsCallback);
-
-    if (!ModuleInternal::InstallCreateRequireBinding(context, binding)) {
-        return false;
-    }
-
-    if (IsDebuggable()) {
-        auto canonicalizeCb = [](const v8::FunctionCallbackInfo<v8::Value>& info) {
-            v8::Isolate* iso = info.GetIsolate();
-            try {
-                if (info.Length() < 1 || !info[0]->IsString()) {
-                    iso->ThrowException(v8::Exception::TypeError(
-                            ToV8String(iso, "canonicalizeHttpUrlKey expects a URL string")));
-                    return;
-                }
-                std::string key = CanonicalizeHttpUrlKey(ArgConverter::ToString(iso, info[0]));
-                info.GetReturnValue().Set(ToV8String(iso, key));
-            } catch (NativeScriptException& e) {
-                e.ReThrowToV8();
-            } catch (std::exception& e) {
-                NativeScriptException nsEx(std::string("Error: c++ exception: ") + e.what() +
-                                           "\n");
-                nsEx.ReThrowToV8();
-            } catch (...) {
-                NativeScriptException nsEx(std::string("Error: c++ exception!"));
-                nsEx.ReThrowToV8();
-            }
-        };
-        v8::Local<v8::Function> fn;
-        if (v8::Function::New(context, canonicalizeCb).ToLocal(&fn)) {
-            fn->SetName(ToV8String(isolate, "canonicalizeHttpUrlKey"));
-            if (!binding
-                         ->CreateDataProperty(context, ToV8String(isolate, "canonicalizeHttpUrlKey"),
-                                              fn)
-                         .FromMaybe(false)) {
-                return false;
-            }
-        }
-    }
-
-    return true;
 }
 
 }  // namespace tns

--- a/test-app/runtime/src/main/cpp/HttpLoader.cpp
+++ b/test-app/runtime/src/main/cpp/HttpLoader.cpp
@@ -898,40 +898,72 @@ std::deque<ModuleFetchJob> g_fetchQueue;
 size_t g_fetchThreadCount = 0;
 
 void RunModuleFetchJob(const ModuleFetchJob& job) {
-    std::string body;
-    std::string contentType;
-    int status = 0;
-    const auto start = std::chrono::steady_clock::now();
-    bool bustApplied = false;
-    bool transportOk = PerformHttpFetchOnceSync(job.url, job.canonicalKey, body, contentType,
-                                                status, bustApplied);
-    if (!transportOk) {
-        // Transport error → one retry, the same single-retry policy the
-        // sync path applies.
-        TNS_DEBUG(Esm, "[http-loader][fetch-async] retrying %s after transport error",
-                       job.url.c_str());
-        usleep(120 * 1000);
-        transportOk = PerformHttpFetchOnceSync(job.url, job.canonicalKey, body, contentType, status,
-                                               bustApplied);
-    }
-
+    // Nothing may escape this function: it runs at the top of a detached
+    // thread, where an unwinding exception is std::terminate for the whole
+    // process — and a throw past the caller's loop would also strand the
+    // queue bookkeeping. The fetch phase converts an escaped exception into a
+    // transport-error result so the completion still runs exactly once; the
+    // completion itself gets a log-only guard, since by then delivery has
+    // either happened or cannot be retried.
     ModuleFetchResult result;
-    ClassifyModuleResponse(job.url, transportOk, status, contentType, body, result);
+    try {
+        std::string body;
+        std::string contentType;
+        int status = 0;
+        const auto start = std::chrono::steady_clock::now();
+        bool bustApplied = false;
+        bool transportOk = PerformHttpFetchOnceSync(job.url, job.canonicalKey, body, contentType,
+                                                    status, bustApplied);
+        if (!transportOk) {
+            // Transport error → one retry, the same single-retry policy the
+            // sync path applies.
+            TNS_DEBUG(Esm, "[http-loader][fetch-async] retrying %s after transport error",
+                           job.url.c_str());
+            usleep(120 * 1000);
+            transportOk = PerformHttpFetchOnceSync(job.url, job.canonicalKey, body, contentType,
+                                                   status, bustApplied);
+        }
 
-    if (result.ok && bustApplied) {
-        ClearCacheBustForUrl(job.canonicalKey);
+        ClassifyModuleResponse(job.url, transportOk, status, contentType, body, result);
+
+        if (result.ok && bustApplied) {
+            ClearCacheBustForUrl(job.canonicalKey);
+        }
+
+        if (!result.ok) {
+            TNS_DEBUG(Esm, "[http-loader][fetch-async][reject] %s", result.failureReason.c_str());
+        } else if (LogCategoryEnabled(LogCategory::Fetch)) {
+            const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                    std::chrono::steady_clock::now() - start)
+                                    .count();
+            TNS_DEBUG(Fetch, "[http-loader][fetch][async] %s bytes=%lu ms=%lld", job.url.c_str(),
+                             (unsigned long)result.body.size(), (long long)ms);
+        }
+    } catch (NativeScriptException& e) {
+        result = ModuleFetchResult{};
+        result.failureReason = "HTTP import failed: " + job.url + " (network error)";
+        DEBUG_WRITE_FORCE("[http-loader][fetch-async] native exception fetching %s: %s",
+                          job.url.c_str(), e.what());
+    } catch (const std::exception& e) {
+        result = ModuleFetchResult{};
+        result.failureReason = "HTTP import failed: " + job.url + " (network error)";
+        DEBUG_WRITE_FORCE("[http-loader][fetch-async] c++ exception fetching %s: %s",
+                          job.url.c_str(), e.what());
+    } catch (...) {
+        result = ModuleFetchResult{};
+        result.failureReason = "HTTP import failed: " + job.url + " (network error)";
+        DEBUG_WRITE_FORCE("[http-loader][fetch-async] unknown exception fetching %s",
+                          job.url.c_str());
     }
 
-    if (!result.ok) {
-        TNS_DEBUG(Esm, "[http-loader][fetch-async][reject] %s", result.failureReason.c_str());
-    } else if (LogCategoryEnabled(LogCategory::Fetch)) {
-        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                std::chrono::steady_clock::now() - start)
-                                .count();
-        TNS_DEBUG(Fetch, "[http-loader][fetch][async] %s bytes=%lu ms=%lld", job.url.c_str(),
-                         (unsigned long)result.body.size(), (long long)ms);
+    try {
+        job.completion(std::move(result));
+    } catch (const std::exception& e) {
+        DEBUG_WRITE_FORCE("[http-loader][fetch-async] completion threw for %s: %s",
+                          job.url.c_str(), e.what());
+    } catch (...) {
+        DEBUG_WRITE_FORCE("[http-loader][fetch-async] completion threw for %s", job.url.c_str());
     }
-    job.completion(std::move(result));
 }
 
 // A fetch thread serves its own job and then drains the queue, so the JVM

--- a/test-app/runtime/src/main/cpp/HttpLoader.h
+++ b/test-app/runtime/src/main/cpp/HttpLoader.h
@@ -4,18 +4,6 @@
 #include <string>
 #include <vector>
 
-// Forward declare v8 types to keep this header lightweight and avoid
-// requiring V8 headers at include sites.
-namespace v8 {
-class Isolate;
-template <class T>
-class Local;
-class Object;
-class Function;
-class Context;
-class Value;
-}  // namespace v8
-
 namespace tns {
 
 // HttpLoader: the native half of the NativeScript HTTP module-loader
@@ -45,9 +33,9 @@ namespace tns {
 // client via ns:module `configureLoader({ canonicalization: {...} })`. It is
 // per-isolate loader vocabulary — installed through SetCanonicalizationConfig
 // in ModuleInternalCallbacks.h — so CanonicalizeHttpUrlKey runs on the
-// isolate's own thread only. The transport canonicalizes at its JS-thread
-// entry points (HttpFetchModule, FetchModuleBodyAsync) and nowhere else;
-// background fetch threads only ever carry keys computed for them.
+// isolate's own thread only. The transport never canonicalizes: every entry
+// point takes the canonical key as a parameter, so an off-thread key is
+// impossible to produce by construction.
 //
 // When unconfigured, canonicalization is purely mechanical (fragment strip).
 struct CanonicalizationConfig {
@@ -101,7 +89,11 @@ struct ModuleFetchResult {
 // Synchronous module fetch with one retry on transport error — the fallback
 // path for anything the module-graph walk missed. Blocks the calling thread.
 // Returns `result.ok`.
-bool HttpFetchModule(const std::string& url, ModuleFetchResult& result);
+// `canonicalKey` is the module's canonical registry key, computed by the
+// caller on its isolate's thread — the transport must never canonicalize,
+// since that reads per-isolate loader vocabulary.
+bool HttpFetchModule(const std::string& url, const std::string& canonicalKey,
+                     ModuleFetchResult& result);
 
 // Asynchronous single-URL module fetch — the I/O primitive behind the
 // module-graph walk (see StartModuleGraphLoad in ModuleInternalCallbacks.h).
@@ -112,8 +104,18 @@ bool HttpFetchModule(const std::string& url, ModuleFetchResult& result);
 //     and one retry on transport error.
 // `completion(result)` is invoked exactly once, on an arbitrary thread —
 // callers must hop to their JS thread before touching V8.
+// `canonicalKey` as for HttpFetchModule: computed on the calling isolate's
+// thread and carried, because the fetch and its completion run on background
+// threads that cannot read per-isolate vocabulary.
+//
+// Concurrency is capped (kMaxConcurrentModuleFetches). iOS gets the same cap
+// per host from NSURLSession; here it is process-wide, because the fetch
+// threads are a process resource and a dev session's modules all come from
+// one origin anyway. Over the cap the request is queued and picked up by a
+// fetch thread as one frees — the CALLER never blocks, so this stays safe to
+// call from the JS thread.
 void FetchModuleBodyAsync(
-    const std::string& url,
+    const std::string& url, const std::string& canonicalKey,
     std::function<void(ModuleFetchResult result)> completion);
 
 // Mark a set of canonical registry keys so that the NEXT network fetch of
@@ -153,30 +155,5 @@ bool IsRemoteUrlAllowed(const std::string& url);
 // Mirrors com.tns.Runtime.isDebuggable(), cached once via the security
 // config init. Fail-safe false until initialized.
 bool IsDebuggable();
-
-// ─────────────────────────────────────────────────────────────
-// The `ns:module` builtin binding
-//
-// Populates the native half of the `ns:module` builtin module — the one
-// namespace carrying every JS-callable dev primitive that any tooling can
-// depend on. Called from NsBuiltinModules::BuildBinding the first time a
-// realm resolves `ns:module` (via require, static import, or import());
-// ns-module.js shapes and freezes the exports.
-//
-// `ns:module` members:
-//   - configureLoader(config)         (import map + volatile patterns +
-//                                      canonicalization vocabulary)
-//   - invalidateModules(urls)         (registry + cache eviction)
-//   - getLoadedModuleUrls()           (registry introspection)
-//   - canonicalizeHttpUrlKey(url)     (debug builds only; test diagnostic)
-//
-// Worker teardown across HMR cycles is userland: the dev client intercepts
-// the global `Worker` constructor and terminates tracked instances
-// (worker.terminate() cascades to nested workers via Runtime::DestroyRuntime).
-//
-// Returns false (with an exception pending or a failed Set) when the
-// binding could not be populated.
-bool BuildNsModuleBinding(v8::Local<v8::Context> context,
-                          v8::Local<v8::Object> binding);
 
 }  // namespace tns

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -39,11 +39,7 @@ using namespace v8;
 using namespace std;
 using namespace tns;
 
-// Classifies the NORMALIZED form: a scheme separator collapsed by a path
-// normalizer (`http:/host/...`) must still route to the HTTP loader, or the
-// same string classifies as a filesystem path and repairs itself only after
-// taking the wrong branch.
-static bool IsHttpModulePath(const std::string& path) {
+bool ModuleInternal::IsHttpModulePath(const std::string& path) {
     const std::string normalized = NormalizeHttpModuleUrl(path);
     return normalized.rfind("http://", 0) == 0 || normalized.rfind("https://", 0) == 0;
 }
@@ -979,7 +975,7 @@ Local<Script> ModuleInternal::LoadScript(Isolate* isolate, const string& path, c
 
     DEBUG_WRITE("Compiling script (module %s)", path.c_str());
     //
-    auto cacheData = TryLoadScriptCache(path);
+    auto cacheData = TryLoadScriptCache(path, ScriptCacheKind::Classic);
 
     auto fullRequiredModulePathWithSchema = ArgConverter::ConvertToV8String(isolate, "file://" + path);
     ScriptOrigin origin(fullRequiredModulePathWithSchema);
@@ -1084,9 +1080,30 @@ MaybeLocal<Module> ModuleInternal::CompileFileEsModule(Isolate* isolate, const s
     ScriptOrigin origin(urlString, 0, 0, false, -1, Local<Value>(), false, false,
                         true  // ← is_module
     );
-    ScriptCompiler::Source source(sourceText, origin);
 
-    return ScriptCompiler::CompileModule(isolate, &source);
+    // The Source takes ownership of the CachedData, so the pointer stays valid
+    // for the `rejected` read below and is freed with the Source.
+    ScriptCompiler::CachedData* cacheData = TryLoadScriptCache(path, ScriptCacheKind::Module);
+    ScriptCompiler::Source source(sourceText, origin, cacheData);
+
+    Local<Module> module;
+    if (!ScriptCompiler::CompileModule(isolate, &source,
+                                       cacheData != nullptr
+                                               ? ScriptCompiler::kConsumeCodeCache
+                                               : ScriptCompiler::kNoCompileOptions)
+                 .ToLocal(&module)) {
+        return MaybeLocal<Module>();
+    }
+
+    // A rejected cache (stale, or produced under different V8 flags) still
+    // compiles — V8 falls back to a full parse — but leaves the file on disk
+    // unusable forever unless it is republished from this compile.
+    if (Constants::V8_CACHE_COMPILED_CODE && (cacheData == nullptr || cacheData->rejected)) {
+        SaveScriptCache(ScriptCompiler::CreateCodeCache(module->GetUnboundModuleScript()), path,
+                        ScriptCacheKind::Module);
+    }
+
+    return MaybeLocal<Module>(module);
 }
 
 // Phase diagnostics for one module's trip through the loader.
@@ -1339,7 +1356,7 @@ MaybeLocal<Promise> tns::EvaluateModuleGraph(Isolate* isolate, Local<Context> co
 // Evaluate(), which hands back the SAME capability promise rather than
 // re-running anything, so it is cheap enough to call from a pump loop.
 static MaybeLocal<Promise> EntryEvaluationPromise(Isolate* isolate, const std::string& path) {
-    if (!ModuleInternal::IsESModule(path) && !IsHttpModulePath(path)) {
+    if (!ModuleInternal::IsESModule(path) && !ModuleInternal::IsHttpModulePath(path)) {
         return MaybeLocal<Promise>();
     }
     auto* registryPtr = ModuleRegistryFor(isolate);
@@ -1602,13 +1619,14 @@ Local<String> ModuleInternal::WrapModuleContent(const string& path) {
     return ArgConverter::ConvertToV8String(m_isolate, result);
 }
 
-ScriptCompiler::CachedData* ModuleInternal::TryLoadScriptCache(const std::string& path) {
+ScriptCompiler::CachedData* ModuleInternal::TryLoadScriptCache(const std::string& path,
+                                                               ScriptCacheKind kind) {
     TNSPERF();
     if (!Constants::V8_CACHE_COMPILED_CODE) {
         return nullptr;
     }
 
-    auto cachePath = path + ".cache";
+    auto cachePath = path + (kind == ScriptCacheKind::Module ? ".mcache" : ".cache");
 
     struct stat result;
     if (stat(cachePath.c_str(), &result) == 0) {
@@ -1632,20 +1650,22 @@ ScriptCompiler::CachedData* ModuleInternal::TryLoadScriptCache(const std::string
     return new ScriptCompiler::CachedData(reinterpret_cast<uint8_t*>(data), length, ScriptCompiler::CachedData::BufferOwned);
 }
 
-void ModuleInternal::SaveScriptCache(const Local<Script> script, const std::string& path) {
+void ModuleInternal::SaveScriptCache(const ScriptCompiler::CachedData* cache,
+                                     const std::string& path, ScriptCacheKind kind) {
+    if (cache == nullptr) {
+        return;
+    }
     if (!Constants::V8_CACHE_COMPILED_CODE) {
+        delete cache;
         return;
     }
 
     tns::instrumentation::Frame frame("SaveScriptCache");
 
-    Local<UnboundScript> unboundScript = script->GetUnboundScript();
-    ScriptCompiler::CachedData* cachedData = ScriptCompiler::CreateCodeCache(unboundScript);
-
-    int length = cachedData->length;
-    auto cachePath = path + ".cache";
-    File::WriteBinary(cachePath, cachedData->data, length);
-    delete cachedData;
+    int length = cache->length;
+    auto cachePath = path + (kind == ScriptCacheKind::Module ? ".mcache" : ".cache");
+    File::WriteBinary(cachePath, cache->data, length);
+    delete cache;
     // make sure cache and js file have the same modification date
     struct stat result;
     struct utimbuf new_times;
@@ -1656,6 +1676,16 @@ void ModuleInternal::SaveScriptCache(const Local<Script> script, const std::stri
         new_times.modtime = jsLastModifiedTime;
     }
     utime(cachePath.c_str(), &new_times);
+}
+
+void ModuleInternal::SaveScriptCache(const Local<Script> script, const std::string& path) {
+    if (!Constants::V8_CACHE_COMPILED_CODE) {
+        return;
+    }
+
+    Local<UnboundScript> unboundScript = script->GetUnboundScript();
+    SaveScriptCache(ScriptCompiler::CreateCodeCache(unboundScript), path,
+                    ScriptCacheKind::Classic);
 }
 
 ModuleInternal::ModulePathKind ModuleInternal::GetModulePathKind(const std::string& path) {

--- a/test-app/runtime/src/main/cpp/ModuleInternal.h
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.h
@@ -95,6 +95,15 @@ class ModuleInternal {
         static bool IsESModule(const std::string& path);
 
         /*
+         * Whether `path` names a module the HTTP loader owns. Classifies the
+         * NORMALIZED form: a scheme separator collapsed by a path normalizer
+         * (`http:/host/...`) must still route to the HTTP loader, or the same
+         * string classifies as a filesystem path and repairs itself only after
+         * taking the wrong branch.
+         */
+        static bool IsHttpModulePath(const std::string& path);
+
+        /*
          * Compile/link/evaluate an ES module; returns its namespace object. `options`
          * decide how the graph's evaluation promise is settled — see
          * ModuleEvaluationPolicy.
@@ -212,9 +221,26 @@ class ModuleInternal {
                                                    const std::string& dirName,
                                                    const ModuleEvaluationOptions& options);
 
-        v8::ScriptCompiler::CachedData* TryLoadScriptCache(const std::string& path);
+        /*
+         * A V8 code cache produced by a classic-script compile and one produced by a
+         * module compile are not interchangeable, and a `.js` file is reachable both
+         * ways — require() compiles it classic, an `import` of the same file compiles
+         * it as a module. Sharing one cache file would make each path reject and
+         * overwrite the other's blob on every load, so the kind is part of the name.
+         */
+        enum class ScriptCacheKind {
+            Classic,
+            Module,
+        };
 
-        void SaveScriptCache(const v8::Local<v8::Script> script, const std::string& path);
+        static v8::ScriptCompiler::CachedData* TryLoadScriptCache(const std::string& path,
+                                                                  ScriptCacheKind kind);
+
+        // Takes ownership of `cache`.
+        static void SaveScriptCache(const v8::ScriptCompiler::CachedData* cache,
+                                    const std::string& path, ScriptCacheKind kind);
+
+        static void SaveScriptCache(const v8::Local<v8::Script> script, const std::string& path);
 
         ModulePathKind GetModulePathKind(const std::string& path);
 

--- a/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.cpp
@@ -49,6 +49,16 @@ static inline bool EndsWith(const std::string& value, const std::string& suffix)
   return std::equal(suffix.rbegin(), suffix.rend(), value.rbegin());
 }
 
+static inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate, const char* str) {
+  return ArgConverter::ConvertToV8String(isolate,
+                                         str ? std::string(str) : std::string());
+}
+
+static inline v8::Local<v8::String> ToV8String(v8::Isolate* isolate,
+                                               const std::string& str) {
+  return ArgConverter::ConvertToV8String(isolate, str);
+}
+
 // Filesystem: `path` names an existing regular file.
 static bool IsFile(const std::string& path) {
   struct stat st;
@@ -692,7 +702,7 @@ v8::MaybeLocal<v8::Module> LoadHttpModuleForUrl(v8::Isolate* isolate,
       requestedUrl.c_str());
 
   ModuleFetchResult fetched;
-  if (!HttpFetchModule(requestedUrl, fetched)) {
+  if (!HttpFetchModule(requestedUrl, registryKey, fetched)) {
     TNS_DEBUG(Esm, "[http-esm][load][fetch-fail] request=%s key=%s status=%d",
                    requestedUrl.c_str(), registryKey.c_str(), fetched.status);
     // The classifier's reason names the URL and the cause (status, MIME or
@@ -919,21 +929,14 @@ static bool ParseImportMap(v8::Isolate* isolate, const std::string& json,
   return true;
 }
 
-bool SetImportMap(const std::string& json, std::string* error) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+// Swaps in an already-parsed map. Split from SetImportMap so configureLoader
+// can validate every section before installing any of them.
+static bool InstallParsedImportMap(ParsedImportMap parsedMap, std::string* error) {
   LoaderVocabulary* vocabulary = VocabularyForCurrentIsolate();
-  std::string localError;
-  std::string& err = error != nullptr ? *error : localError;
   if (vocabulary == nullptr) {
-    err = "the isolate is shutting down";
-    return false;
-  }
-
-  // Parse-validate-swap: the live vocabulary is replaced only once a complete
-  // map has been built, so a rejected update leaves resolution exactly as it
-  // was rather than silently emptying it.
-  ParsedImportMap parsedMap;
-  if (!ParseImportMap(isolate, json, &parsedMap, &err)) {
+    if (error != nullptr) {
+      *error = "the isolate is shutting down";
+    }
     return false;
   }
   vocabulary->importMap = std::move(parsedMap);
@@ -943,11 +946,17 @@ bool SetImportMap(const std::string& json, std::string* error) {
   return true;
 }
 
-bool ValidateImportMapJson(const std::string& json, std::string* error) {
-  std::string localError;
+bool SetImportMap(const std::string& json, std::string* error) {
+  // Parse-validate-swap: the live vocabulary is replaced only once a complete
+  // map has been built, so a rejected update leaves resolution exactly as it
+  // was rather than silently emptying it.
   ParsedImportMap parsedMap;
-  return ParseImportMap(v8::Isolate::GetCurrent(), json, &parsedMap,
-                        error != nullptr ? error : &localError);
+  std::string localError;
+  std::string* sink = error != nullptr ? error : &localError;
+  if (!ParseImportMap(v8::Isolate::GetCurrent(), json, &parsedMap, sink)) {
+    return false;
+  }
+  return InstallParsedImportMap(std::move(parsedMap), sink);
 }
 
 void SetVolatilePatterns(const std::vector<std::string>& patterns) {
@@ -1672,7 +1681,9 @@ static void AsyncGraphEnqueue(const std::shared_ptr<AsyncGraphLoad>& load,
   load->pendingFetches++;
   std::shared_ptr<AsyncGraphLoad> loadRef = load;
   const std::string url = target;
-  FetchModuleBodyAsync(url, [loadRef, url](ModuleFetchResult result) {
+  // The canonical key is computed here, on the isolate's thread; the fetch
+  // carries it so background threads never touch per-isolate vocabulary.
+  FetchModuleBodyAsync(url, key, [loadRef, url](ModuleFetchResult result) {
     // Arbitrary thread. Hop to the isolate's home thread as a nestable v8
     // foreground task — delivery is a property of the isolate, not of the
     // thread that started the fetch, and the pumped walk's
@@ -3410,6 +3421,363 @@ void InitializeImportMetaObject(v8::Local<v8::Context> context,
           context, ArgConverter::ConvertToV8String(isolate, "dirname"),
           ArgConverter::ConvertToV8String(isolate, moduleDirname))
       .FromMaybe(false);
+}
+
+
+// ─────────────────────────────────────────────────────────────
+// The `ns:module` dev surface
+//
+// The runtime's dev surface is deliberately small: it exposes *mechanism*
+// only (resolution config, registry eviction, registry introspection). All
+// HMR *policy* — boot orchestration, `import.meta.hot`, full reload, CSS
+// apply, WebSocket protocol, worker teardown — lives in the JS dev client
+// (`@nativescript/vite`). The surface is reachable exclusively through the
+// `ns:module` builtin module (require / static import / import()); there is
+// no global.
+
+namespace {
+
+void InstallDevFunction(v8::Isolate* isolate, v8::Local<v8::Context> context,
+                        v8::Local<v8::Object> target, const char* name,
+                        v8::FunctionCallback callback) {
+    v8::Local<v8::FunctionTemplate> fnTpl = v8::FunctionTemplate::New(isolate, callback);
+    v8::Local<v8::Function> fn = fnTpl->GetFunction(context).ToLocalChecked();
+    fn->SetName(ToV8String(isolate, name));
+    target->CreateDataProperty(context, ToV8String(isolate, name), fn).Check();
+}
+
+// The only sections configureLoader understands. An unlisted key is a typo the
+// caller hears about rather than a setting that silently does nothing.
+constexpr const char* kLoaderConfigKeys[] = {"importMap", "volatilePatterns", "canonicalization"};
+
+void ConfigureLoaderCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    v8::Isolate* isolate = info.GetIsolate();
+    v8::HandleScope scope(isolate);
+    v8::Local<v8::Context> ctx = isolate->GetCurrentContext();
+
+    try {
+        auto throwTypeError = [&](const std::string& message) {
+            isolate->ThrowException(v8::Exception::TypeError(ToV8String(isolate, message)));
+        };
+
+        if (info.Length() < 1 || !info[0]->IsObject()) {
+            throwTypeError("configureLoader expects a config object");
+            return;
+        }
+
+        v8::Local<v8::Object> config = info[0].As<v8::Object>();
+
+        // ── Validation phase ─────────────────────────────────────────────
+        // Nothing below mutates the vocabulary. The whole config is checked first
+        // so a rejected call leaves every section exactly as it was — the
+        // atomicity the import map alone used to have, now covering the entire
+        // call.
+
+        // Unknown top-level keys.
+        v8::Local<v8::Array> configKeys;
+        if (!config->GetOwnPropertyNames(ctx, v8::PropertyFilter::ONLY_ENUMERABLE,
+                                         v8::KeyConversionMode::kConvertToString)
+                     .ToLocal(&configKeys)) {
+            return;  // pending exception
+        }
+        for (uint32_t i = 0; i < configKeys->Length(); i++) {
+            v8::Local<v8::Value> keyVal;
+            if (!configKeys->Get(ctx, i).ToLocal(&keyVal)) {
+                return;
+            }
+            std::string key = ArgConverter::ToString(isolate, keyVal);
+            bool known = false;
+            for (const char* candidate : kLoaderConfigKeys) {
+                if (key == candidate) {
+                    known = true;
+                    break;
+                }
+            }
+            if (!known) {
+                throwTypeError("configureLoader: unknown option '" + key + "'");
+                return;
+            }
+        }
+
+        // Reads `obj[key]` as an array of strings into `out`. `label` names the
+        // section in any error. Returns false with an exception pending on a type
+        // failure; `present` distinguishes "absent" from "present and valid".
+        auto readStringArray = [&](v8::Local<v8::Object> obj, const char* key,
+                                   const std::string& label, std::vector<std::string>& out,
+                                   bool* present) -> bool {
+            *present = false;
+            v8::Local<v8::Value> val;
+            if (!obj->Get(ctx, ToV8String(isolate, key)).ToLocal(&val)) {
+                return false;
+            }
+            if (val->IsUndefined()) {
+                return true;
+            }
+            if (!val->IsArray()) {
+                throwTypeError("configureLoader: " + label + " must be an array of strings");
+                return false;
+            }
+            v8::Local<v8::Array> arr = val.As<v8::Array>();
+            for (uint32_t i = 0; i < arr->Length(); i++) {
+                v8::Local<v8::Value> elem;
+                if (!arr->Get(ctx, i).ToLocal(&elem)) {
+                    return false;
+                }
+                if (!elem->IsString()) {
+                    throwTypeError("configureLoader: " + label + "[" + std::to_string(i) +
+                                   "] must be a string");
+                    return false;
+                }
+                out.push_back(ArgConverter::ToString(isolate, elem));
+            }
+            *present = true;
+            return true;
+        };
+
+        // importMap: an object or a JSON string. Parsed here, installed below.
+        ParsedImportMap parsedMap;
+        bool haveImportMap = false;
+        size_t importMapBytes = 0;
+        v8::Local<v8::Value> importMapVal;
+        if (!config->Get(ctx, ToV8String(isolate, "importMap")).ToLocal(&importMapVal)) {
+            return;
+        }
+        if (!importMapVal->IsUndefined()) {
+            std::string jsonStr;
+            if (importMapVal->IsString()) {
+                jsonStr = ArgConverter::ToString(isolate, importMapVal);
+            } else if (importMapVal->IsObject() && !importMapVal->IsFunction()) {
+                // A function is an object to V8, and JSON::Stringify hands one back
+                // as the literal text "undefined" rather than failing — so it is
+                // excluded here and falls through to the TypeError below.
+                v8::Local<v8::String> stringified;
+                if (!v8::JSON::Stringify(ctx, importMapVal).ToLocal(&stringified)) {
+                    return;  // a throwing toJSON / getter propagates unchanged
+                }
+                std::string text = ArgConverter::ToString(isolate, stringified);
+                // The same "undefined" answer reaches a plain object whose toJSON
+                // returns undefined; leaving jsonStr empty routes it to the same
+                // TypeError.
+                if (text != "undefined") {
+                    jsonStr = std::move(text);
+                }
+            }
+            if (jsonStr.empty()) {
+                throwTypeError("configureLoader: importMap must be an object or a JSON string");
+                return;
+            }
+            std::string importMapError;
+            if (!ParseImportMap(isolate, jsonStr, &parsedMap, &importMapError)) {
+                // The previous map is still installed: a rejected update changes
+                // nothing, so a typo cannot empty a live session's vocabulary.
+                throwTypeError("configureLoader: " + importMapError);
+                return;
+            }
+            haveImportMap = true;
+            importMapBytes = jsonStr.size();
+        }
+
+        // volatilePatterns: array of strings. Presence of the array decides, not
+        // its contents — an empty one is explicit policy meaning "nothing is
+        // volatile any more", the same rule canonicalization follows, and the only
+        // reading under which a present section replaces its state wholesale.
+        std::vector<std::string> patterns;
+        bool havePatterns = false;
+        if (!readStringArray(config, "volatilePatterns", "volatilePatterns", patterns,
+                             &havePatterns)) {
+            return;
+        }
+
+        // canonicalization: { stripParams, forPathPrefixes, preserveQueryFor } —
+        // the URL vocabulary CanonicalizeHttpUrlKey applies (see its doc block).
+        // Presence of the object marks the vocabulary as configured, replacing the
+        // built-in fallback entirely (empty arrays are honored as explicit policy).
+        CanonicalizationConfig canon;
+        bool haveCanon = false;
+        v8::Local<v8::Value> canonVal;
+        if (!config->Get(ctx, ToV8String(isolate, "canonicalization")).ToLocal(&canonVal)) {
+            return;
+        }
+        if (!canonVal->IsUndefined()) {
+            if (!canonVal->IsObject()) {
+                throwTypeError("configureLoader: canonicalization must be an object");
+                return;
+            }
+            v8::Local<v8::Object> canonObj = canonVal.As<v8::Object>();
+            bool ignored = false;
+            if (!readStringArray(canonObj, "stripParams", "canonicalization.stripParams",
+                                 canon.stripParams, &ignored) ||
+                !readStringArray(canonObj, "forPathPrefixes", "canonicalization.forPathPrefixes",
+                                 canon.devPathPrefixes, &ignored) ||
+                !readStringArray(canonObj, "preserveQueryFor", "canonicalization.preserveQueryFor",
+                                 canon.preserveQueryPrefixes, &ignored)) {
+                return;
+            }
+            haveCanon = true;
+        }
+
+        // ── Apply phase ──────────────────────────────────────────────────
+        // Everything validated; from here nothing can fail on the caller's input.
+
+        if (haveImportMap) {
+            std::string installError;
+            if (!InstallParsedImportMap(std::move(parsedMap), &installError)) {
+                throwTypeError("configureLoader: " + installError);
+                return;
+            }
+            TNS_DEBUG(Esm, "[ns:module configureLoader] import map set (%zu bytes)",
+                           importMapBytes);
+        }
+
+        if (havePatterns) {
+            SetVolatilePatterns(patterns);
+            TNS_DEBUG(Esm, "[ns:module configureLoader] %zu volatile patterns set",
+                           patterns.size());
+        }
+
+        if (haveCanon) {
+            SetCanonicalizationConfig(std::move(canon));
+        }
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception& e) {
+        NativeScriptException nsEx(std::string("Error: c++ exception: ") + e.what() + "\n");
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
+    }
+}
+
+void InvalidateModulesCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    v8::Isolate* isolate = info.GetIsolate();
+    v8::HandleScope scope(isolate);
+    v8::Local<v8::Context> ctx = isolate->GetCurrentContext();
+
+    try {
+        if (info.Length() < 1 || !info[0]->IsArray()) {
+            isolate->ThrowException(v8::Exception::TypeError(
+                    ToV8String(isolate, "invalidateModules expects an array of URL strings")));
+            return;
+        }
+
+        v8::Local<v8::Array> urlsArray = info[0].As<v8::Array>();
+        std::vector<std::string> urls;
+        urls.reserve(urlsArray->Length());
+        for (uint32_t index = 0; index < urlsArray->Length(); index++) {
+            v8::Local<v8::Value> value;
+            if (!urlsArray->Get(ctx, index).ToLocal(&value)) {
+                return;
+            }
+            if (!value->IsString()) {
+                isolate->ThrowException(v8::Exception::TypeError(ToV8String(
+                        isolate,
+                        "invalidateModules: urls[" + std::to_string(index) +
+                                "] must be a string")));
+                return;
+            }
+            urls.push_back(ArgConverter::ToString(isolate, value));
+        }
+
+        if (tns::LogCategoryEnabled(tns::LogCategory::Registry)) {
+            TNS_DEBUG(Registry, "invalidate called urls.count=%zu", urls.size());
+            size_t shown = 0;
+            for (const auto& u : urls) {
+                if (shown >= 32) break;
+                TNS_DEBUG(Registry, "invalidate url[%zu]=%s", shown, u.c_str());
+                shown++;
+            }
+            if (urls.size() > shown) {
+                TNS_DEBUG(Registry, "invalidate (hidden %zu more URL(s))", urls.size() - shown);
+            }
+        }
+
+        tns::InvalidateModules(isolate, ctx, urls);
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception& e) {
+        NativeScriptException nsEx(std::string("Error: c++ exception: ") + e.what() + "\n");
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
+    }
+}
+
+void GetLoadedModuleUrlsCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    v8::Isolate* isolate = info.GetIsolate();
+    v8::HandleScope scope(isolate);
+    v8::Local<v8::Context> ctx = isolate->GetCurrentContext();
+
+    try {
+        std::vector<std::string> urls = tns::GetLoadedModuleUrls();
+        v8::Local<v8::Array> result = v8::Array::New(isolate, static_cast<int>(urls.size()));
+
+        for (uint32_t index = 0; index < urls.size(); index++) {
+            result->Set(ctx, index, ToV8String(isolate, urls[index])).FromMaybe(false);
+        }
+
+        info.GetReturnValue().Set(result);
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception& e) {
+        NativeScriptException nsEx(std::string("Error: c++ exception: ") + e.what() + "\n");
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
+    }
+}
+
+}  // namespace
+
+bool BuildNsModuleBinding(v8::Local<v8::Context> context, v8::Local<v8::Object> binding) {
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+
+    InstallDevFunction(isolate, context, binding, "configureLoader", ConfigureLoaderCallback);
+    InstallDevFunction(isolate, context, binding, "invalidateModules", InvalidateModulesCallback);
+    InstallDevFunction(isolate, context, binding, "getLoadedModuleUrls",
+                       GetLoadedModuleUrlsCallback);
+
+    if (!ModuleInternal::InstallCreateRequireBinding(context, binding)) {
+        return false;
+    }
+
+    if (IsDebuggable()) {
+        auto canonicalizeCb = [](const v8::FunctionCallbackInfo<v8::Value>& info) {
+            v8::Isolate* iso = info.GetIsolate();
+            try {
+                if (info.Length() < 1 || !info[0]->IsString()) {
+                    iso->ThrowException(v8::Exception::TypeError(
+                            ToV8String(iso, "canonicalizeHttpUrlKey expects a URL string")));
+                    return;
+                }
+                std::string key = CanonicalizeHttpUrlKey(ArgConverter::ToString(iso, info[0]));
+                info.GetReturnValue().Set(ToV8String(iso, key));
+            } catch (NativeScriptException& e) {
+                e.ReThrowToV8();
+            } catch (std::exception& e) {
+                NativeScriptException nsEx(std::string("Error: c++ exception: ") + e.what() +
+                                           "\n");
+                nsEx.ReThrowToV8();
+            } catch (...) {
+                NativeScriptException nsEx(std::string("Error: c++ exception!"));
+                nsEx.ReThrowToV8();
+            }
+        };
+        v8::Local<v8::Function> fn;
+        if (v8::Function::New(context, canonicalizeCb).ToLocal(&fn)) {
+            fn->SetName(ToV8String(isolate, "canonicalizeHttpUrlKey"));
+            if (!binding
+                         ->CreateDataProperty(context, ToV8String(isolate, "canonicalizeHttpUrlKey"),
+                                              fn)
+                         .FromMaybe(false)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 }  // namespace tns

--- a/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.cpp
@@ -3766,7 +3766,12 @@ bool BuildNsModuleBinding(v8::Local<v8::Context> context, v8::Local<v8::Object> 
             }
         };
         v8::Local<v8::Function> fn;
-        if (v8::Function::New(context, canonicalizeCb).ToLocal(&fn)) {
+        if (!v8::Function::New(context, canonicalizeCb).ToLocal(&fn)) {
+            // The member is absent-by-design in release, but a debug build
+            // must not report the binding built with a pending exception.
+            return false;
+        }
+        {
             fn->SetName(ToV8String(isolate, "canonicalizeHttpUrlKey"));
             if (!binding
                          ->CreateDataProperty(context, ToV8String(isolate, "canonicalizeHttpUrlKey"),

--- a/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.h
+++ b/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.h
@@ -233,11 +233,6 @@ void InitializeImportMetaObject(v8::Local<v8::Context> context,
 // through the copy taken at spawn.
 bool SetImportMap(const std::string& json, std::string* error);
 
-// Run the same parse `SetImportMap` runs and throw the result away. Lets
-// `configureLoader` validate the whole call before installing any section,
-// without the parsed representation leaving the loader implementation.
-bool ValidateImportMapJson(const std::string& json, std::string* error);
-
 // Set URL patterns that should bypass module cache (e.g. "?v=", "/hot/")
 // on the calling isolate.
 void SetVolatilePatterns(const std::vector<std::string>& patterns);
@@ -251,5 +246,37 @@ const CanonicalizationConfig* CanonicalizationConfigForCurrentIsolate();
 // isolate. Its presence replaces the mechanical default entirely — empty
 // vectors are honored as explicit policy.
 void SetCanonicalizationConfig(CanonicalizationConfig config);
+
+// ── The `ns:module` builtin binding ──────────────────────────
+//
+// Populates the native half of the `ns:module` builtin module — the one
+// namespace carrying every JS-callable dev primitive that any tooling can
+// depend on. Called from NsBuiltinModules::BuildBinding the first time a
+// realm resolves `ns:module` (via require, static import, or import());
+// ns-module.js shapes and freezes the exports.
+//
+// The runtime's dev surface is deliberately small: it exposes *mechanism*
+// only (resolution config, registry eviction, registry introspection). All
+// HMR *policy* — boot orchestration, `import.meta.hot`, full reload, CSS
+// apply, WebSocket protocol, worker teardown — lives in the JS dev client
+// (`@nativescript/vite`). The surface is reachable exclusively through the
+// `ns:module` builtin module; there is no global.
+//
+// `ns:module` members:
+//   - configureLoader(config)         (import map + volatile patterns +
+//                                      canonicalization vocabulary)
+//   - invalidateModules(urls)         (registry + cache eviction)
+//   - getLoadedModuleUrls()           (registry introspection)
+//   - createRequire(path)             (a CommonJS require for `path`)
+//   - canonicalizeHttpUrlKey(url)     (debug builds only; test diagnostic)
+//
+// Worker teardown across HMR cycles is userland: the dev client intercepts
+// the global `Worker` constructor and terminates tracked instances
+// (worker.terminate() cascades to nested workers via Runtime::DestroyRuntime).
+//
+// Returns false (with an exception pending or a failed Set) when the
+// binding could not be populated.
+bool BuildNsModuleBinding(v8::Local<v8::Context> context,
+                          v8::Local<v8::Object> binding);
 
 }  // namespace tns

--- a/test-app/runtime/src/main/cpp/NativeScriptException.cpp
+++ b/test-app/runtime/src/main/cpp/NativeScriptException.cpp
@@ -1049,7 +1049,10 @@ string NativeScriptException::GetFullMessage(const TryCatch& tc,
   } else {
     ss << endl << "File: (<unknown>";
   }
-  ss << ":" << message->GetLineNumber(context).ToChecked() << ":"
+  // An isolate that started terminating while this message was being
+  // formatted answers Nothing to every query below - a missing line number
+  // must degrade the report, not abort the process.
+  ss << ":" << message->GetLineNumber(context).FromMaybe(0) << ":"
      << message->GetStartColumn() << ")" << endl
      << endl;
   ss << "StackTrace: " << endl << stackTraceMessage << endl;
@@ -1135,7 +1138,7 @@ string NativeScriptException::GetErrorMessage(const Local<Message>& message,
   bool hasFullErrorMessage = false;
   auto v8FullMessage = ArgConverter::ConvertToV8String(isolate, "fullMessage");
   if (error->IsObject() &&
-      error.As<Object>()->Has(context, v8FullMessage).ToChecked()) {
+      error.As<Object>()->Has(context, v8FullMessage).FromMaybe(false)) {
     hasFullErrorMessage = true;
     Local<Value> errMsgVal;
     error.As<Object>()->Get(context, v8FullMessage).ToLocal(&errMsgVal);

--- a/test-app/runtime/src/main/cpp/NsBuiltinModules.cpp
+++ b/test-app/runtime/src/main/cpp/NsBuiltinModules.cpp
@@ -6,7 +6,7 @@
 
 #include "ArgConverter.h"
 #include "BuiltinLoader.h"
-#include "HttpLoader.h"
+#include "ModuleInternalCallbacks.h"
 #include "NativeScriptAssert.h"
 #include "Runtime.h"
 #include "RuntimeState.h"
@@ -163,6 +163,9 @@ MaybeLocal<Object> BuildBinding(Local<Context> context, BuiltinId builtin) {
 
     switch (builtin) {
         case BuiltinId::kNsModule: {
+            // The module loader's control surface (ModuleInternalCallbacks.cpp).
+            // The binding builder decides build-dependent membership;
+            // ns-module.js only shapes and freezes whatever arrives.
             if (!BuildNsModuleBinding(context, binding)) {
                 return MaybeLocal<Object>();
             }

--- a/test-app/runtime/src/main/cpp/WorkerWrapper.cpp
+++ b/test-app/runtime/src/main/cpp/WorkerWrapper.cpp
@@ -10,6 +10,7 @@
 #include "CrashBreadcrumbs.h"
 #include "JEnv.h"
 #include "JniLocalRef.h"
+#include "ModuleInternal.h"
 #include "NativeScriptAssert.h"
 #include "NativeScriptException.h"
 #include "NativeScriptPlatform.h"
@@ -739,8 +740,11 @@ void WorkerWrapper::CreateInspector(Isolate* isolate) {
         return;
     }
 
-    // Same url scheme the module loader reports in Debugger.scriptParsed.
-    std::string url = "file://" + workerPath_;
+    // Same url the module loader reports in Debugger.scriptParsed: an http(s)
+    // entry already IS that url, only a filesystem path needs the scheme.
+    std::string url = ModuleInternal::IsHttpModulePath(workerPath_)
+                              ? workerPath_
+                              : "file://" + workerPath_;
 
     auto* client = new WorkerInspectorClient(workerId_, isolate, ALooper_forThread(), url);
     {

--- a/test-app/runtime/src/main/cpp/WorkerWrapper.cpp
+++ b/test-app/runtime/src/main/cpp/WorkerWrapper.cpp
@@ -148,6 +148,12 @@ void WorkerWrapper::Terminate() {
         // The only v8 call that is legal from another thread - interrupts any
         // JS currently running on the worker (e.g. a busy loop).
         isolate->TerminateExecution();
+        // A pump parked with nothing queued runs no JS, so the interrupt
+        // above never materializes for it - the loop's own flag ends it.
+        auto loop = NativeScriptPlatform::Instance()->LookupEventLoop(isolate);
+        if (loop != nullptr) {
+            loop->NoteTerminationRequested();
+        }
     }
 
 #ifdef APPLICATION_IN_DEBUG


### PR DESCRIPTION
Closes the last parity gaps against the merged iOS loader overhaul that #1965 missed — features present in ios#383's merged code that the port review initially misfiled as deferred work (see the reclassification in #2020):

- **ES module code cache**: `CompileFileEsModule` consumes and produces compiled-code cache blobs through the existing scheme, under the same config gate as classic scripts. Module caches are keyed `.mcache`, so a classic `require()` of a `.js` file and an `import` of the same file keep separate blobs instead of rejecting and overwriting each other's on every load (verified on-device: 58 `.mcache` alongside 221 `.cache`, cold and warm runs green).
- **Fetch concurrency cap** (iOS: `HTTPMaximumConnectionsPerHost = 16`): concurrent module fetches are bounded at 16 process-wide; excess jobs queue and finishing threads drain them, so the cap bounds threads and JVM attaches, not just sockets, and the caller never blocks. A failed thread spawn now delivers a transport-error completion instead of wedging the graph pump, and jobs queued behind it fail rather than wait forever.
- **Canonical keys by construction**: the transport takes canonical keys from its callers (computed on the isolate thread) instead of canonicalizing internally — iOS's parameter shape. This also fixes cache-bust marks for collapsed-scheme URLs: eviction marks under the repaired registry key while the transport canonicalized the raw URL, so the mark could never match or clear.
- **HTTP worker entries**: `new Worker("http://…/entry.mjs")` works — the constructor classifies the URL up front and skips filesystem resolution; the existing HTTP entry branch, boot evaluation options, security gate, spawn-time vocabulary copy, and settle-gated message queue all apply; the worker inspector target passes the URL through instead of prefixing `file://`. Spec included (entry + imported dependency served by the in-app fixture server, exercising the graph walk).
- **ns:module binding beside the loader state** (ios `5ca0c43c`): the binding moves out of the transport TU, which no longer depends on the loader headers; `configureLoader` parses the import map once and installs the parsed result, deleting the validate-by-parse double parse.

Suite: 1036 specs / 0 failures on-device (API 33 emulator), including the new HTTP-worker spec. Contract strings unchanged and byte-matched against the specs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workers can load ES modules directly from HTTP(S) URLs, including relative dependencies.
  - Added controls for import maps, URL canonicalization, module invalidation, and loaded-module inspection.
  - Improved debugging for HTTP-based worker modules.
  - Dynamic imports now honor configured import-map scopes.
  - Added separate caching for classic scripts and ES modules.

- **Bug Fixes**
  - Improved module URL handling and local path resolution.
  - Prevented network and callback errors from terminating worker processing.
  - Improved worker shutdown, including repeated termination of workers awaiting indefinitely.
  - Made error handling more resilient during worker termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->