### PR TITLE
Make LiveSync writes atomic instead of locking the runtime's reads

### DIFF
--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncServiceSocketImpl.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncServiceSocketImpl.java
@@ -357,23 +357,45 @@ public class NativeScriptSyncServiceSocketImpl {
             return lengthInt;
         }
 
+        /*
+         * Written through a sibling temp file renamed over the target, because
+         * the app keeps running JS while files stream in: rename(2) within a
+         * directory is atomic, so a runtime thread that requires this path
+         * mid-sync gets either the whole previous file or the whole new one.
+         * Writing in place cannot be made safe from the reader side -- the
+         * truncate lands before any lock a reader could share, and each runtime
+         * (main, every worker) reads on its own thread.
+         */
         private void createOrOverrideFile(String fileName, byte[] content) throws IOException {
-            File fileToCreate = prepareFile(fileName);
+            File fileToCreate = new File(DEVICE_APP_DIR, fileName);
+            File parentDir = fileToCreate.getParentFile();
+
+            if (parentDir != null) {
+                parentDir.mkdirs();
+            }
+
+            File temp = null;
             try {
+                // Same directory as the target: rename is only atomic within one
+                // filesystem, and a sibling is the one placement that guarantees it.
+                temp = File.createTempFile("livesync", ".tmp", parentDir);
 
-                fileToCreate.getParentFile().mkdirs();
-                FileOutputStream fos = new FileOutputStream(fileToCreate.getCanonicalPath());
-                if(runtime != null) {
-                    runtime.lock();
+                FileOutputStream fos = new FileOutputStream(temp);
+                try {
+                    fos.write(content);
+                } finally {
+                    fos.close();
                 }
-                fos.write(content);
-                fos.close();
 
+                if (!temp.renameTo(fileToCreate)) {
+                    throw new IOException(String.format("failed to rename %s onto the target", temp.getAbsolutePath()));
+                }
+                temp = null;
             } catch (Exception e) {
                 throw new IOException(String.format("\nLiveSync: failed to write file: %s\nOriginal Exception: %s", fileName, e.toString()));
             } finally {
-                if(runtime != null) {
-                    runtime.unlock();
+                if (temp != null) {
+                    temp.delete();
                 }
             }
         }
@@ -385,14 +407,6 @@ public class NativeScriptSyncServiceSocketImpl {
                 }
 
             fileOrDirectory.delete();
-        }
-
-        private File prepareFile(String fileName) {
-            File fileToCreate = new File(DEVICE_APP_DIR, fileName);
-            if (fileToCreate.exists()) {
-                fileToCreate.delete();
-            }
-            return fileToCreate;
         }
 
         /*

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -335,29 +335,11 @@ Runtime::~Runtime() {
 }
 
 std::string Runtime::ReadFileText(const std::string& filePath) {
-#ifdef APPLICATION_IN_DEBUG
-  std::lock_guard<std::mutex> lock(m_fileWriteMutex);
-#endif
   return File::ReadText(filePath);
 }
 
 std::string Runtime::ReadFileText(const std::string& filePath, bool& ok) {
-#ifdef APPLICATION_IN_DEBUG
-  std::lock_guard<std::mutex> lock(m_fileWriteMutex);
-#endif
   return File::ReadText(filePath, ok);
-}
-
-void Runtime::Lock() {
-#ifdef APPLICATION_IN_DEBUG
-  m_fileWriteMutex.lock();
-#endif
-}
-
-void Runtime::Unlock() {
-#ifdef APPLICATION_IN_DEBUG
-  m_fileWriteMutex.unlock();
-#endif
 }
 
 // The boot backstop: hold the launching thread until boot has actually

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -145,9 +145,6 @@ class Runtime {
         jboolean PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring message, jstring fullStackTrace, jstring jsStackTrace, jboolean isDiscarded);
         void DestroyRuntime();
 
-        void Lock();
-        void Unlock();
-
         int GetId();
 
         v8::Local<v8::Context> GetContext();
@@ -392,9 +389,6 @@ class Runtime {
 
         static thread_local Runtime* s_currentRuntime;
 
-#ifdef APPLICATION_IN_DEBUG
-        std::mutex m_fileWriteMutex;
-#endif
 };
 }
 

--- a/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
@@ -285,20 +285,6 @@ extern "C" JNIEXPORT jboolean Java_com_tns_Runtime_notifyGcLegacy(JNIEnv* env, j
     return notifyGcFast_impl(env, obj, runtimeId);
 }
 
-extern "C" JNIEXPORT void Java_com_tns_Runtime_lock(JNIEnv* env, jobject obj, jint runtimeId) {
-    auto runtime = TryGetRuntime(runtimeId);
-    if (runtime != nullptr) {
-        runtime->Lock();
-    }
-}
-
-extern "C" JNIEXPORT void Java_com_tns_Runtime_unlock(JNIEnv* env, jobject obj, jint runtimeId) {
-    auto runtime = TryGetRuntime(runtimeId);
-    if (runtime != nullptr) {
-        runtime->Unlock();
-    }
-}
-
 extern "C" JNIEXPORT jboolean Java_com_tns_Runtime_passExceptionToJsNative(JNIEnv* env, jobject obj, jint runtimeId, jthrowable exception, jstring message, jstring fullStackTrace, jstring jsStackTrace, jboolean isDiscarded) {
     auto runtime = TryGetRuntime(runtimeId);
     if (runtime == nullptr) {

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -71,10 +71,6 @@ public class Runtime {
         return SUPPORTS_OPTIMIZED_NATIVE ? notifyGcFast(runtimeId) : notifyGcLegacy(runtimeId);
     }
 
-    private native void lock(int runtimeId);
-
-    private native void unlock(int runtimeId);
-
     private native boolean passExceptionToJsNative(int runtimeId, Throwable ex, String message, String fullStackTrace, String jsStackTrace, boolean isDiscarded);
 
     @CriticalNative
@@ -766,12 +762,20 @@ public class Runtime {
         notifyGc(runtimeId);
     }
 
+    /**
+     * @deprecated No-op. This paired the runtime's file reads against LiveSync's
+     * writes, which now land atomically via a temp file renamed over the target,
+     * so readers need no lock. Retained because it is public API.
+     */
+    @Deprecated
     public void lock() {
-        lock(runtimeId);
     }
 
+    /**
+     * @deprecated No-op. See {@link #lock()}.
+     */
+    @Deprecated
     public void unlock() {
-        unlock(runtimeId);
     }
 
     public static void initInstanceFromPossibleNonMainThread(final Object instance) {


### PR DESCRIPTION
### Description

`m_fileWriteMutex` paired LiveSync's file writes against `Runtime::ReadFileText`, so the runtime would not compile a half-written hot-synced module. It could not deliver that, for three independent reasons:

1. **Wrong scope.** It is a non-static *member* (`Runtime.h`), so LiveSync locking one runtime excludes nothing on a worker's thread — precisely the case that matters now that workers run on their own detached threads.
2. **Taken after the damage.** The lock landed *after* `prepareFile()` deleted the file and the `FileOutputStream` constructor truncated it, so it covered only `fos.write` and not the window a reader actually hits.
3. **Unmatched unlock.** The `finally` called `runtime.unlock()` even when `lock()` had never been reached (a throw from `mkdirs()` or the `FileOutputStream` constructor). Unlocking a `std::mutex` this thread does not own is UB, and on bionic can release a lock the JS thread holds inside `ReadFileText`.

Rather than fix the locking, this inverts the approach: **make the write atomic instead of locking the readers.**

Writes now go to a sibling temp file which is renamed over the target. `rename(2)` within a directory is atomic, so a reader gets either the whole previous file or the whole new one — on every runtime and every thread, with no shared state to scope wrongly. That also closes the delete/truncate window that no reader-side lock could have covered, and takes a mutex off every debug module read.

`java.nio.file`'s `ATOMIC_MOVE` is unavailable at minSdk 21 (it needs 26), so this uses `File.createTempFile(prefix, suffix, parentDir)` plus `File.renameTo`, which maps to `rename(2)` on every API level. The temp file must be a sibling — rename is only atomic within one filesystem.

`m_fileWriteMutex`, `Runtime::Lock`/`Unlock`, both `lock_guard`s, the two JNI entry points and the `private native lock/unlock(int)` declarations are removed. `com.tns.Runtime.lock()`/`unlock()` remain as `@Deprecated` no-ops, since they are `public` API and external tooling may call them.

**Current behaviour:** LiveSync truncates the target in place and takes a per-runtime mutex around part of the write; readers on other runtimes are unprotected, and an early throw unlocks a mutex the thread does not hold.

**New behaviour:** LiveSync writes atomically; readers never observe a partial file, and there is no lock on the read path.

Found while removing `File::Buffer` in 7c9c3db3 — this mutex superficially looked like it guarded that shared buffer. It never did.

### Does your commit message include the wording below to reference a specific issue in this repo?

Fixes the `m_fileWriteMutex` item in #2020.

### Related Pull Requests

Follows 7c9c3db3 on `main` (process-global state shared across isolates), which surfaced this.

### Does your pull request have unit tests?

No. **The test suite does not exercise LiveSync at all** — it is a debug socket service driven by the CLI over a `LocalServerSocket`, with no harness in the runtime test app. So the green run below proves the code builds and nothing else regressed, *not* that hot-sync still works.

Verified:
- `:runtime:externalNativeBuildDebug -Pabis=arm64-v8a` — compiles and links clean
- `./gradlew runtestsAndVerifyResults` — **1038/1038 passed, 0 failed**

Manual check still needed before merge:
1. `ns run android` on a device/emulator
2. Edit a `.js`/`.ts` file in the app while it runs
3. Confirm the file hot-syncs and the app reloads (i.e. `createOrOverrideFile` → `renameTo` succeeds and `DO_SYNC_OPERATION` still triggers `livesync.js`)
4. Worth also confirming a *new* file (not just an overwrite) and a deleted file, since `prepareFile()` is gone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime file updates by writing changes safely and replacing files atomically.
  * Automatically creates missing parent directories during file updates.
  * Cleans up temporary files when an update fails.
  * Removed obsolete file-locking behavior that could interfere with runtime file access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->