### PR TITLE
fix: keep the query on relative and root-absolute imports from served modules

### DIFF
--- a/test-app/app/src/main/assets/app/esm/relative/query-entry.mjs
+++ b/test-app/app/src/main/assets/app/esm/relative/query-entry.mjs
@@ -1,0 +1,8 @@
+import defaultValue, { relativeValue } from "./dependency.mjs?v=static";
+
+export const viaDefault = defaultValue;
+export const viaNamed = relativeValue;
+
+export function loadWithQuery() {
+    return import("./dependency.mjs?v=dynamic");
+}

--- a/test-app/app/src/main/assets/app/tests/testEsmHttpLoader.js
+++ b/test-app/app/src/main/assets/app/tests/testEsmHttpLoader.js
@@ -73,6 +73,22 @@ describe("HTTP ESM Loader", function () {
             });
         });
 
+        // A query or fragment on a specifier that names a file is URL syntax
+        // the filesystem never sees. The same statement in a served module
+        // keeps it — see "query-bearing specifiers from a served referrer".
+        it("drops the query when a local import names a file", function (done) {
+            import("~/esm/relative/query-entry.mjs?v=entry").then(function (module) {
+                expect(module.viaDefault).toBe("relative-import-success");
+                expect(module.viaNamed).toBe("relative-import-success");
+                return module.loadWithQuery();
+            }).then(function (dependency) {
+                expect(dependency.relativeValue).toBe("relative-import-success");
+                done();
+            }).catch(function (error) {
+                reportRejection(error, done);
+            });
+        });
+
         it("should surface helpful errors for unresolved bare specifiers", function (done) {
             import("bare-spec-example").then(function (mod) {
                 // A placeholder module default-exports a Proxy whose get trap
@@ -90,6 +106,76 @@ describe("HTTP ESM Loader", function () {
                 expect(formatError(error)).toContain("bare-spec-example");
                 done();
             });
+        });
+    });
+
+    // A served module's relative and root-absolute imports resolve against its
+    // URL, and a query on them is part of the resulting module's identity:
+    // `/esm/query.mjs?v=a` and `/esm/query.mjs` are two modules to the server,
+    // exactly as `/ns/asm?path=...` and `/ns/asm` are to a dev server. Every
+    // specifier shape must reach the server with its query intact.
+    describe("query-bearing specifiers from a served referrer", function () {
+        useHttpTimeout();
+
+        var nsModule = require("ns:module");
+        var formsUrl = origin + "/esm/query-forms.mjs";
+
+        afterEach(function () {
+            nsModule.configureLoader({ importMap: { imports: {} } });
+        });
+
+        it("keeps the query on static root-absolute and relative imports", function (done) {
+            withTimeout(import(formsUrl), 10000, "import " + formsUrl)
+                .then(function (mod) {
+                    expect(mod.path).toBe("/esm/query.mjs");
+                    expect(mod.query).toContain("v=root-abs");
+                    expect(mod.relativeQuery).toContain("v=relative");
+                    // `export *` and `export { default }` name one URL, so
+                    // they share one evaluated instance.
+                    expect(mod.default.query).toContain("v=root-abs");
+                    expect(mod.default.evaluatedAt).toBe(mod.evaluatedAt);
+                    done();
+                })
+                .catch(function (error) {
+                    reportRejection(error, done);
+                });
+        });
+
+        it("keeps the query on dynamic root-absolute and relative imports", function (done) {
+            var forms;
+            withTimeout(import(formsUrl), 10000, "import " + formsUrl)
+                .then(function (mod) {
+                    forms = mod;
+                    return withTimeout(forms.loadRootAbs(), 10000, "dynamic root-absolute import");
+                })
+                .then(function (rootAbs) {
+                    expect(rootAbs.path).toBe("/esm/query.mjs");
+                    expect(rootAbs.query).toContain("v=dyn-root");
+                    return withTimeout(forms.loadRelative(), 10000, "dynamic relative import");
+                })
+                .then(function (relative) {
+                    expect(relative.path).toBe("/esm/query.mjs");
+                    expect(relative.query).toContain("v=dyn-rel");
+                    done();
+                })
+                .catch(function (error) {
+                    reportRejection(error, done);
+                });
+        });
+
+        it("keeps the query through an import-map prefix entry", function (done) {
+            nsModule.configureLoader({
+                importMap: { imports: { "ns-test-esm/": origin + "/esm/" } },
+            });
+            withTimeout(import("ns-test-esm/query.mjs?v=prefix"), 10000, "prefix-mapped import")
+                .then(function (mod) {
+                    expect(mod.path).toBe("/esm/query.mjs");
+                    expect(mod.query).toContain("v=prefix");
+                    done();
+                })
+                .catch(function (error) {
+                    reportRejection(error, done);
+                });
         });
     });
 

--- a/test-app/app/src/main/java/com/tns/tests/ModuleTestServer.java
+++ b/test-app/app/src/main/java/com/tns/tests/ModuleTestServer.java
@@ -154,6 +154,21 @@ public final class ModuleTestServer {
             return;
         }
 
+        if ("/esm/query-forms.mjs".equals(path)) {
+            // Every specifier shape a served module can use to reach a sibling
+            // whose query is its identity. The server must receive each query
+            // intact: `/esm/query.mjs?v=x` and `/esm/query.mjs` are different
+            // modules to it, as `/ns/asm?path=...` and `/ns/asm` are to a dev
+            // server.
+            String body = "export * from \"/esm/query.mjs?v=root-abs\";\n"
+                    + "export { default } from \"/esm/query.mjs?v=root-abs\";\n"
+                    + "export { query as relativeQuery } from \"./query.mjs?v=relative\";\n"
+                    + "export function loadRootAbs() { return import(\"/esm/query.mjs?v=dyn-root\"); }\n"
+                    + "export function loadRelative() { return import(\"./query.mjs?v=dyn-rel\"); }\n";
+            respond(socket, "200 OK", JS_MIME, body.getBytes(UTF8));
+            return;
+        }
+
         if ("/esm/html-fallback.mjs".equals(path)) {
             // The SPA-fallback shape: an unknown path answered with the index
             // document, 200 OK. The module loader must reject it on MIME rather

--- a/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternalCallbacks.cpp
@@ -1147,16 +1147,6 @@ static ModuleResolution ResolveSpecifierToPath(const std::string& rawSpec,
     spec.insert(6, "/");
   }
 
-  // Query and fragment only mean something to a server, so a non-http
-  // specifier drops them before anything looks it up. Applied here, in the one
-  // seam both import forms go through, so `./x.js?v=1` names the same module
-  // whether it arrives as a static import or an import().
-  if (!(StartsWith(spec, "http://") || StartsWith(spec, "https://"))) {
-    size_t cut = spec.find_first_of("?#");
-    if (cut != std::string::npos) spec = spec.substr(0, cut);
-    if (spec.empty()) return result;
-  }
-
   TNS_DEBUG(Esm, "[resolver][spec] %s", spec.c_str());
 
   // The import map is consulted before any other resolution: bare specifiers
@@ -1221,6 +1211,24 @@ static ModuleResolution ResolveSpecifierToPath(const std::string& rawSpec,
       result.url = resolvedHttp;
       return result;
     }
+  }
+
+  // A query or fragment is URL syntax, never part of a file name, so
+  // `import './x.js?v=1'` names x.js on disk. It is dropped only here, after
+  // every HTTP outcome has returned: for a served module the query is part of
+  // its identity (`/ns/asm?path=A` and `/ns/asm` are two modules to the
+  // server), and that holds for a root-absolute or relative specifier just as
+  // it does for an absolute URL. Applied in this one seam, so a static import
+  // and an import() of `./x.js?v=1` name the same file.
+  {
+    size_t cut = spec.find_first_of("?#");
+    if (cut != std::string::npos) {
+      std::string stripped = spec.substr(0, cut);
+      TNS_DEBUG(Esm, "[resolver][strip-query] %s -> %s", spec.c_str(),
+                     stripped.c_str());
+      spec = stripped;
+    }
+    if (spec.empty()) return result;
   }
 
   // Build the filesystem candidates for this specifier shape. The specifier may
@@ -2533,21 +2541,10 @@ v8::MaybeLocal<v8::Promise> ImportModuleDynamicallyCallback(
     return builtinScope.Escape(builtinResolver->GetPromise());
   }
 
+  // The specifier reaches the shared seam verbatim. Whether its query is
+  // identity (a served module) or noise (a file) is the seam's decision, made
+  // the same way for a static import and an import().
   std::string normalizedSpec = rawSpec;
-  // remove query/hash ONLY for non-HTTP specs
-  bool isHttpLike =
-      (!normalizedSpec.empty() && (StartsWith(normalizedSpec, "http://") ||
-                                    StartsWith(normalizedSpec, "https://")));
-  if (!isHttpLike) {
-    size_t qpos = normalizedSpec.find_first_of("?#");
-    if (qpos != std::string::npos) {
-      normalizedSpec = normalizedSpec.substr(0, qpos);
-    }
-  }
-  if (normalizedSpec != rawSpec) {
-    TNS_DEBUG(Esm, "[dyn-import][normalize] %s -> %s", rawSpec.c_str(),
-                   normalizedSpec.c_str());
-  }
 
   v8::EscapableHandleScope scope(isolate);
 
@@ -2578,6 +2575,16 @@ v8::MaybeLocal<v8::Promise> ImportModuleDynamicallyCallback(
     normalizedSpec = dynamicResolution.specifier;
     TNS_DEBUG(Esm, "[dyn-import][import-map] rewrite: %s -> %s",
                    rawSpec.c_str(), normalizedSpec.c_str());
+  }
+  // A relative or root-absolute specifier from a served referrer resolves to
+  // a URL the specifier itself never spells out. Routing on that URL keeps
+  // such an import() on the async fetch path with its absolute-URL siblings.
+  if (dynamicResolution.kind == ModuleResolution::Kind::kHttp &&
+      !dynamicResolution.url.empty() &&
+      dynamicResolution.url != normalizedSpec) {
+    TNS_DEBUG(Esm, "[dyn-import][http-rel] %s -> %s", normalizedSpec.c_str(),
+                   dynamicResolution.url.c_str());
+    normalizedSpec = dynamicResolution.url;
   }
 
   try {


### PR DESCRIPTION
Fixes `ns debug android` failing on NativeScript 9.1 + @nativescript/vite 8.0.4 with:
```
HTTP import failed: http://127.0.0.1:5173/ns/asm (status=400)
```

`ResolveSpecifierToPath` stripped `?query#fragment` from every non-http specifier up front, before the import map or the HTTP referrer were consulted. The Vue `/ns/sfc` delegator re-exports from `/ns/asm?path=%2Fsrc%2Fcomponents%2FHome.vue`; the runtime resolved that to `http://127.0.0.1:5173/ns/asm` and the assembler rejected it. The graph walk and the sync fallback share that seam, hence the "module graph walk missed" line preceding the error.

This is not Vue-specific. The Vite plugin emits root-relative `/ns/...` specifiers with meaningful queries in several places (`?path=`, `&mode=inline`, `?vue&type=`, `?ns_worker=1`), so a plugin-side workaround would have been incomplete.

## Why iOS was unaffected

Both runtimes share the resolver shape, but iOS consults the import map, resolves relative and root-absolute specs against an HTTP referrer, and only then strips the query for filesystem probing.
Android stripped first. This change adopts the iOS ordering. The early strip landed in #1965 (first shipped in 9.1.0-alpha.11), which is why projects moving off earlier alphas hit it on 9.1.0.

closes https://github.com/NativeScript/nativescript/issues/11417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP-based ES module imports now preserve query strings and fragments when resolving both static and dynamic imports.
  - Query-bearing imports work consistently with root-absolute, relative, and import-map-based paths.
  - Local file imports continue to resolve without query strings or fragments.
  - Improved module resolution for imports originating from served modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->