### PR TITLE
feat: serialize DOMException per Web IDL [Serializable]

### DIFF
--- a/docs/structured-clone.md
+++ b/docs/structured-clone.md
@@ -18,7 +18,7 @@ buffer.byteLength; // 0 — the memory now belongs to `moved`
 - `options` may be `undefined` or `null` (both mean "no transfer"); anything else must be an object, or a `TypeError` is thrown.
 - `options.transfer` is a WebIDL sequence: any object with a callable `Symbol.iterator` works (an array, a `Set`, a generator). A non-iterable value — including a string primitive — throws a `TypeError`.
 
-Cloneable: every primitive value except symbols — numbers (including `-0`, `NaN` and the infinities), strings, booleans, `BigInt`, `null` and `undefined`; plain objects and arrays; `Date`, `RegExp`, `Map`, `Set`, `Error`; `Boolean`/`String`/`Number` wrapper objects; `ArrayBuffer`, every typed array and `DataView`.
+Cloneable: every primitive value except symbols — numbers (including `-0`, `NaN` and the infinities), strings, booleans, `BigInt`, `null` and `undefined`; plain objects and arrays; `Date`, `RegExp`, `Map`, `Set`, `Error`; `Boolean`/`String`/`Number` wrapper objects; `ArrayBuffer`, every typed array and `DataView`; and `DOMException`, per its Web IDL `[Serializable]` slot — `name`, `message` and `stack` round-trip through `structuredClone` and worker `postMessage`, and object identity within a graph is preserved.
 
 The clone preserves the shape of the graph, not just the values: an object referenced twice in the input is a single object referenced twice in the output, and cycles round-trip. Prototypes do not survive — a class instance clones to a plain object with the same own properties. Getters are invoked during cloning and their result is stored as a plain data property. Property insertion order is preserved.
 

--- a/test-app/app/src/main/assets/app/tests/domExceptionFirstCloneWorker.js
+++ b/test-app/app/src/main/assets/app/tests/domExceptionFirstCloneWorker.js
@@ -1,0 +1,14 @@
+// A fresh isolate: the DOMException constructed inside the getter below is
+// the first one this isolate has ever seen, and it is born while the clone
+// that carries it is already being written.
+var graph = {
+    get inner() {
+        return new DOMException("first in this isolate", "AbortError");
+    },
+};
+var clone = structuredClone(graph);
+postMessage({
+    isDomException: clone.inner instanceof DOMException,
+    name: clone.inner.name,
+    message: clone.inner.message,
+});

--- a/test-app/app/src/main/assets/app/tests/testRuntimeImplementedAPIs.js
+++ b/test-app/app/src/main/assets/app/tests/testRuntimeImplementedAPIs.js
@@ -62,6 +62,47 @@ describe("DOMException canary", function () {
   it("is not reachable as a module from app code", function () {
     expect(function () { require("internal/dom-exception"); }).toThrow();
   });
+
+  it("serializes through structuredClone on this runtime", function () {
+    var clone = structuredClone(new DOMException("x", "AbortError"));
+    expect(clone instanceof DOMException).toBe(true);
+    expect(clone.name).toBe("AbortError");
+  });
+
+  it("clones the isolate's first DOMException even when a getter creates it mid-clone", function (done) {
+    var worker = new Worker("./domExceptionFirstCloneWorker.js");
+    worker.onmessage = function (event) {
+      expect(event.data.isDomException).toBe(true);
+      expect(event.data.name).toBe("AbortError");
+      expect(event.data.message).toBe("first in this isolate");
+      worker.terminate();
+      done();
+    };
+    worker.onerror = function (event) {
+      fail("worker error: " + event.message);
+      worker.terminate();
+      done();
+      return true;
+    };
+  });
+
+  // Once an isolate holds a DOMException the serializer claims host objects
+  // itself, and V8 then stops detecting native wrappers on its own. These are
+  // the shapes that would silently clone as {} if the claim missed them.
+  it("still rejects native wrappers once a DOMException exists", function () {
+    new DOMException("x", "AbortError");
+    var wrappers = [new java.lang.Object(), new URL("https://example.com/")];
+    for (var i = 0; i < wrappers.length; i++) {
+      var error;
+      try {
+        structuredClone(wrappers[i]);
+      } catch (e) {
+        error = e;
+      }
+      expect(error instanceof DOMException).toBe(true);
+      expect(error.name).toBe("DataCloneError");
+    }
+  });
 });
 
 describe("CustomEvent canary", function () {

--- a/test-app/runtime/src/main/cpp/LazyGlobals.cpp
+++ b/test-app/runtime/src/main/cpp/LazyGlobals.cpp
@@ -3,6 +3,7 @@
 #include "ArgConverter.h"
 #include "Base64.h"
 #include "BuiltinLoader.h"
+#include "StructuredSerialization.h"
 #include "TextEncoding.h"
 
 using namespace v8;
@@ -38,7 +39,7 @@ constexpr LazyGlobalEntry kLazyGlobals[] = {
         {"TextDecoder", "TextDecoder", TextEncoding::GetExports},
         {"atob", "atob", Base64::GetExports},
         {"btoa", "btoa", Base64::GetExports},
-        {"DOMException", "DOMException", BuiltinExports<BuiltinId::kDomException>},
+        {"DOMException", "DOMException", serialization::GetDomExceptionExports},
         // events.js is an eager builtin (Events::Init), so this row never runs
         // a file: the read hits the exports cache and only the placement is
         // lazy.

--- a/test-app/runtime/src/main/cpp/NsBuiltinModules.cpp
+++ b/test-app/runtime/src/main/cpp/NsBuiltinModules.cpp
@@ -10,6 +10,7 @@
 #include "NativeScriptAssert.h"
 #include "Runtime.h"
 #include "RuntimeState.h"
+#include "StructuredSerialization.h"
 #include "TextEncoding.h"
 #include "TraceLog.h"
 #include "console/Console.h"
@@ -58,7 +59,8 @@ constexpr Registration kRegistry[] = {
         {"node:module", BuiltinId::kNodeModule, nullptr},
         {"node:url", BuiltinId::kNodeUrl, nullptr},
         {"node:util", BuiltinId::kNodeUtil, nullptr},
-        {"internal/dom-exception", BuiltinId::kDomException, nullptr, true},
+        {"internal/dom-exception", BuiltinId::kDomException, serialization::DomExceptionBinding,
+         true},
         {"internal/events", BuiltinId::kEvents, nullptr, true},
 };
 

--- a/test-app/runtime/src/main/cpp/StructuredSerialization.cpp
+++ b/test-app/runtime/src/main/cpp/StructuredSerialization.cpp
@@ -4,11 +4,76 @@
 
 #include "ArgConverter.h"
 #include "BuiltinLoader.h"
+#include "RuntimeState.h"
 
 using namespace v8;
 
 namespace tns {
 namespace serialization {
+
+namespace {
+
+/*
+ * The private symbol markCloneable stamps on every DOMException instance.
+ * Private, so app code can neither forge the brand onto an impostor nor strip
+ * it; per isolate because a worker's instances are branded and checked on its
+ * own isolate, and only bytes cross between them. Every instance passes
+ * through markCloneable — deserialization rebuilds via the constructor.
+ */
+struct DomExceptionBrandState {
+    Persistent<Private> brand;
+};
+
+Local<Private> BrandOf(Isolate* isolate, DomExceptionBrandState* state) {
+    if (state->brand.IsEmpty()) {
+        state->brand.Reset(isolate,
+                           Private::New(isolate, ArgConverter::ConvertToV8String(
+                                                         isolate, "domExceptionCloneable")));
+    }
+    return state->brand.Get(isolate);
+}
+
+// Empty once teardown has begun — callers bail to their fallback.
+Local<Private> DomExceptionBrand(Isolate* isolate) {
+    auto* state = RuntimeState::For<DomExceptionBrandState>(isolate);
+    if (state == nullptr) {
+        return Local<Private>();
+    }
+    return BrandOf(isolate, state);
+}
+
+void MarkCloneableCallback(const FunctionCallbackInfo<Value>& info) {
+    Isolate* isolate = info.GetIsolate();
+    if (info.Length() < 1 || !info[0]->IsObject()) {
+        return;
+    }
+    auto* state = RuntimeState::For<DomExceptionBrandState>(isolate);
+    if (state == nullptr) {
+        return;
+    }
+    Local<Private> brand = BrandOf(isolate, state);
+    (void)info[0].As<Object>()->SetPrivate(isolate->GetCurrentContext(), brand,
+                                           v8::True(isolate));
+}
+
+}  // namespace
+
+MaybeLocal<Object> DomExceptionBinding(Local<Context> context) {
+    Isolate* isolate = v8::Isolate::GetCurrent();
+    Local<Object> binding = Object::New(isolate);
+    Local<v8::Function> markCloneable;
+    if (!v8::Function::New(context, MarkCloneableCallback).ToLocal(&markCloneable) ||
+        !binding->Set(context, ArgConverter::ConvertToV8String(isolate, "markCloneable"),
+                      markCloneable)
+                 .FromMaybe(false)) {
+        return MaybeLocal<Object>();
+    }
+    return binding;
+}
+
+MaybeLocal<Object> GetDomExceptionExports(Local<Context> context) {
+    return BuiltinLoader::GetExports(context, BuiltinId::kDomException, DomExceptionBinding);
+}
 
 void ThrowDataCloneError(Isolate* isolate, const std::string& message) {
     Local<Context> context = isolate->GetCurrentContext();
@@ -25,8 +90,7 @@ void ThrowDataCloneError(Isolate* isolate, const std::string& message) {
         TryCatch tc(isolate);
         Local<Object> exports;
         Local<Value> ctor;
-        if (BuiltinLoader::GetExports(context, BuiltinId::kDomException, nullptr)
-                    .ToLocal(&exports) &&
+        if (GetDomExceptionExports(context).ToLocal(&exports) &&
             exports->Get(context, ArgConverter::ConvertToV8String(isolate, "DOMException"))
                     .ToLocal(&ctor) &&
             ctor->IsFunction()) {
@@ -56,24 +120,73 @@ void ThrowDataCloneError(Isolate* isolate, const std::string& message) {
 
 namespace {
 
+/*
+ * Every host object's payload starts with one of these, so the reader can
+ * dispatch. kHostObjectDegraded carries nothing further; kHostObjectDomException
+ * carries a uint32 index into the SerializedValue's out-of-band payload list.
+ * The bytes never outlive the process (structuredClone round-trips in one
+ * isolate, worker messages cross isolates in the same binary), so the format can
+ * evolve freely with this file.
+ */
+constexpr uint32_t kHostObjectDegraded = 0;
+constexpr uint32_t kHostObjectDomException = 1;
+
 class SerializerDelegate : public ValueSerializer::Delegate {
 public:
     SerializerDelegate(Isolate* isolate, HostObjectPolicy hostObjectPolicy,
-                       std::vector<std::shared_ptr<BackingStore>>* sharedBuffers)
+                       std::vector<std::shared_ptr<BackingStore>>* sharedBuffers,
+                       std::vector<SerializedValue::DomExceptionPayload>* domExceptions)
             : isolate_(isolate),
               hostObjectPolicy_(hostObjectPolicy),
-              sharedBuffers_(sharedBuffers) {}
+              sharedBuffers_(sharedBuffers),
+              domExceptions_(domExceptions),
+              domExceptionBrand_(DomExceptionBrand(isolate)) {}
+
+    void SetSerializer(ValueSerializer* serializer) { serializer_ = serializer; }
 
     void ThrowDataCloneError(Local<v8::String> message) override {
         serialization::ThrowDataCloneError(
                 isolate_, ArgConverter::ConvertToString(message));
     }
 
+    /*
+     * Always claimed: V8 samples this once per ValueSerializer and never again,
+     * so a gate on "this isolate holds a DOMException" would miss the isolate's
+     * first instance when a getter constructs it during the very clone that
+     * carries it. The price is one IsHostObject call per plain JS object in a
+     * graph, the same Node pays for its JSTransferable protocol.
+     */
+    bool HasCustomHostObject(Isolate* isolate) override { return true; }
+
+    Maybe<bool> IsHostObject(Isolate* isolate, Local<Object> object) override {
+        // Claiming custom host objects REPLACES V8's own embedder-field
+        // detection rather than adding to it, so anything with a native half
+        // has to be claimed here too — otherwise a Java proxy would be written
+        // out as a plain object, silently losing the half that mattered.
+        if (object->InternalFieldCount() > 0) {
+            return Just(true);
+        }
+        if (domExceptionBrand_.IsEmpty()) {
+            return Just(false);
+        }
+        return object->HasPrivate(isolate->GetCurrentContext(), domExceptionBrand_);
+    }
+
     Maybe<bool> WriteHostObject(Isolate* isolate, Local<Object> object) override {
+        // DOMException serializes under both policies: it is [Serializable] in
+        // the IDL, and it is a plain JS object with no native half to lose.
+        bool isDomException = false;
+        if (!domExceptionBrand_.IsEmpty() &&
+            !object->HasPrivate(isolate->GetCurrentContext(), domExceptionBrand_)
+                     .To(&isDomException)) {
+            return Nothing<bool>();
+        }
+        if (isDomException) {
+            return WriteDomException(isolate, object);
+        }
         if (hostObjectPolicy_ == HostObjectPolicy::kDegrade) {
-            // V8 has already written the kHostObject tag; writing no payload is
-            // what the zero-byte ReadHostObject below expects, and the value
-            // surfaces as an empty object.
+            // Tag only, no payload: the value surfaces as an empty object.
+            serializer_->WriteUint32(kHostObjectDegraded);
             return Just(true);
         }
         std::string name =
@@ -109,21 +222,83 @@ public:
     }
 
 private:
+    /*
+     * Web IDL's DOMException serialization steps (name and message), plus the
+     * stack, matching Node. The payload travels out-of-band and only an index
+     * enters the stream: the receiving side must construct instances before
+     * ReadValue runs, because V8 forbids JS execution during deserialization.
+     */
+    Maybe<bool> WriteDomException(Isolate* isolate, Local<Object> object) {
+        Local<Context> context = isolate->GetCurrentContext();
+        Local<Value> name, message, stack;
+        if (!object->Get(context, ArgConverter::ConvertToV8String(isolate, "name"))
+                     .ToLocal(&name) ||
+            !object->Get(context, ArgConverter::ConvertToV8String(isolate, "message"))
+                     .ToLocal(&message) ||
+            !object->Get(context, ArgConverter::ConvertToV8String(isolate, "stack"))
+                     .ToLocal(&stack)) {
+            return Nothing<bool>();
+        }
+        SerializedValue::DomExceptionPayload payload;
+        payload.name = ArgConverter::ToString(isolate, name);
+        payload.message = ArgConverter::ToString(isolate, message);
+        // The stack can legitimately be absent or tampered into a non-string;
+        // carry it only when it is the string captureStackTrace left.
+        payload.hasStack = stack->IsString();
+        if (payload.hasStack) {
+            payload.stack = ArgConverter::ToString(isolate, stack);
+        }
+        serializer_->WriteUint32(kHostObjectDomException);
+        serializer_->WriteUint32(static_cast<uint32_t>(domExceptions_->size()));
+        domExceptions_->push_back(std::move(payload));
+        return Just(true);
+    }
+
     Isolate* isolate_;
     HostObjectPolicy hostObjectPolicy_;
     std::vector<std::shared_ptr<BackingStore>>* sharedBuffers_;
+    std::vector<SerializedValue::DomExceptionPayload>* domExceptions_;
+    // Resolved once per serializer: V8 asks about every object in the graph,
+    // and each lookup would otherwise re-resolve the state slot and push a
+    // fresh handle into the caller's scope.
+    Local<Private> domExceptionBrand_;
+    ValueSerializer* serializer_ = nullptr;
 };
 
 class DeserializerDelegate : public ValueDeserializer::Delegate {
 public:
-    explicit DeserializerDelegate(
-            const std::vector<Local<SharedArrayBuffer>>* sharedBuffers)
-            : sharedBuffers_(sharedBuffers) {}
+    DeserializerDelegate(const std::vector<Local<SharedArrayBuffer>>* sharedBuffers,
+                         const std::vector<Local<Object>>* domExceptions)
+            : sharedBuffers_(sharedBuffers), domExceptions_(domExceptions) {}
 
-    // Counterpart of the kDegrade branch: consumes no bytes, so the stream
-    // stays balanced. Unreachable for a value written under kReject.
+    void SetDeserializer(ValueDeserializer* deserializer) {
+        deserializer_ = deserializer;
+    }
+
+    // No JS may run in here (V8 forbids it during a read); DOMException
+    // instances were constructed by Deserialize before ReadValue started, and
+    // this only hands them out.
     MaybeLocal<Object> ReadHostObject(Isolate* isolate) override {
-        return Object::New(isolate);
+        uint32_t tag;
+        if (!deserializer_->ReadUint32(&tag)) {
+            return MaybeLocal<Object>();
+        }
+        switch (tag) {
+            case kHostObjectDegraded:
+                // Counterpart of the kDegrade branch: tag only, so the value
+                // arrives as an empty object. Unreachable for a value written
+                // under kReject.
+                return Object::New(isolate);
+            case kHostObjectDomException: {
+                uint32_t index;
+                if (!deserializer_->ReadUint32(&index) || index >= domExceptions_->size()) {
+                    return MaybeLocal<Object>();
+                }
+                return (*domExceptions_)[index];
+            }
+            default:
+                return MaybeLocal<Object>();
+        }
     }
 
     MaybeLocal<SharedArrayBuffer> GetSharedArrayBufferFromId(
@@ -136,6 +311,8 @@ public:
 
 private:
     const std::vector<Local<SharedArrayBuffer>>* sharedBuffers_;
+    const std::vector<Local<Object>>* domExceptions_;
+    ValueDeserializer* deserializer_ = nullptr;
 };
 
 /*
@@ -207,8 +384,9 @@ Maybe<bool> SerializedValue::Serialize(Isolate* isolate, Local<Context> context,
         return Nothing<bool>();
     }
 
-    SerializerDelegate delegate(isolate, hostObjectPolicy, &sharedBuffers_);
+    SerializerDelegate delegate(isolate, hostObjectPolicy, &sharedBuffers_, &domExceptions_);
     ValueSerializer serializer(isolate, &delegate);
+    delegate.SetSerializer(&serializer);
     for (size_t i = 0; i < transfers.size(); i++) {
         serializer.TransferArrayBuffer(static_cast<uint32_t>(i), transfers[i]);
     }
@@ -258,9 +436,54 @@ MaybeLocal<Value> SerializedValue::Deserialize(Isolate* isolate,
         sharedBuffers.push_back(SharedArrayBuffer::New(isolate, backingStore));
     }
 
-    DeserializerDelegate delegate(&sharedBuffers);
+    /*
+     * Construct every DOMException the payload names before the read begins:
+     * JS is allowed here and forbidden inside ReadHostObject. Construction goes
+     * through the real constructor — on a worker isolate that never touched
+     * DOMException this runs the builtin on demand — so each instance is
+     * branded again and re-serializes on the next hop.
+     */
+    std::vector<Local<Object>> domExceptions;
+    if (!domExceptions_.empty()) {
+        Local<Object> exports;
+        Local<Value> ctor;
+        if (!GetDomExceptionExports(context).ToLocal(&exports) ||
+            !exports->Get(context, ArgConverter::ConvertToV8String(isolate, "DOMException"))
+                     .ToLocal(&ctor) ||
+            !ctor->IsFunction()) {
+            // Only reached with nothing pending (a builtin that cannot load
+            // during teardown); the caller must see a failure, not an undefined
+            // result.
+            if (!isolate->HasPendingException()) {
+                ThrowDataCloneError(isolate,
+                                    "DOMException could not be rebuilt on this isolate.");
+            }
+            return MaybeLocal<Value>();
+        }
+        Local<v8::String> stackKey = ArgConverter::ConvertToV8String(isolate, "stack");
+        for (const DomExceptionPayload& payload : domExceptions_) {
+            Local<Value> args[] = {ArgConverter::ConvertToV8String(isolate, payload.message),
+                                   ArgConverter::ConvertToV8String(isolate, payload.name)};
+            Local<Object> exception;
+            if (!ctor.As<v8::Function>()->NewInstance(context, 2, args).ToLocal(&exception)) {
+                return MaybeLocal<Value>();
+            }
+            // The sender's stack replaces the one captured just now for the
+            // receiving side's constructor frame, matching Node.
+            if (payload.hasStack &&
+                !exception->Set(context, stackKey,
+                                ArgConverter::ConvertToV8String(isolate, payload.stack))
+                         .FromMaybe(false)) {
+                return MaybeLocal<Value>();
+            }
+            domExceptions.push_back(exception);
+        }
+    }
+
+    DeserializerDelegate delegate(&sharedBuffers, &domExceptions);
     ValueDeserializer deserializer(isolate, buffer_.get(), bufferSize_,
                                    &delegate);
+    delegate.SetDeserializer(&deserializer);
 
     for (size_t i = 0; i < transferredBuffers_.size(); i++) {
         deserializer.TransferArrayBuffer(

--- a/test-app/runtime/src/main/cpp/StructuredSerialization.h
+++ b/test-app/runtime/src/main/cpp/StructuredSerialization.h
@@ -35,6 +35,23 @@ enum class HostObjectPolicy {
 void ThrowDataCloneError(v8::Isolate* isolate, const std::string& message);
 
 /*
+ * The dom-exception builtin's native half: `markCloneable`, which stamps a
+ * per-isolate private brand on every instance the constructor makes. The brand
+ * is what the serialization delegates answer IsHostObject from, so DOMException
+ * travels through structuredClone and worker postMessage (Web IDL
+ * [Serializable]). Lives here, next to those delegates.
+ */
+v8::MaybeLocal<v8::Object> DomExceptionBinding(v8::Local<v8::Context> context);
+
+/*
+ * The dom-exception builtin's exports with its binding attached. GetExports
+ * consults the factory only on the run that populates the cache, so every call
+ * site for this builtin must go through here — a site passing a different
+ * factory would win or lose by init order.
+ */
+v8::MaybeLocal<v8::Object> GetDomExceptionExports(v8::Local<v8::Context> context);
+
+/*
  * A value serialized out of one isolate, plus the memory that travels with it.
  * Serializing and deserializing are separate halves because a worker message
  * is read back on a different isolate than it was written on, while
@@ -68,6 +85,20 @@ class SerializedValue {
     v8::MaybeLocal<v8::Value> Deserialize(v8::Isolate* isolate,
                                           v8::Local<v8::Context> context);
 
+    /*
+     * Web IDL's DOMException serialization steps (name, message) plus the
+     * stack, matching Node. Kept out-of-band because V8 forbids JS while a
+     * value is being read: Deserialize constructs every instance up front and
+     * ReadHostObject only hands them out by index (Node's host_objects_
+     * design).
+     */
+    struct DomExceptionPayload {
+        std::string name;
+        std::string message;
+        std::string stack;
+        bool hasStack = false;
+    };
+
    private:
     struct FreeDeleter {
         void operator()(void* pointer) const { std::free(pointer); }
@@ -82,6 +113,9 @@ class SerializedValue {
     std::vector<std::shared_ptr<v8::BackingStore>> transferredBuffers_;
     // Backing stores shared with — not moved from — the sending isolate.
     std::vector<std::shared_ptr<v8::BackingStore>> sharedBuffers_;
+    // One entry per distinct DOMException in the graph, in write order (a
+    // repeated reference is an object id in the stream, not a second entry).
+    std::vector<DomExceptionPayload> domExceptions_;
 };
 
 }  // namespace serialization

--- a/test-app/runtime/src/main/cpp/WorkerWrapper.cpp
+++ b/test-app/runtime/src/main/cpp/WorkerWrapper.cpp
@@ -343,13 +343,26 @@ void WorkerWrapper::FireMessageOnParentWorkerObject(int workerId,
         }
 
         Local<Value> data;
-        if (message->Deserialize(isolate, context).ToLocal(&data)) {
-            auto event = Object::New(isolate);
-            event->DefineOwnProperty(context, ArgConverter::ConvertToV8String(isolate, "data"),
-                                     data, PropertyAttribute::ReadOnly);
-            Local<Value> args[] = {event};
-            callback.As<Function>()->Call(context, Undefined(isolate), 1, args);
+        {
+            // Reading runs JS (a DOMException is rebuilt through its
+            // constructor), so a failure here must not stay pending on the
+            // isolate past this callout.
+            TryCatch tc(isolate);
+            if (!message->Deserialize(isolate, context).ToLocal(&data)) {
+                if (!tc.HasTerminated() && tc.HasCaught()) {
+                    DEBUG_WRITE_FORCE("MAIN: worker(id=%d) message could not be read: %s",
+                                      workerId,
+                                      ArgConverter::ToString(isolate, tc.Exception()).c_str());
+                }
+                return;
+            }
         }
+
+        auto event = Object::New(isolate);
+        event->DefineOwnProperty(context, ArgConverter::ConvertToV8String(isolate, "data"), data,
+                                 PropertyAttribute::ReadOnly);
+        Local<Value> args[] = {event};
+        callback.As<Function>()->Call(context, Undefined(isolate), 1, args);
     } catch (NativeScriptException& ex) {
         ex.ReThrowToV8();
     }

--- a/test-app/runtime/src/main/cpp/js/dom-exception.js
+++ b/test-app/runtime/src/main/cpp/js/dom-exception.js
@@ -9,10 +9,11 @@
 // constructor through require("internal/dom-exception") at throw time, so
 // this file never runs in an app that never touches a DOMException.
 //
-// Not implemented: the spec's [Serializable] slot. structuredClone and worker
-// postMessage go through v8::ValueSerializer, which has no hook for a plain
-// JS class, so a DOMException inside a cloned graph degrades the same way any
-// custom Error subclass does.
+// [Serializable]: the constructor stamps every instance with a native private
+// brand (binding.markCloneable), which the serialization delegates in
+// StructuredSerialization.cpp claim through V8's IsHostObject hook — name,
+// message and stack travel across structuredClone and worker postMessage,
+// Node's JSTransferable approach reduced to the one class.
 const {
   ErrorCaptureStackTrace,
   ErrorPrototype,
@@ -20,6 +21,8 @@ const {
   ObjectSetPrototypeOf,
   SymbolToStringTag,
 } = primordials;
+
+const { markCloneable } = binding;
 
 // Web IDL §4.3.4: the closed table of names with a legacy code. Any name
 // outside it — including every post-table spec name — has code 0.
@@ -62,6 +65,7 @@ class DOMException {
     this.#message = `${message}`;
     this.#name = `${name}`;
     ErrorCaptureStackTrace(this, DOMException);
+    markCloneable(this);
   }
 
   get name() {


### PR DESCRIPTION
Implements the `[Serializable]` slot DOMException was deliberately shipped without, so it survives `structuredClone` and worker `postMessage` instead of degrading like a custom Error subclass. Mirrors NativeScript/ios#453.

## Mechanism (Node's JSTransferable protocol, reduced to one class)

- **Branding.** The dom-exception builtin gains a native half: `binding.markCloneable` stamps every instance with a per-isolate `v8::Private` (stored in the runtime's `RuntimeState` slot bag), unforgeable and invisible from JS. All three `GetExports` call sites for the builtin — the lazy-global row, the `internal/dom-exception` registry row and `ThrowDataCloneError` — now share one binding factory (`serialization::DomExceptionBinding`), because `GetExports` consults the factory only on the run that populates the cache, so a site passing a different one would win or lose by init order.
- **Claiming.** The serializer delegate turns on `HasCustomHostObject` and answers `IsHostObject` with a private-symbol check, V8's escape hatch for treating a plain JS object as a host object. That claim *replaces* V8's own embedder-field detection rather than adding to it, so `IsHostObject` claims anything with internal fields first — Java proxies, `URL`/`URLPattern`/`URLSearchParams`, ObjectManager wrappers — and those keep raising `DataCloneError` under `structuredClone` and keep arriving as `{}` over `postMessage`. Cost: one private-symbol lookup per plain JS object in a serialized graph, the same price Node pays.
- **Two-phase payload.** V8 forbids JS execution while a value is being read (calling the constructor inside `ReadHostObject` is a `V8_Fatal`), so this mirrors Node's `host_objects_` design: `WriteHostObject` pushes `{name, message, stack}` onto an out-of-band list on the `SerializedValue` and writes only a tag + index into the stream; `Deserialize` constructs every instance through the real constructor **before** `ReadValue` starts, and `ReadHostObject` hands them out by index. Construction re-brands the instance, so a forwarded exception serializes again on the next hop — and on a worker isolate that never touched DOMException, the pre-construction step runs the builtin on demand.
- **Failure handling.** `Deserialize` throws a `DataCloneError` rather than returning empty with nothing pending when the builtin cannot load, so `structuredClone` never yields `undefined` silently. The main-thread worker message read (`WorkerWrapper::FireMessageOnParentWorkerObject`) now runs under a `TryCatch`, so a failed read is logged instead of left pending on the isolate; the worker-side read in `DrainPendingTasks` was already inside one.

## Wire format

Host objects now start with a uint32 tag: `0` = degraded native wrapper (writes nothing else; the reader returns `Object::New`, keeping today's empty-object shape), `1` = a uint32 index into the out-of-band DOMException payload list. The bytes never outlive the process (`structuredClone` round-trips in one isolate, worker messages cross isolates in the same binary), so the format is free to evolve with the file.

## Policies

DOMException serializes under both `kReject` (`structuredClone`) and `kDegrade` (worker `postMessage`): the reject policy exists to refuse objects whose native half would be left behind, and a DOMException has none. Graph identity is preserved by V8's object-id machinery — one payload per distinct instance.

Claiming is unconditional: V8 samples `HasCustomHostObject` once per `ValueSerializer` and never re-checks it, so a gate on "this isolate holds a DOMException" would lose the type of the isolate's first instance when a getter creates it during the very clone that carries it.

## Tests

- Shared suite bumped to common-runtime-tests-app@aa7f8cf: DOMException round-trip (name/message/code/instanceof, identity within a graph, nesting, stack) and worker `postMessage` in **both directions** — main→worker exercises the on-demand builtin run in a fresh isolate. Those specs probe whether `structuredClone` actually carries a DOMException rather than assuming it from presence, so they self-gate on runtimes without the slot. The commit also pins the "Throw error in onerror" forward count on whether `Worker` is an `EventTarget`; Android's is not yet, so the legacy count of 2 stays pinned and the worker error path is untouched here.
- `tests/testRuntimeImplementedAPIs.js`: an unguarded `structuredClone` canary; a worker (`tests/domExceptionFirstCloneWorker.js`) whose first DOMException is born inside a getter during the clone that carries it; and a spec cloning `new java.lang.Object()` and `new URL("https://example.com/")` after a DOMException exists, pinning that native wrappers still raise `DataCloneError`.
- Full device suite on an arm64 API 36 emulator: 1216 specs, 0 failures (4 pre-existing skips).
